### PR TITLE
Code compatibility with Python3

### DIFF
--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -82,7 +82,7 @@ def _pavnosigfun(power, nspec):
     while m >= 0:
 
         s = 0.0
-        for i in xrange(int(m)-1):
+        for i in range(int(m)-1):
             s += np.log(float(m-i))
 
         logterm = m*np.log(pn/2.0) - pn/2.0 - s
@@ -340,7 +340,7 @@ class Powerspectrum(object):
 
         ## compute the number of powers in each frequency bin
         nsamples = np.array([len(binno[np.where(binno == i)[0]]) \
-                             for i in xrange(np.max(binno))])
+                             for i in range(np.max(binno))])
 
         ## the frequency resolution
         df = np.diff(binfreq)

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -89,7 +89,7 @@ class TestLightcurve(object):
         dt = 0.5
         mean_counts = 2.0
         times = np.arange(0+dt/2.,5-dt/2., dt)
-        counts = np.array([None for i in xrange(times.shape[0])])
+        counts = np.array([None for i in range(times.shape[0])])
         lc = Lightcurve(times, counts)
 
     @raises(AssertionError)
@@ -97,7 +97,7 @@ class TestLightcurve(object):
         dt = 0.5
         mean_counts = 2.0
         times = np.arange(0+dt/2.,5-dt/2., dt)
-        counts = np.array([np.inf for i in xrange(times.shape[0])])
+        counts = np.array([np.inf for i in range(times.shape[0])])
         lc = Lightcurve(times, counts)
 
     @raises(AssertionError)
@@ -105,7 +105,7 @@ class TestLightcurve(object):
         dt = 0.5
         mean_counts = 2.0
         times = np.arange(0+dt/2.,5-dt/2., dt)
-        counts = np.array([np.nan for i in xrange(times.shape[0])])
+        counts = np.array([np.nan for i in range(times.shape[0])])
         lc = Lightcurve(times, counts)
 
 

--- a/tests/test_powerspectrum.py
+++ b/tests/test_powerspectrum.py
@@ -64,7 +64,7 @@ class TestPowerspectrum(object):
 
     @raises(AssertionError)
     def test_init_with_nonsense_data(self):
-        nonsense_data = [None for i in xrange(100)]
+        nonsense_data = [None for i in range(100)]
         assert Powerspectrum(nonsense_data)
 
     @raises(AssertionError)
@@ -234,9 +234,9 @@ class TestPowerspectrum(object):
 
         pval = ps.classical_significances(threshold=threshold,
                                           trial_correction=False)
-
-        assert pval[0][0] < threshold
-        assert pval[0][1] == index
+        pval_list = list(pval)
+        assert pval_list[0][0] < threshold
+        assert pval_list[0][1] == index
 
     def test_classical_significances_trial_correction(self):
         ps = Powerspectrum(lc = self.lc, norm="leahy")
@@ -251,8 +251,8 @@ class TestPowerspectrum(object):
 
         pval = ps.classical_significances(threshold=threshold,
                                           trial_correction=True)
-
-        assert len(pval) == 0
+        pval_list = list(pval)
+        assert len(pval_list) == 0
 
 
 class TestAveragedPowerspectrum(object):
@@ -331,7 +331,7 @@ class TestAveragedPowerspectrum(object):
         mean_counts = mean_count_rate*dt
 
         lc_all = []
-        for n in xrange(n_lcs):
+        for n in range(n_lcs):
             poisson_counts = np.random.poisson(mean_counts,
                                            size=len(time))
 
@@ -355,7 +355,7 @@ class TestAveragedPowerspectrum(object):
         mean_counts = mean_count_rate*dt
 
         lc_all = []
-        for n in xrange(n_lcs):
+        for n in range(n_lcs):
             poisson_counts = np.random.poisson(mean_counts,
                                            size=len(time))
 


### PR DESCRIPTION
1. Converted xrange to range (xrange not supported in Python3 ) range() will have an extra overhead in Python 2 but atleast its compatible for both versions now.

2. Python 2 returns a list for zip object while python 3 doesn't. So converted zip to list to assert length at some places.