### PR TITLE
Fix the `rebin_data()` method

### DIFF
--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -14,6 +14,7 @@ Stingray Project Coordinators
 Contributors
 ============
 
+* Evandro M. Ribeiro
 
 If you have contributed to Stingray and your name is missing,
 please send an email to the coordinators, or

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -303,8 +303,8 @@ class Lightcurve(object):
     def rebin_lightcurve(self, dt_new, method='sum'):
         """
         Rebin the light curve to a new time resolution. While the new
-        resolution need not be an integer multiple of the previous time
-        resolution, be aware that if it is not, the last bin will be cut
+        resolution need not be an integer multiple of the lenght of the
+        time array, be aware that if it is not, the last bin will be cut
         off by the fraction left over by the integer division.
 
         Parameters
@@ -326,9 +326,9 @@ class Lightcurve(object):
         assert dt_new >= self.dt, "New time resolution must be larger than " \
                                   "old time resolution!"
 
-        bin_time, bin_counts, _ = utils.rebin_data(self.time,
-                                                   self.counts,
-                                                   dt_new, method)
+        bin_time, bin_counts, _ = utils.rebin_data_lc(self.time,
+                                                      self.counts,
+                                                      dt_new, method)
 
         lc_new = Lightcurve(bin_time, bin_counts)
         return lc_new

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -300,7 +300,7 @@ class Lightcurve(object):
 
         return Lightcurve(time, counts)
 
-    def rebin_lightcurve(self, dt_new, method='sum'):
+    def rebin(self, dt_new, method='sum'):
         """
         Rebin the light curve to a new time resolution. While the new
         resolution need not be an integer multiple of the lenght of the

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -272,8 +272,8 @@ class Powerspectrum(object):
         """
 
         # rebin power spectrum to new resolution
-        binfreq, binps, step_size = utils.rebin_data_ps(self.freq[1:],
-                                                        self.ps[1:], df,
+        binfreq, binps, step_size = utils.rebin_data_ps(self.freq,
+                                                        self.ps, df,
                                                         method=method)
 
         # make an empty periodogram object
@@ -281,8 +281,8 @@ class Powerspectrum(object):
 
         # store the binned periodogram in the new object
         bin_ps.norm = self.norm
-        bin_ps.freq = np.hstack([binfreq[0] - self.df, binfreq])
-        bin_ps.ps = np.hstack([self.ps[0], binps])
+        bin_ps.freq = binfreq
+        bin_ps.ps = binps
         bin_ps.df = df
         bin_ps.n = self.n
         bin_ps.nphots = self.nphots

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -272,9 +272,9 @@ class Powerspectrum(object):
         """
 
         # rebin power spectrum to new resolution
-        binfreq, binps, step_size = utils.rebin_data(self.freq[1:],
-                                                     self.ps[1:], df,
-                                                     method=method)
+        binfreq, binps, step_size = utils.rebin_data_ps(self.freq[1:],
+                                                        self.ps[1:], df,
+                                                        method=method)
 
         # make an empty periodogram object
         bin_ps = Powerspectrum()

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -366,7 +366,7 @@ class TestLightcurveRebin(object):
 
     def test_rebin_even(self):
         dt_new = 2.0
-        lc_binned = self.lc.rebin_lightcurve(dt_new)
+        lc_binned = self.lc.rebin(dt_new)
         assert np.isclose(lc_binned.dt, dt_new)
         counts_test = np.zeros_like(lc_binned.time) + \
             self.lc.counts[0]*dt_new/self.lc.dt
@@ -374,7 +374,7 @@ class TestLightcurveRebin(object):
 
     def test_rebin_odd(self):
         dt_new = 1.5
-        lc_binned = self.lc.rebin_lightcurve(dt_new)
+        lc_binned = self.lc.rebin(dt_new)
         assert np.isclose(lc_binned.dt, dt_new)
 
         counts_test = np.zeros_like(lc_binned.time) + \
@@ -385,7 +385,7 @@ class TestLightcurveRebin(object):
         """
         TODO: Not sure how to write tests for the rebin method!
         """
-        lc_binned = self.lc.rebin_lightcurve(dt)
+        lc_binned = self.lc.rebin(dt)
         assert len(lc_binned.time) == len(lc_binned.counts)
 
     def test_rebin_equal_numbers(self):

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -5,7 +5,7 @@ import stingray.utils as utils
 np.random.seed(20150907)
 
 
-class TestRebinData(object):
+class TestRebinDataForLightCurve(object):
 
     @classmethod
     def setup_class(cls):
@@ -17,36 +17,36 @@ class TestRebinData(object):
 
     def test_new_stepsize(self):
         dx_new = 2.0
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, step_size = utils.rebin_data_lc(self.x, self.y, dx_new)
         assert step_size == dx_new/self.dx
 
     def test_arrays(self):
         dx_new = 2.0
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, step_size = utils.rebin_data_lc(self.x, self.y, dx_new)
         assert isinstance(xbin, np.ndarray)
         assert isinstance(ybin, np.ndarray)
 
     def test_length_matches(self):
         dx_new = 2.0
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, step_size = utils.rebin_data_lc(self.x, self.y, dx_new)
         assert xbin.shape[0] == ybin.shape[0]
 
     def test_binned_counts(self):
         dx_new = 2.0
 
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, step_size = utils.rebin_data_lc(self.x, self.y, dx_new)
 
         ybin_test = np.zeros_like(xbin) + self.counts*dx_new/self.dx
         assert np.allclose(ybin, ybin_test)
 
     def test_uneven_bins(self):
         dx_new = 1.5
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, step_size = utils.rebin_data_lc(self.x, self.y, dx_new)
         assert np.isclose(xbin[1]-xbin[0], dx_new)
 
     def test_uneven_binned_counts(self):
         dx_new = 1.5
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, step_size = utils.rebin_data_lc(self.x, self.y, dx_new)
         print(xbin)
         print(ybin)
         ybin_test = np.zeros_like(xbin) + self.counts*dx_new/self.dx
@@ -55,7 +55,61 @@ class TestRebinData(object):
     def test_rebin_data_should_raise_error_when_method_is_different_than_allowed(self):
         dx_new = 2.0
         try:
-            utils.rebin_data(self.x, self.y, dx_new, method='not_allowed_method')
+            utils.rebin_data_lc(self.x, self.y, dx_new, method='not_allowed_method')
+        except utils.UnrecognizedMethod:
+            pass
+        else:
+            raise AssertionError("Expected exception does not occurred")
+
+class TestRebinDataForPowerSpectrum(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.dx = 1.0
+        cls.n = 10
+        cls.counts = 2.0
+        cls.x = np.arange(cls.dx/2, cls.dx/2+cls.n*cls.dx, cls.dx)
+        cls.y = np.zeros_like(cls.x)+cls.counts
+
+    def test_new_stepsize(self):
+        dx_new = 2.0
+        xbin, ybin, step_size = utils.rebin_data_ps(self.x, self.y, dx_new)
+        assert step_size == dx_new/self.dx
+
+    def test_arrays(self):
+        dx_new = 2.0
+        xbin, ybin, step_size = utils.rebin_data_ps(self.x, self.y, dx_new)
+        assert isinstance(xbin, np.ndarray)
+        assert isinstance(ybin, np.ndarray)
+
+    def test_length_matches(self):
+        dx_new = 2.0
+        xbin, ybin, step_size = utils.rebin_data_ps(self.x, self.y, dx_new)
+        assert xbin.shape[0] == ybin.shape[0]
+
+    def test_binned_counts(self):
+        dx_new = 2.0
+
+        xbin, ybin, step_size = utils.rebin_data_ps(self.x, self.y, dx_new)
+
+        ybin_test = np.zeros_like(xbin) + self.counts*dx_new/self.dx
+        assert np.allclose(ybin, ybin_test)
+
+    def test_uneven_bins(self):
+        dx_new = 1.5
+        xbin, ybin, step_size = utils.rebin_data_ps(self.x, self.y, dx_new)
+        assert np.isclose(xbin[1]-xbin[0], dx_new)
+
+    def test_uneven_binned_counts(self):
+        dx_new = 1.5
+        xbin, ybin, step_size = utils.rebin_data_ps(self.x, self.y, dx_new)
+        ybin_test = np.zeros_like(xbin) + self.counts*dx_new/self.dx
+        assert np.allclose(ybin_test, ybin)
+
+    def test_rebin_data_should_raise_error_when_method_is_different_than_allowed(self):
+        dx_new = 2.0
+        try:
+            utils.rebin_data_ps(self.x, self.y, dx_new, method='not_allowed_method')
         except utils.UnrecognizedMethod:
             pass
         else:

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -36,7 +36,7 @@ def simon(message, **kwargs):
     warnings.warn("SIMON says: {0}".format(message), **kwargs)
 
 
-def rebin_data(x, y, dx_new, method='sum'):
+def rebin_data_ps(x, y, dx_new, method='sum'):
 
     """
     Rebin some data to an arbitrary new data resolution. Either sum
@@ -112,6 +112,88 @@ def rebin_data(x, y, dx_new, method='sum'):
         ybin = ybin[:-1]
 
     xbin = np.arange(ybin.shape[0]) * dx_new + x[0] - dx_old + dx_new
+
+    return xbin, ybin, step_size
+
+
+def rebin_data_lc(x, y, dx_new, method='sum'):
+
+    """
+    Rebin some data to an arbitrary new data resolution. Either sum
+    the data points in the new bins or average them.
+
+    Parameters
+    ----------
+    x: iterable
+        The dependent variable with some resolution dx_old = x[1]-x[0]
+
+    y: iterable
+        The independent variable to be binned
+
+    dx_new: float
+        The new resolution of the dependent variable x
+
+    method: {"sum" | "average" | "mean"}, optional, default "sum"
+        The method to be used in binning. Either sum the samples y in
+        each new bin of x, or take the arithmetic mean.
+
+
+    Returns
+    -------
+    xbin: numpy.ndarray
+        The midpoints of the new bins in x
+
+    ybin: numpy.ndarray
+        The binned quantity y
+    """
+
+    y = np.asarray(y)
+    x = np.asarray(x)
+
+    dx_old = x[1] - x[0]
+
+    assert dx_new >= dx_old, "New frequency resolution must be larger than " \
+                             "old frequency resolution."
+
+    step_size = dx_new / dx_old
+
+    output = []
+    for i in np.arange(0, y.shape[0], step_size):
+        total = 0
+
+        int_i = int(i)
+        prev_frac = int_i + 1 - i
+        prev_bin = int_i
+        total += prev_frac * y[prev_bin]
+
+        if i + step_size < len(x):
+            # Fractional part of next bin:
+            next_frac = i + step_size - int(i + step_size)
+            next_bin = int(i + step_size)
+            total += next_frac * y[next_bin]
+
+        total += sum(y[int(i+1):int(i+step_size)])
+        output.append(total)
+
+    output = np.asarray(output)
+
+    if method in ['mean', 'avg', 'average', 'arithmetic mean']:
+        ybin = output / np.float(step_size)
+
+    elif method == "sum":
+        ybin = output
+
+    else:
+        raise UnrecognizedMethod("Method for summing or averaging not recognized. "
+                                 "Please enter either 'sum' or 'mean'.")
+
+    tseg = x[-1] - x[0] + dx_old
+
+    if (tseg / dx_new % 1) > 0:
+        ybin = ybin[:-1]
+
+    # The lightcurve time array gives the central value of the bin
+    xbin = np.arange(ybin.shape[0]) * dx_new + ((x[0]+x[int(step_size)-1])/2)
 
     return xbin, ybin, step_size
 


### PR DESCRIPTION
### NEEDS REVIEW

Fixes #82 

#### Summary

The rebin_data() has different expected behavior for lightcurves and powerspectra. The previous implementation showed some weird outputs (for me at least, see #82, nobody else has commented on it).

#### Discussion

The changes reflect what I expect to be the correct behavior but, please, review and point out what's wrong in my reasoning if you disagree.

I broke the `utils.rebin_data()` function into `rebin_data_lc` and `rebin_data_ps`, they are still living in the `utils` namespace but perhaps it is better to move them to `lightcurve` and `powerspectrum`, respectively?
Or maybe they will be useful for other classes in the future (e.g, bispectra, crossspectrum) and should remain on `utils`?

#### Modifications:

 - `Powerspectrum.rebin` receives `self.freq` and `self.ps` as arguments, instead of `self.freq[1:]`
 - `utils.rebin_data` substituted by `utils.rebin_data_ps` and `utils.rebin_data_lc 
 -  `Lightcurve.rebin_lightcurve` renamed to `Lightcurve.rebin`
 - `Powerspectrum.rebin` calls `utils.rebin_data_ps()` instead of `utils.rebin_data()`
 - `Lightcurve.rebin` calls `utils.rebin_data_lc()` instead of `utils.rebin_data()`
 - Changed names of test functions to reflect the changes above
 - I added myself to the CREDITS.rst file, let me know if I shouldn't :grimacing:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/95)
<!-- Reviewable:end -->
