### PR TITLE
stingray/utils: Minor fix to avoid attribute error

### DIFF
--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -41,7 +41,7 @@ def rebin_data(x, y, dx_new, method='sum'):
     x: iterable
         The dependent variable with some resolution dx_old = x[1]-x[0]
 
-    y: interable
+    y: iterable
         The independent variable to be binned
 
     dx_new: float
@@ -60,6 +60,8 @@ def rebin_data(x, y, dx_new, method='sum'):
     ybin: numpy.ndarray
         The binned quantity y
     """
+
+    y = np.asarray(y)
 
     dx_old = x[1] - x[0]
 


### PR DESCRIPTION
On line 74, the code tries to access the shape attribute
of the iterable, y. If y happens to be a list, it will
result in an Attribute error. Thus, code converting y into a
numpy array beforehand was added.