### PR TITLE
Activate Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+# AppVeyor.com is a Continuous Integration service to build and run tests under
+# Windows
+
+environment:
+
+    global:
+        PYTHON: "C:\\conda"
+        MINICONDA_VERSION: "latest"
+        CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+        PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
+                          # of 32 bit and 64 bit builds are needed, move this
+                          # to the matrix section.
+        CONDA_DEPENDENCIES: "scipy h5py numpy nose astropy"
+        PIP_DEPENDENCIES: ""
+
+    matrix:
+
+        - PYTHON_VERSION: "2.7"
+          NUMPY_VERSION: "stable"
+        - PYTHON_VERSION: "3.4"
+          NUMPY_VERSION: "stable"
+        - PYTHON_VERSION: "3.5"
+          NUMPY_VERSION: "stable"
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - PYTHON_VERSION: "3.5"
+          NUMPY_VERSION: "stable"
+
+platform:
+    -x64
+
+install:
+    - "git clone git://github.com/astropy/ci-helpers.git"
+    - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - "activate test"
+
+# Not a .NET project, we build Astropy in the install step instead
+build: false
+
+test_script:
+    - "%CMD_IN_ENV% python setup.py test"


### PR DESCRIPTION
This PR adds necessary file(s) for starting CI based builds over [AppVeyor](https://ci.appveyor.com/projects). AppVeyor helps ensure that the code is _really_ OS independent by testing it over a Windows based platform.

The latest build on my fork can be seen here - https://ci.appveyor.com/project/OrkoHunter/stingray

@dhuppenkothen @matteobachetti Please tell me when you add a hook on the AppVeyor site. I'll refresh the PR and we'll watch the build and merge.