### PR TITLE
classical_significances now returns numpy array instead of zip object

### DIFF
--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -476,12 +476,12 @@ class Powerspectrum(object):
         if trial_correction:
             threshold /= self.ps.shape[0]
 
+
         ## need to add 1 to the indices to make up for the fact that
         ## we left out the first power above!
         indices = np.where(pv < threshold)[0]
 
-
-        pvals = zip(pv[indices], indices)
+        pvals = np.vstack([pv[indices-1], indices])
 
         return pvals
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -481,7 +481,7 @@ class Powerspectrum(object):
         ## we left out the first power above!
         indices = np.where(pv < threshold)[0]
 
-        pvals = np.vstack([pv[indices-1], indices])
+        pvals = np.vstack([pv[indices], indices])
 
         return pvals
 

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -79,7 +79,6 @@ class TestPowerspectrum(object):
         assert Powerspectrum(self.lc, norm=nonsense_norm)
 
 
-
     def test_total_variance(self):
         """
         the integral of powers (or Riemann sum) should be close
@@ -211,6 +210,7 @@ class TestPowerspectrum(object):
         ps = Powerspectrum(lc = self.lc, norm="rms")
         ps.classical_significances()
 
+
     def test_classical_significances_threshold(self):
         ps = Powerspectrum(lc = self.lc, norm="leahy")
 
@@ -225,8 +225,8 @@ class TestPowerspectrum(object):
         pval = ps.classical_significances(threshold=threshold,
                                           trial_correction=False)
 
-        assert pval[0][0] < threshold
-        assert pval[0][1] == index
+        assert pval[0,0] < threshold
+
 
     def test_classical_significances_trial_correction(self):
         ps = Powerspectrum(lc = self.lc, norm="leahy")
@@ -242,7 +242,26 @@ class TestPowerspectrum(object):
         pval = ps.classical_significances(threshold=threshold,
                                           trial_correction=True)
 
-        assert len(pval) == 0
+        assert np.size(pval) == 0
+
+
+    def test_pvals_is_numpy_array(self):
+
+        ps = Powerspectrum(lc = self.lc, norm="leahy")
+
+        ## change the powers so that just one exceeds the threshold
+        ps.ps = np.zeros(ps.ps.shape[0])+2.0
+
+        index = 1
+        ps.ps[index] = 10.0
+
+        threshold = 1.0
+
+        pval = ps.classical_significances(threshold=threshold,
+                                          trial_correction=True)
+
+        assert isinstance(pval, np.ndarray)
+        assert pval.shape[0] == 2
 
 
 class TestAveragedPowerspectrum(object):
@@ -472,3 +491,4 @@ class TestClassicalSignificances(object):
         nspec = 1
         pval = classical_pvalue(power, nspec)
         assert np.isclose(pval, 0.0)
+

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -226,7 +226,7 @@ class TestPowerspectrum(object):
                                           trial_correction=False)
 
         assert pval[0,0] < threshold
-
+        assert pval[1,0] == index
 
     def test_classical_significances_trial_correction(self):
         ps = Powerspectrum(lc = self.lc, norm="leahy")


### PR DESCRIPTION
As referenced in pull request #46, `classical_signififances` should return a numpy array instead of a zip object, the latter of which causes incompatibilities between Python2 and Python3. This patch should fix that problem.