### PR TITLE
Fix docstring of AveragedPowerspectrum for sphinx build

### DIFF
--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -493,6 +493,7 @@ class AveragedPowerspectrum(Powerspectrum):
         Make an averaged periodogram from a light curve by segmenting the light
         curve, Fourier-transforming each segment and then averaging the
         resulting periodograms.
+
         Parameters
         ----------
         lc: lightcurve.Lightcurve object OR


### PR DESCRIPTION
Fixed #54. Build now succeeding.

It is a blockage in setting up of readthedocs.