### PR TITLE
Add covariance spectra

### DIFF
--- a/stingray/__init__.py
+++ b/stingray/__init__.py
@@ -17,3 +17,4 @@ if not _ASTROPY_SETUP_:
     from stingray.powerspectrum import *
     from stingray.crossspectrum import *
     from stingray.exceptions import *
+    from stingray.covariancespectrum import *

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -107,8 +107,7 @@ class Covariancespectrum(object):
 
         self.event_list = event_list
 
-        # Sort by energy values as second row
-        self.event_list_T = event_list[self.event_list[:, 1].argsort()].T
+        self.event_list_T = event_list.T
 
         self._init_special_vars()
 
@@ -137,27 +136,14 @@ class Covariancespectrum(object):
         self.std = std
 
     def _init_special_vars(self, T_start=None, T_end=None):
-        if self.avg_covar:
-            self.min_energy = np.min(self.event_list.T[1][T_start:T_end])
-            self.max_energy = np.max(self.event_list.T[1][T_start:T_end])
-            self.min_time = np.min(self.event_list.T[0][T_start:T_end])
-            self.max_time = np.max(self.event_list.T[0][T_start:T_end])
-        else:
-            self.min_energy = np.min(self.event_list_T[1][T_start:T_end])
-            self.max_energy = np.max(self.event_list_T[1][T_start:T_end])
-            self.min_time = np.min(self.event_list_T[0][T_start:T_end])
-            self.max_time = np.max(self.event_list_T[0][T_start:T_end])
-
-
-
+        self.min_energy = np.min(self.event_list_T[1][T_start:T_end])
+        self.max_energy = np.max(self.event_list_T[1][T_start:T_end])
+        self.min_time = np.min(self.event_list_T[0][T_start:T_end])
+        self.max_time = np.max(self.event_list_T[0][T_start:T_end])
 
     def _construct_energy_events(self, T_start=None, T_end=None):
-        if self.avg_covar:
-            event_list_T = np.array([self.event_list.T[0][T_start: T_end],
-                                     self.event_list.T[1][T_start: T_end]])
-        else:
-            event_list_T = np.array([self.event_list_T[0][T_start: T_end],
-                                     self.event_list_T[1][T_start: T_end]])
+        event_list_T = np.array([self.event_list_T[0][T_start: T_end],
+                                 self.event_list_T[1][T_start: T_end]])
         least_count = np.diff(np.unique(event_list_T[1])).min()
 
         # An array of unique energy values
@@ -402,8 +388,8 @@ class AveragedCovariancespectrum(Covariancespectrum):
         for i in range(nbins):
             tstart = self.min_time + i*self.segment_size
             tend = self.min_time + self.segment_size*(i+1) - 1
-            indices = np.intersect1d(np.where(self.event_list.T[0] >= tstart),
-                                     np.where(self.event_list.T[0] <= tend))
+            indices = np.intersect1d(np.where(self.event_list_T[0] >= tstart),
+                                     np.where(self.event_list_T[0] <= tend))
             self._init_special_vars(T_start=indices[0], T_end=indices[-1]+1)
             energy_events = self._construct_energy_events(T_start=indices[0],
                                                           T_end=indices[-1]+1)

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -226,7 +226,7 @@ class Covariancespectrum(object):
             self.covar_error = {}
 
     def _construct_energy_covar(self, energy_events, energy_covar,
-                                covar_error=None, xs_var=None):
+                                xs_var=None):
         """Form the actual output covaraince dictionary and array."""
         self._init_energy_covar(energy_events, energy_covar)
 
@@ -260,9 +260,7 @@ class Covariancespectrum(object):
             if not self.avg_covar:
                 self.covar_error[energy] = self._calculate_covariance_error(
                                                 lc, lc_ref)
-            else:
-                covar_error[energy] = self._calculate_covariance_error(
-                                           lc, lc_ref)
+
             # Excess variance in ref band
             xs_var[energy] = self._calculate_excess_variance(lc_ref)
 
@@ -436,27 +434,22 @@ class AveragedCovariancespectrum(Covariancespectrum):
 
             energy_covar = {}
             xs_var = {}
-            covar_error = {}
             self._construct_energy_covar(energy_events, energy_covar,
-                                         covar_error, xs_var)
+                                         xs_var)
 
             if n == 0:  # Declare
                 self.energy_covar = energy_covar
                 self.xs_var = xs_var
-                self.covar_error = covar_error
             else:  # Sum up
                 for key in energy_covar.keys():
                     self.energy_covar[key] = self.energy_covar.get(key, 0) + \
                                              energy_covar[key]
                     self.xs_var[key] = self.xs_var.get(key, 0) + xs_var[key]
-                    self.covar_error[key] = self.covar_error.get(key, 0) + \
-                                            covar_error[key]
 
         # Now divide with total number of bins for averaging
         for key in self.energy_covar.keys():
             self.energy_covar[key] /= self.nbins
             self.xs_var[key] /= self.nbins
-            self.covar_error[key] /= self.nbins
 
         self.unnorm_covar = np.vstack(self.energy_covar.items())
 
@@ -464,4 +457,3 @@ class AveragedCovariancespectrum(Covariancespectrum):
             self.energy_covar[key] = value / (self.xs_var[key])**0.5
 
         self.covar = np.vstack(self.energy_covar.items())
-        self.covar_error = np.vstack(self.covar_error.items())

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -8,7 +8,7 @@ import stingray.utils as utils
 
 class Covariancespectrum(object):
 
-    def __init__(self, event_list, bin_width, band_interest=None,
+    def __init__(self, event_list, dt, band_interest=None,
                  ref_band_interest=None):
         """
         Parameters
@@ -17,9 +17,8 @@ class Covariancespectrum(object):
             A numpy 2D array with first column as time of arrival and second
             column as photon energies associated.
 
-        bin_width : float
-            The width of the energy bin when the spectrum is divided into N
-            divisions.
+        dt : float
+            The time resolution of the Lightcurve formed from the energy bin.
 
         band_interest : iterable of tuples, default All
             An iterable of tuples with minimum and maximum values of the range
@@ -73,7 +72,7 @@ class Covariancespectrum(object):
             self.energy_covar[key] = []
 
         for energy in energy_events.keys():
-            lc = Lightcurve.make_lightcurve(energy_events[energy], bin_width, tstart=min_time, tseg=max_time - min_time)
+            lc = Lightcurve.make_lightcurve(energy_events[energy], dt, tstart=min_time, tseg=max_time - min_time)
 
             # Calculating timestamps for lc_ref
             toa_ref = []
@@ -83,7 +82,7 @@ class Covariancespectrum(object):
 
             toa_ref = np.array(sorted(toa_ref))
 
-            lc_ref = Lightcurve.make_lightcurve(toa_ref, bin_width, tstart=min_time, tseg=max_time - min_time)
+            lc_ref = Lightcurve.make_lightcurve(toa_ref, dt, tstart=min_time, tseg=max_time - min_time)
 
             assert len(lc.time) == len(lc_ref.time)
 

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -404,9 +404,9 @@ class AveragedCovariancespectrum(Covariancespectrum):
             tend = self.min_time + self.segment_size*(i+1) - 1
             indices = np.intersect1d(np.where(self.event_list.T[0] >= tstart),
                                      np.where(self.event_list.T[0] <= tend))
-            self._init_special_vars(T_start=indices[0], T_end=indices[-1])
+            self._init_special_vars(T_start=indices[0], T_end=indices[-1]+1)
             energy_events = self._construct_energy_events(T_start=indices[0],
-                                                          T_end=indices[-1])
+                                                          T_end=indices[-1]+1)
             self._update_energy_events(energy_events)
             energy_covar = {}
             self._construct_energy_covar(energy_events, energy_covar)

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -396,8 +396,8 @@ class AveragedCovariancespectrum(Covariancespectrum):
         nbins = int((self.max_time - self.min_time + 1) / self.segment_size)
 
         for n in range(nbins):
-            tstart = self.min_time + i*self.segment_size
-            tend = self.min_time + self.segment_size*(i+1) - 1
+            tstart = self.min_time + n*self.segment_size
+            tend = self.min_time + self.segment_size*(n+1) - 1
             indices = np.intersect1d(np.where(self.event_list_T[0] >= tstart),
                                      np.where(self.event_list_T[0] <= tend))
 

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -1,5 +1,5 @@
 from __future__ import division
-
+import collections
 import numpy as np
 
 from stingray import Lightcurve
@@ -35,8 +35,8 @@ class Covariancespectrum(object):
             If error is set to None, default Poisson case is taken and the
             error is calculated as `mean(lc)**0.5`. In the case of a single
             float as input, the same is used as the standard deviation which
-            is also used as the error. And if the error is a list or array of
-            numbers, the mean is used for the same purpose.
+            is also used as the error. And if the error is an iterable of
+            numbers, their mean is used for the same purpose.
 
 
         Attributes
@@ -209,8 +209,8 @@ class Covariancespectrum(object):
             # Calculate error
             if self.error is None:
                 std = np.mean(lc_ref)**0.5
-            elif type(self.error) in [list, np.array]: # Array of numbers
-                std = np.mean(self.error)
+            elif isinstance(self.error, collections.Iterable):
+                std = np.mean(self.error)  # Iterable of numbers
             else:  # Single float number
                 std = self.error
 

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -217,7 +217,8 @@ class Covariancespectrum(object):
             # Error in covariance
             self.covar_error = {}
 
-    def _construct_energy_covar(self, energy_events, energy_covar, xs_var=None):
+    def _construct_energy_covar(self, energy_events, energy_covar,
+                                covar_error=None, xs_var=None):
         """Form the actual output covaraince dictionary and array."""
         self._init_energy_covar(energy_events, energy_covar)
 
@@ -251,7 +252,9 @@ class Covariancespectrum(object):
             if not self.avg_covar:
                 self.covar_error[energy] = self._calculate_covariance_error(
                                                 lc, lc_ref)
-
+            else:
+                covar_error[energy] = self._calculate_covariance_error(
+                                           lc, lc_ref)
             # Excess variance in ref band
             xs_var[energy] = self._calculate_excess_variance(lc_ref)
 
@@ -302,7 +305,10 @@ class Covariancespectrum(object):
         # Number of time bins in lightcurve
         N = lc_x.ncounts
         # Number of segments averaged
-        M = 1
+        if not self.avg_covar:
+            M = 1
+        else:
+            M = self.segment_size
 
         num = xs_x*err_y + xs_y*err_x + err_x*err_y
         denom = N * M * xs_y
@@ -417,25 +423,32 @@ class AveragedCovariancespectrum(Covariancespectrum):
 
             energy_covar = {}
             xs_var = {}
-            self._construct_energy_covar(energy_events, energy_covar, xs_var)
+            covar_error = {}
+            self._construct_energy_covar(energy_events, energy_covar,
+                                         covar_error, xs_var)
 
             if n == 0:
                 self.energy_covar = energy_covar
                 self.xs_var = xs_var
+                self.covar_error = covar_error
             else:
                 for key in energy_covar.keys():
                     self.energy_covar[key] = self.energy_covar.get(key, 0) + \
                                              energy_covar[key]
                     self.xs_var[key] = self.xs_var.get(key, 0) + xs_var[key]
+                    self.covar_error[key] = self.covar_error.get(key, 0) + \
+                                            covar_error[key]
 
         # Now divide with total number of bins for averaging
         for key in self.energy_covar.keys():
             self.energy_covar[key] /= self.nbins
             self.xs_var[key] /= self.nbins
+            self.covar_error[key] /= self.nbins
 
         self.unnorm_covar = np.vstack(self.energy_covar.items())
 
         for key, value in self.energy_covar.items():
-            self.energy_covar[key] = value / (xs_var[key])**0.5
+            self.energy_covar[key] = value / (self.xs_var[key])**0.5
 
         self.covar = np.vstack(self.energy_covar.items())
+        self.covar_error = np.vstack(self.covar_error.items())

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -19,6 +19,8 @@ class Covariancespectrum(object):
         event_list : numpy 2D array
             A numpy 2D array with first column as time of arrival and second
             column as photon energies associated.
+            Note : The event list must be in sorted order with respect to the
+            times of arrivals.
 
         dt : float
             The time resolution of the Lightcurve formed from the energy bin.
@@ -92,9 +94,13 @@ class Covariancespectrum(object):
 
     def _init_vars(self, event_list, dt, band_interest,
                    ref_band_interest, std):
+        if np.all(np.diff(event_list, axis=0).T[0] >= 0) == False:
+            utils.simon("The event list must be sorted with respect to times of arrivals.")
+            event_list = event_list[event_list[:, 0].argsort()]
+
         self.event_list = event_list
 
-        # Sorted by energy values as second row
+        # Sort by energy values as second row
         self.event_list_T = event_list[self.event_list[:, 1].argsort()].T
 
         self.min_energy = np.min(self.event_list_T[1])
@@ -359,4 +365,12 @@ class AveragedCovariancespectrum(Covariancespectrum):
             Energy of the photon with the maximum energy.
 
         """
+
+        self.segment_size = segment_size
+
         self._init_vars(event_list, dt, band_interest, ref_band_interest, std)
+        self._construct_energy_events()
+        self._update_energy_events()
+
+
+

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -206,14 +206,7 @@ class Covariancespectrum(object):
 
             self.energy_covar[energy] = covar
 
-            # Calculate error
-            if self.error is None:
-                std = np.mean(lc_ref)**0.5
-            elif isinstance(self.error, collections.Iterable):
-                std = np.mean(self.error)  # Iterable of numbers
-            else:  # Single float number
-                std = self.error
-
+            std = self._calculate_error(lc_ref)
             xs_var[energy] = np.var(lc_ref) - std**2  # Excess variance in ref band
 
         self.unnorm_covar = np.vstack(self.energy_covar.items())
@@ -224,6 +217,17 @@ class Covariancespectrum(object):
             self.energy_covar[key] = value / (xs_var[key])**0.5
 
         self.covar = np.vstack(self.energy_covar.items())
+
+    def _calculate_error(self, lc):
+        """Return error calculated for the possible types of `error`"""
+        if self.error is None:
+            std = np.mean(lc)**0.5
+        elif isinstance(self.error, collections.Iterable):
+            std = np.mean(self.error)  # Iterable of numbers
+        else:  # Single float number
+            std = self.error
+
+        return std
 
     def _compute_covariance(self, lc1, lc2):
         """Calculate and return the covariance between two time series."""

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -11,7 +11,7 @@ __all__ = ['Covariancespectrum']
 class Covariancespectrum(object):
 
     def __init__(self, event_list, dt, band_interest=None,
-                 ref_band_interest=None, error=None):
+                 ref_band_interest=None, std=None):
         """
         Parameters
         ----------
@@ -30,12 +30,12 @@ class Covariancespectrum(object):
             A tuple with minimum and maximum values of the range in the band
             of interest in reference channel.
 
-        error : float or np.array or list of numbers
-            The term error is used to cacluate the excess variance of a band.
-            If error is set to None, default Poisson case is taken and the
-            error is calculated as `mean(lc)**0.5`. In the case of a single
+        std : float or np.array or list of numbers
+            The term std is used to cacluate the excess variance of a band.
+            If std is set to None, default Poisson case is taken and the
+            std is calculated as `mean(lc)**0.5`. In the case of a single
             float as input, the same is used as the standard deviation which
-            is also used as the error. And if the error is an iterable of
+            is also used as the std. And if the std is an iterable of
             numbers, their mean is used for the same purpose.
 
 
@@ -103,7 +103,7 @@ class Covariancespectrum(object):
         self.band_interest = band_interest
         self.dt = dt
 
-        self.error = error
+        self.std = std
 
         self._construct_energy_events(event_list_T)
 
@@ -206,7 +206,7 @@ class Covariancespectrum(object):
 
             self.energy_covar[energy] = covar
 
-            std = self._calculate_error(lc_ref)
+            std = self._calculate_std(lc_ref)
             xs_var[energy] = np.var(lc_ref) - std**2  # Excess variance in ref band
 
         self.unnorm_covar = np.vstack(self.energy_covar.items())
@@ -221,14 +221,14 @@ class Covariancespectrum(object):
 
         self.covar = np.vstack(self.energy_covar.items())
 
-    def _calculate_error(self, lc):
-        """Return error calculated for the possible types of `error`"""
-        if self.error is None:
+    def _calculate_std(self, lc):
+        """Return std calculated for the possible types of `std`"""
+        if self.std is None:
             std = np.mean(lc)**0.5
-        elif isinstance(self.error, collections.Iterable):
-            std = np.mean(self.error)  # Iterable of numbers
+        elif isinstance(self.std, collections.Iterable):
+            std = np.mean(self.std)  # Iterable of numbers
         else:  # Single float number
-            std = self.error
+            std = self.std
 
         return std
 

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -82,6 +82,11 @@ class Covariancespectrum(object):
             in the hard state of black hole X-ray binaries. Monthly Notices
             of the Royal Astronomical Society, 397: 666–676.
             doi: 10.1111/j.1365-2966.2009.15008.x
+
+        Examples
+        --------
+        See https://github.com/StingraySoftware/notebooks repository for
+        detailed notebooks on the code.
         """
 
         # This parameter is used to identify whether the current object is
@@ -105,7 +110,10 @@ class Covariancespectrum(object):
 
     def _init_vars(self, event_list, dt, band_interest,
                    ref_band_interest, std):
-        if np.all(np.diff(event_list, axis=0).T[0] >= 0) == False:
+        """
+        Check for consistency with input variables and declare public ones.
+        """
+        if not np.all(np.diff(event_list, axis=0).T[0] >= 0):
             utils.simon("The event list must be sorted with respect to "
                         "times of arrivals.")
             event_list = event_list[event_list[:, 0].argsort()]
@@ -274,6 +282,7 @@ class Covariancespectrum(object):
             self.covar_error = np.vstack(self.covar_error.items())
 
     def _calculate_excess_variance(self, lc):
+        """Calculate excess variance in a band with the standard deviation."""
         std = self._calculate_std(lc)
         return np.var(lc) - std**2
 
@@ -403,6 +412,10 @@ class AveragedCovariancespectrum(Covariancespectrum):
         self._make_averaged_covar_spectrum()
 
     def _make_averaged_covar_spectrum(self):
+        """
+        Calls methods from base class for every segment and calculates averaged
+        covariance and error.
+        """
         self.nbins = int((self.max_time - self.min_time + 1) / self.segment_size)
 
         for n in range(self.nbins):
@@ -427,11 +440,11 @@ class AveragedCovariancespectrum(Covariancespectrum):
             self._construct_energy_covar(energy_events, energy_covar,
                                          covar_error, xs_var)
 
-            if n == 0:
+            if n == 0:  # Declare
                 self.energy_covar = energy_covar
                 self.xs_var = xs_var
                 self.covar_error = covar_error
-            else:
+            else:  # Sum up
                 for key in energy_covar.keys():
                     self.energy_covar[key] = self.energy_covar.get(key, 0) + \
                                              energy_covar[key]

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -24,9 +24,9 @@ class Covariancespectrum(object):
             An iterable of tuples with minimum and maximum values of the range
             in the band of interest.
 
-        ref_band_interest : iterable of tuples, default All
-            An iterable of tuples with minimum and maximum values of the range
-            in the band of interest in reference channel.
+        ref_band_interest : tuple of reference band range, default All
+            A tuple with minimum and maximum values of the range in the band
+            of interest in reference channel.
         """
         min_energy, max_energy = np.min(event_list.T[1]), np.max(event_list.T[1])
         min_time, max_time = np.min(event_list.T[0]), np.max(event_list.T[0])
@@ -36,6 +36,10 @@ class Covariancespectrum(object):
 
         if ref_band_interest is None:
             ref_band_interest = (min_energy, max_energy)
+
+        assert len(ref_band_interest) == 2, "Band interest should be a tuple " \
+                                            "with min and max energy value " \
+                                            "for the reference band."
 
         # Sorted by energy values as second row
         event_list_T = event_list[event_list[:, 1].argsort()].T
@@ -77,8 +81,9 @@ class Covariancespectrum(object):
             # Calculating timestamps for lc_ref
             toa_ref = []
             for key, value in energy_events.items():
-                if key != energy:
-                    toa_ref.extend(value)
+                if key >= ref_band_interest[0] and key <= ref_band_interest[1]:
+                    if key != energy:
+                        toa_ref.extend(value)
 
             toa_ref = np.array(sorted(toa_ref))
 
@@ -90,7 +95,7 @@ class Covariancespectrum(object):
 
             self.energy_covar[energy] = covar
 
-            self.covar = np.vstack(self.energy_covar.items())
+        self.covar = np.vstack(self.energy_covar.items())
 
     def _compute_covariance(self, lc1, lc2):
         return np.cov(lc1.counts, lc2.counts)[0][1]

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -1,0 +1,95 @@
+from __future__ import division
+
+import numpy as np
+
+from stingray import Lightcurve
+import stingray.utils as utils
+
+
+class Covariancespectrum(object):
+
+    def __init__(self, event_list, bin_width, band_interest=None,
+                 ref_band_interest=None):
+        """
+        Parameters
+        ----------
+        event_list : numpy 2D array
+            A numpy 2D array with first column as time of arrival and second
+            column as photon energies associated.
+
+        bin_width : float
+            The width of the energy bin when the spectrum is divided into N
+            divisions.
+
+        band_interest : iterable of tuples, default All
+            An iterable of tuples with minimum and maximum values of the range
+            in the band of interest.
+
+        ref_band_interest : iterable of tuples, default All
+            An iterable of tuples with minimum and maximum values of the range
+            in the band of interest in reference channel.
+        """
+        min_energy, max_energy = min(event_list.T[1]), max(event_list.T[1])
+        min_time, max_time = min(event_list.T[0]), max(event_list.T[0])
+
+        if band_interest is None:
+            band_interest = (min_energy, max_energy)
+
+        if ref_band_interest is None:
+            ref_band_interest = (min_energy, max_energy)
+
+        # Sorted by energy values as second row
+        event_list_T = event_list[event_list[:, 1].argsort()].T
+
+        least_count = np.diff(np.unique(event_list_T[1])).min()
+
+        # An array of unique energy values
+        unique_energy = np.unique(event_list_T[1])
+
+        # A dictionary with energy bin as key and events as value of the key
+        energy_events = {}
+
+        for i in range(len(unique_energy) - 1):
+            energy_events[unique_energy[i] + least_count*0.5] = []
+
+        # Add time of arrivals to corresponding energy bins
+        for energy in energy_events.keys():
+            if energy == max_energy - least_count*0.5:  # The last energy bin
+                toa = event_list_T[0][np.logical_and(
+                    event_list_T[1] >= energy - least_count*0.5,
+                    event_list_T[1] <= energy + least_count*0.5)]
+                energy_events[energy] = sorted(toa)
+            else:
+                toa = event_list_T[0][np.logical_and(
+                    event_list_T[1] >= energy - least_count*0.5,
+                    event_list_T[1] < energy + least_count*0.5)]
+                energy_events[energy] = sorted(toa)
+
+        # The dictionary with covariance spectrum for each energy bin
+        self.energy_covar = {}
+
+        # Initialize it with empty mapping
+        for key in energy_events.keys():
+            self.energy_covar[key] = []
+
+        for energy in energy_events.keys():
+            lc = Lightcurve.make_lightcurve(energy_events[energy], bin_width, tstart=min_time, tseg=max_time - min_time)
+
+            # Calculating timestamps for lc_ref
+            toa_ref = []
+            for key, value in energy_events.items():
+                if key != energy:
+                    toa_ref.extend(value)
+
+            toa_ref = np.array(sorted(toa_ref))
+
+            lc_ref = Lightcurve.make_lightcurve(toa_ref, bin_width, tstart=min_time, tseg=max_time - min_time)
+
+            assert len(lc.time) == len(lc_ref.time)
+
+            covar = self._compute_covariance(lc, lc_ref)
+
+            self.energy_covar[energy] = covar
+
+    def _compute_covariance(self, lc1, lc2):
+        return np.cov(lc1.counts, lc2.counts)[0][1]

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -56,8 +56,10 @@ class Covariancespectrum(object):
         max_energy : float
             Energy of the photon with the maximum energy.
         """
-        self.min_energy, self.max_energy = np.min(event_list.T[1]), np.max(event_list.T[1])
-        self.min_time, self.max_time = np.min(event_list.T[0]), np.max(event_list.T[0])
+        self.min_energy = np.min(event_list.T[1])
+        self.max_energy = np.max(event_list.T[1])
+        self.min_time = np.min(event_list.T[0])
+        self.max_time = np.max(event_list.T[0])
 
         if ref_band_interest is None:
             ref_band_interest = (self.min_energy, self.max_energy)
@@ -66,16 +68,15 @@ class Covariancespectrum(object):
                                                          "should be either " \
                                                          "tuple or list."
 
-        assert len(ref_band_interest) == 2, "Band interest should be a tuple " \
-                                            "with min and max energy value " \
+        assert len(ref_band_interest) == 2, "Band interest should be a tuple" \
+                                            " with min and max energy value " \
                                             "for the reference band."
         self.ref_band_interest = ref_band_interest
 
         if band_interest is not None:
             for element in list(band_interest):
-                assert type(element) in (list, tuple), "band_interest should " \
-                                                       "be iterable of either " \
-                                                       "tuple or list."
+                assert type(element) in (list, tuple), \
+                    "band_interest should be iterable of either tuple or list."
                 assert len(element) == 2, "Band interest should be a tuple " \
                                           "with min and max energy values."
 
@@ -92,7 +93,6 @@ class Covariancespectrum(object):
         self._update_energy_events()
 
         self._construct_energy_covar()
-
 
     def _construct_energy_events(self, event_list_T):
 
@@ -111,7 +111,8 @@ class Covariancespectrum(object):
         # For each bin except the last one, the lower bound is included and
         # the upper bound is excluded.
         for energy in self.energy_events.keys():
-            if energy == self.max_energy - least_count*0.5:  # The last energy bin
+            # The last energy bin
+            if energy == self.max_energy - least_count*0.5:
                 toa = event_list_T[0][np.logical_and(
                     event_list_T[1] >= energy - least_count*0.5,
                     event_list_T[1] <= energy + least_count*0.5)]
@@ -121,7 +122,6 @@ class Covariancespectrum(object):
                     event_list_T[1] >= energy - least_count*0.5,
                     event_list_T[1] < energy + least_count*0.5)]
                 self.energy_events[energy] = sorted(toa)
-
 
     def _update_energy_events(self):
         """
@@ -142,7 +142,6 @@ class Covariancespectrum(object):
 
             self.energy_events.update(energy_events_)
 
-
     def _init_energy_covar(self):
         """
         Initialize the energy_covar dictionary for further computations.
@@ -159,24 +158,28 @@ class Covariancespectrum(object):
                 mid_bin = (band[0] + band[1]) / 2
                 self.energy_covar[mid_bin] = []
 
-
     def _construct_energy_covar(self):
         """Form the actual output covaraince dictionary and array."""
         self._init_energy_covar()
 
         for energy in self.energy_covar.keys():
-            lc = Lightcurve.make_lightcurve(self.energy_events[energy], self.dt, tstart=self.min_time, tseg=self.max_time - self.min_time)
+            lc = Lightcurve.make_lightcurve(
+                    self.energy_events[energy], self.dt, tstart=self.min_time,
+                    tseg=self.max_time - self.min_time)
 
             # Calculating timestamps for lc_ref
             toa_ref = []
             for key, value in self.energy_events.items():
-                if key >= self.ref_band_interest[0] and key <= self.ref_band_interest[1]:
+                if key >= self.ref_band_interest[0] and \
+                        key <= self.ref_band_interest[1]:
                     if key != energy:
                         toa_ref.extend(value)
 
             toa_ref = np.array(sorted(toa_ref))
 
-            lc_ref = Lightcurve.make_lightcurve(toa_ref, self.dt, tstart=self.min_time, tseg=self.max_time - self.min_time)
+            lc_ref = Lightcurve.make_lightcurve(
+                    toa_ref, self.dt, tstart=self.min_time,
+                    tseg=self.max_time - self.min_time)
 
             assert len(lc.time) == len(lc_ref.time)
 

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -5,6 +5,8 @@ import numpy as np
 from stingray import Lightcurve
 import stingray.utils as utils
 
+__all__ = ['Covariancespectrum']
+
 
 class Covariancespectrum(object):
 
@@ -33,6 +35,10 @@ class Covariancespectrum(object):
 
         if ref_band_interest is None:
             ref_band_interest = (self.min_energy, self.max_energy)
+
+        assert type(ref_band_interest) in (list, tuple), "Ref Band interest " \
+                                                         "should be either " \
+                                                         "tuple or list."
 
         assert len(ref_band_interest) == 2, "Band interest should be a tuple " \
                                             "with min and max energy value " \

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import division
 import collections
 import numpy as np
@@ -72,6 +73,13 @@ class Covariancespectrum(object):
 
         max_energy : float
             Energy of the photon with the maximum energy.
+
+        Reference
+        ---------
+        [1] Wilkinson, T. and Uttley, P. (2009), Accretion disc variability
+            in the hard state of black hole X-ray binaries. Monthly Notices
+            of the Royal Astronomical Society, 397: 666–676.
+            doi: 10.1111/j.1365-2966.2009.15008.x
         """
 
         self.event_list = event_list

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -28,8 +28,8 @@ class Covariancespectrum(object):
             An iterable of tuples with minimum and maximum values of the range
             in the band of interest in reference channel.
         """
-        min_energy, max_energy = min(event_list.T[1]), max(event_list.T[1])
-        min_time, max_time = min(event_list.T[0]), max(event_list.T[0])
+        min_energy, max_energy = np.min(event_list.T[1]), np.max(event_list.T[1])
+        min_time, max_time = np.min(event_list.T[0]), np.max(event_list.T[0])
 
         if band_interest is None:
             band_interest = (min_energy, max_energy)
@@ -89,6 +89,8 @@ class Covariancespectrum(object):
             covar = self._compute_covariance(lc, lc_ref)
 
             self.energy_covar[energy] = covar
+
+            self.covar = np.vstack(self.energy_covar.items())
 
     def _compute_covariance(self, lc1, lc2):
         return np.cov(lc1.counts, lc2.counts)[0][1]

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -213,7 +213,10 @@ class Covariancespectrum(object):
 
         for key, value in self.energy_covar.items():
             if not xs_var[key] > 0 :
-                utils.simon('xs_var must not take non-positive values.')
+                utils.simon("The excess variance in the reference band is " \
+                            "negative. This implies that the reference " \
+                            "band was badly chosen. Beware that the " \
+                            "covariance spectra will have NaNs!")
             self.energy_covar[key] = value / (xs_var[key])**0.5
 
         self.covar = np.vstack(self.energy_covar.items())

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -56,10 +56,16 @@ class Covariancespectrum(object):
         max_energy : float
             Energy of the photon with the maximum energy.
         """
-        self.min_energy = np.min(event_list.T[1])
-        self.max_energy = np.max(event_list.T[1])
-        self.min_time = np.min(event_list.T[0])
-        self.max_time = np.max(event_list.T[0])
+
+        self.event_list = event_list
+
+        # Sorted by energy values as second row
+        event_list_T = event_list[self.event_list[:, 1].argsort()].T
+
+        self.min_energy = np.min(event_list_T[1])
+        self.max_energy = np.max(event_list_T[1])
+        self.min_time = np.min(event_list_T[0])
+        self.max_time = np.max(event_list_T[0])
 
         if ref_band_interest is None:
             ref_band_interest = (self.min_energy, self.max_energy)
@@ -83,10 +89,6 @@ class Covariancespectrum(object):
         self.band_interest = band_interest
         self.dt = dt
 
-        self.event_list = event_list
-
-        # Sorted by energy values as second row
-        event_list_T = event_list[self.event_list[:, 1].argsort()].T
 
         self._construct_energy_events(event_list_T)
 

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -201,7 +201,7 @@ class Covariancespectrum(object):
                 energy_events_[mid_bin] = []
 
                 # Modify self.energy_events to form a band with one key
-                for key in list(self.energy_events.keys()):
+                for key in list(energy_events.keys()):
                     if key >= band[0] and key <= band[1]:
                         energy_events_[mid_bin] += energy_events[key]
                         del energy_events[key]
@@ -317,7 +317,7 @@ class Covariancespectrum(object):
         if not self.avg_covar:
             M = 1
         else:
-            M = self.segment_size
+            M = self.nbins
 
         num = xs_x*err_y + xs_y*err_x + err_x*err_y
         denom = N * M * xs_y

--- a/stingray/tests/test_covariancespectrum.py
+++ b/stingray/tests/test_covariancespectrum.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import warnings
 
-from stingray import Covariancespectrum, Lightcurve
+from stingray import AveragedCovariancespectrum, Covariancespectrum, Lightcurve
 
 
 class TestCovariancespectrum(object):
@@ -39,3 +39,33 @@ class TestCovariancespectrum(object):
                                ref_band_interest=(1, 10))
         assert len(c.covar) == 2
 
+    def test_with_unsorted_event_list(self):
+        event_list = np.array([[2, 1], [2, 3], [1, 2], [5, 2], [4, 1]])
+        with warnings.catch_warnings(record=True) as w:
+            c = Covariancespectrum(event_list, 1)
+            assert "must be sorted" in str(w[0].message)
+
+    def test_with_std_as_iterable(self):
+        c = Covariancespectrum(self.event_list, 1, std=[1, 2])
+
+    def test_with_std_as_a_single_float(self):
+        c = Covariancespectrum(self.event_list, 1, std=2.55)
+
+
+class TestAveragedCovariancespectrum(object):
+
+    def setup_class(self):
+        event_list = np.array([[1, 2], [1, 4], [1, 8], [3, 6], [3, 1], [4, 2],
+                               [4, 4], [4, 6], [4, 7], [4, 5], [4, 9], [5, 1],
+                               [5, 6], [5, 7], [5, 9], [5, 3], [5, 8], [6, 1],
+                               [6, 3], [7, 3], [7, 4], [7, 5], [7, 7], [8, 8],
+                               [9, 2], [9, 5], [9, 9], [10, 1], [10, 2]])
+        self.event_list = event_list
+
+    def test_with_full_segment(self):
+        c = Covariancespectrum(self.event_list, 1)
+        avg_c = AveragedCovariancespectrum(self.event_list, 1, segment_size=10)
+        assert np.all(avg_c.unnorm_covar == c.unnorm_covar)
+
+    def test_with_two_segments(self):
+        avg_c = AveragedCovariancespectrum(self.event_list, 1, segment_size=5)

--- a/stingray/tests/test_covariancespectrum.py
+++ b/stingray/tests/test_covariancespectrum.py
@@ -1,0 +1,41 @@
+from __future__ import division
+import numpy as np
+
+import pytest
+import warnings
+
+from stingray import Covariancespectrum, Lightcurve
+
+
+class TestCovariancespectrum(object):
+
+    def setup_class(self):
+        event_list = np.array([[1, 2], [1, 4], [1, 8], [3, 6], [3, 1], [4, 2],
+                               [4, 4], [4, 6], [4, 7], [4, 5], [4, 9], [5, 1],
+                               [5, 6], [5, 7], [5, 9], [5, 3], [5, 8], [6, 1],
+                               [6, 3], [7, 3], [7, 4], [7, 5], [7, 7], [8, 8],
+                               [9, 2], [9, 5], [9, 9]])
+        self.event_list = event_list
+
+    def test_covar_without_any_band_interest(self):
+        c = Covariancespectrum(self.event_list, 1)
+        assert len(c.covar) == 8
+
+    def test_init_with_invalid_band_interest(self):
+        with pytest.raises(AssertionError):
+            c = Covariancespectrum(self.event_list, 1, band_interest=(1, 4))
+
+    def test_init_with_invalid_ref_band_interest(self):
+        with pytest.raises(AssertionError):
+            c = Covariancespectrum(self.event_list, 1, ref_band_interest=(0))
+
+    def test_covar_with_ref_band_interest(self):
+        c = Covariancespectrum(self.event_list, 1, ref_band_interest=(2, 3))
+        assert c.energy_covar[2.5] == 0
+
+    def test_covar_with_both_bands(self):
+        c = Covariancespectrum(self.event_list, 1,
+                               band_interest=[(2, 6), (8, 9)],
+                               ref_band_interest=(1, 10))
+        assert len(c.covar) == 2
+

--- a/stingray/tests/test_covariancespectrum.py
+++ b/stingray/tests/test_covariancespectrum.py
@@ -29,10 +29,6 @@ class TestCovariancespectrum(object):
         with pytest.raises(AssertionError):
             c = Covariancespectrum(self.event_list, 1, ref_band_interest=(0))
 
-    def test_covar_with_ref_band_interest(self):
-        c = Covariancespectrum(self.event_list, 1, ref_band_interest=(2, 3))
-        assert np.isnan(c.energy_covar[2.5])
-
     def test_covar_with_both_bands(self):
         c = Covariancespectrum(self.event_list, 1,
                                band_interest=[(2, 6), (8, 9)],

--- a/stingray/tests/test_covariancespectrum.py
+++ b/stingray/tests/test_covariancespectrum.py
@@ -31,7 +31,7 @@ class TestCovariancespectrum(object):
 
     def test_covar_with_ref_band_interest(self):
         c = Covariancespectrum(self.event_list, 1, ref_band_interest=(2, 3))
-        assert c.energy_covar[2.5] == 0
+        assert np.isnan(c.energy_covar[2.5])
 
     def test_covar_with_both_bands(self):
         c = Covariancespectrum(self.event_list, 1,


### PR DESCRIPTION
Currently, this PR adds a basic functionality to create a covariance spectra for full range of event list.
To do :

- [x] Add band of interest for reference spectrum
- [x] Add band of interest for base light curve

A working example :-
```python
>>> event_list = np.array([[1, 2],
                       [1, 4],
                       [1, 8],
                       [3, 6],
                       [3, 1],
                       [4, 2],
                       [4, 4],
                       [4, 6],
                       [4, 7],
                       [4, 5],
                       [4, 9],
                       [5, 1],
                       [5, 6],
                       [5, 7],
                       [5, 9],
                       [5, 3],
                       [5, 8],
                       [6, 1],
                       [6, 3],
                       [7, 3],
                       [7, 4],
                       [7, 5],
                       [7, 7],
                       [8, 8],
                       [9, 2],
                       [9, 5],
                       [9, 9]])

>>> c = Covariancespectrum(event_list, 1)

>>> c.energy_covar
{1.5: -0.2857142857142857,
 2.5: 0.14285714285714285,
 3.5: 0.0,
 4.5: 0.14285714285714285,
 5.5: 0.2857142857142857,
 6.5: 0.2857142857142857,
 7.5: 0.5714285714285714,
 8.5: 0.46428571428571425}
```

The format and technique are all open to discussion. I've ignored a little of pep8, which I intend to fix soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/111)
<!-- Reviewable:end -->
