### PR TITLE
Fixed differences in ConfigParser between Python2 and Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import sys
 
 import ah_bootstrap
 from setuptools import setup
+from six.moves import configparser
 
 #A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
@@ -22,7 +23,7 @@ from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
 from distutils import config
-conf = config.ConfigParser()
+conf = configparser.ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
I've had trouble running `setup.py` on my computer due to an attribute error saying that `config` has no attribute `ConfigParser`. With a bit of searching, I discovered that this is likely a Python2/3 conversion issue, and I added an import to `six.moves` that should fix the issue.

I'm surprised that Travis didn't catch it?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/118)
<!-- Reviewable:end -->
