### PR TITLE
[WIP] Add Python 3.5 in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 2.7
     - 3.3
     - 3.4
+    - 3.5
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -44,7 +45,7 @@ env:
 
 matrix:
     include:
-        
+
         #Try without importing h5py
         - python: 2.7
           env: CONDA_DEPENDENCIES='Cython numpy scipy nose matplotlib'
@@ -117,7 +118,7 @@ install:
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some
     # cases this may not provide enough flexibility in how to install a
-    # specific dependency (and it will not be able to install non-Python 
+    # specific dependency (and it will not be able to install non-Python
     # dependencies). Therefore, you can also include commands below (as
     # well as at the start of the install section or in the before_install
     # section if they are needed before setting up conda) to install any

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
@dhuppenkothen We're getting build failure for Py 3.5
```
Traceback (most recent call last):
  File "setup.py", line 25, in <module>
    conf = config.ConfigParser()
AttributeError: module 'distutils.config' has no attribute 'ConfigParser'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/122)
<!-- Reviewable:end -->
