### PR TITLE
Corrected the file path for the documentation directory in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,9 @@ Documentation
 
 Is generated using `Sphinx`_. Try::
 
-   $ sphinx-build doc doc/_build
+   $ sphinx-build docs docs/_build
 
-Then open ``./doc/_build/index.html`` in the browser of your choice.
+Then open ``./docs/_build/index.html`` in the browser of your choice.
 
 .. _Sphinx: http://sphinx-doc.org
 
@@ -57,8 +57,6 @@ this project, please `get in touch via the issues
 <https://github.com/dhuppenkothen/stingray/issues>`_!
 
 .. |Build Status Master| image:: https://travis-ci.org/StingraySoftware/stingray.svg?branch=master
-    :target: https://travis-ci.org/StingraySoftware/stingray   
-.. |Coverage Status Master| image:: https://coveralls.io/repos/github/StingraySoftware/stingray/badge.svg?branch=master 
-    :target: https://coveralls.io/github/StingraySoftware/stingray?branch=master 
-
-
+    :target: https://travis-ci.org/StingraySoftware/stingray
+.. |Coverage Status Master| image:: https://coveralls.io/repos/github/StingraySoftware/stingray/badge.svg?branch=master
+    :target: https://coveralls.io/github/StingraySoftware/stingray?branch=master


### PR DESCRIPTION
Minor change in README.rst which corrects the file path
required for building and viewing the documentation.

**"doc/" --> "docs/"**