### PR TITLE
Get Travis-CI running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ env:
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES=''
-        # - CONDA_DEPENDENCIES='Cython numpy scipy matplotlib'
+        - CONDA_DEPENDENCIES='scipy numpy nose'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
@@ -61,20 +60,20 @@ matrix:
           env: ASTROPY_VERSION=development
 
         # Try older numpy versions
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.8
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.7
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.6
+        - python: 2.7
+          env: NUMPY_VERSION=1.8
+        - python: 2.7
+          env: NUMPY_VERSION=1.7
+        - python: 2.7
+          env: NUMPY_VERSION=1.6
         # Try older scipy versions
-        # - python: 2.7
-        #   env: SCIPY_VERSION=0.16.0
-        # - python: 2.7
-        #   env: SCIPY_VERSION=0.15.0
-        # - python: 2.7
-        #   env: SCIPY_VERSION=0.14.0
- 
+        - python: 2.7
+          env: SCIPY_VERSION=0.16.0
+        - python: 2.7
+          env: SCIPY_VERSION=0.15.0
+        - python: 2.7
+          env: SCIPY_VERSION=0.14.0
+
 
 before_install:
 
@@ -102,7 +101,7 @@ install:
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some
     # cases this may not provide enough flexibility in how to install a
-    # specific dependency (and it will not be able to install non-Python 
+    # specific dependency (and it will not be able to install non-Python
     # dependencies). Therefore, you can also include commands below (as
     # well as at the start of the install section or in the before_install
     # section if they are needed before setting up conda) to install any

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,12 @@ env:
         - SCIPY_VERSION=0.17.0
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='emcee corner'
+        # - PIP_DEPENDENCIES='emcee corner'
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython numpy scipy matplotlib'
+        - CONDA_DEPENDENCIES=''
+        # - CONDA_DEPENDENCIES='Cython numpy scipy matplotlib'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
@@ -60,19 +61,19 @@ matrix:
           env: ASTROPY_VERSION=development
 
         # Try older numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.8
-        - python: 2.7
-          env: NUMPY_VERSION=1.7
-        - python: 2.7
-          env: NUMPY_VERSION=1.6
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.8
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.7
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.6
         # Try older scipy versions
-        - python: 2.7
-          env: SCIPY_VERSION=0.16.0
-        - python: 2.7
-          env: SCIPY_VERSION=0.15.0
-        - python: 2.7
-          env: SCIPY_VERSION=0.14.0
+        # - python: 2.7
+        #   env: SCIPY_VERSION=0.16.0
+        # - python: 2.7
+        #   env: SCIPY_VERSION=0.15.0
+        # - python: 2.7
+        #   env: SCIPY_VERSION=0.14.0
  
 
 before_install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,24 +7,6 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.3.3
-norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat"
-doctest_plus = enabled
-doctest_norecursedirs = "astropy[\/]sphinx"
-open_files_ignore = "astropy.log" "/etc/hosts"
-
-[bdist_dmg]
-background = static/dmg_background.png
-# Note: The SVG source file for the DMG background image is located in the
-# repository at https://github.com/astropy/astropy-logo
-
-[bdist_wininst]
-bitmap = static/wininst_background.bmp
-
-[ah_bootstrap]
-auto_use = True
-
 [pep8]
 # E101 - mix of tabs and spaces
 # W191 - use of tabs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,39 @@
+[build_sphinx]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
+[upload_docs]
+upload-dir = docs/_build/html
+show-response = 1
+
+[pytest]
+minversion = 2.3.3
+norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat"
+doctest_plus = enabled
+doctest_norecursedirs = "astropy[\/]sphinx"
+open_files_ignore = "astropy.log" "/etc/hosts"
+
+[bdist_dmg]
+background = static/dmg_background.png
+# Note: The SVG source file for the DMG background image is located in the
+# repository at https://github.com/astropy/astropy-logo
+
+[bdist_wininst]
+bitmap = static/wininst_background.bmp
+
+[ah_bootstrap]
+auto_use = True
+
+[pep8]
+# E101 - mix of tabs and spaces
+# W191 - use of tabs
+# W291 - trailing whitespace
+# W292 - no newline at end of file
+# W293 - trailing whitespace
+# W391 - blank line at end of file
+# E111 - 4 spaces per indentation level
+# E112 - 4 spaces per indentation level
+# E113 - 4 spaces per indentation level
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113
+exclude = extern,sphinx,*parsetab.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import glob
+import os
+import sys
+
+from setuptools import setup
+
+
+setup(name='stingray',
+      version='0.1.dev',
+      description='Time Series Methods For Astronomical X-ray Data',
+      author='Stingray Developers',
+      author_email='spectraltiming-stingray@googlegroups.com',
+      license='MIT',
+      url='https://github.com/StingraySoftware/stingray',
+      packages=['stingray'],
+      classifiers=[
+          'Intended Audience :: Science/Research',
+          'License :: OSI Approved :: MIT License',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Topic :: Scientific/Engineering :: Astronomy',
+          'Topic :: Scientific/Engineering :: Physics'
+      ],
+      test_suite='nose.collector',
+)


### PR DESCRIPTION
- Added an initial `setup.py` file so that the command

  ```shell
  $ python setup.py test
  ```
  could execute.

- There are some installation conflicts in the conda environment due to inter-dependencies e.g. SciPy and Numpy, SciPy and Python 2.6, etc.

I did not yet look into the AstroPy ci helpers completely, so can't comment about the second issue. It would be great if some AstroPy dev could look into this.

Hoping for a fix of the issue here - https://github.com/conda/conda/issues/124