### PR TITLE
Use logging and warnings instead of print

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -9,6 +9,7 @@ __all__ = ["Lightcurve"]
 
 import numpy as np
 import stingray.utils as utils
+import logging
 
 class Lightcurve(object):
     def __init__(self, time, counts, input_counts=True):
@@ -124,10 +125,10 @@ class Lightcurve(object):
         if tseg is None:
             tseg = toa[-1] - toa[0]
 
-        print("tseg: " + str(tseg))
+        logging.info("make_lightcurve: tseg: " + str(tseg))
 
         timebin = np.int(tseg/dt)
-        print("timebin:  " + str(timebin))
+        logging.info("make_lightcurve: timebin:  " + str(timebin))
 
         tend = tstart + timebin*dt
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -5,6 +5,8 @@ import scipy
 import scipy.stats
 import scipy.fftpack
 import scipy.optimize
+import logging
+import warnings
 
 import stingray.lightcurve as lightcurve
 import stingray.utils as utils
@@ -59,7 +61,7 @@ def classical_pvalue(power, nspec):
     ## If the power is really big, it's safe to say it's significant,
     ## and the p-value will be nearly zero
     if power*nspec > 30000:
-        print("Probability of no signal too miniscule to calculate.")
+        warnings.warn("Probability of no signal too miniscule to calculate.")
         return 0.0
 
     else:


### PR DESCRIPTION
Change calls to `print` into a log. I also propose the following call to logging: `logging.info("method/class: message")`
```
logging.info("make_lightcurve: lc.counts: {}".format(lc.counts)"
```
This addresses Issue #35