### PR TITLE
When rebinning logarithmically cross power spectra, use simple floats

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -286,7 +286,7 @@ class Crossspectrum(object):
             the binned powers
 
         nsamples: numpy.ndarray
-            the samples of the original periodogramincluded in each
+            the samples of the original periodogram included in each
             frequency bin
         """
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -301,9 +301,10 @@ class Crossspectrum(object):
             binfreq.append(binfreq[-1] + df*(1.0+f))
             df = binfreq[-1] - binfreq[-2]
 
-        # compute the mean of the powers that fall into each new frequency bin
+        # compute the mean of the powers that fall into each new frequency bin.
+        # we cast to np.double due to scipy's bad handling of longdoubles
         binpower, bin_edges, binno = scipy.stats.binned_statistic(
-            self.freq.astype(np.float), self.power.astype(np.float),
+            self.freq.astype(np.double), self.power.astype(np.double),
             statistic="mean", bins=binfreq)
 
         # compute the number of powers in each frequency bin

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -303,7 +303,8 @@ class Crossspectrum(object):
 
         # compute the mean of the powers that fall into each new frequency bin
         binpower, bin_edges, binno = scipy.stats.binned_statistic(
-            self.freq, self.power, statistic="mean", bins=binfreq)
+            self.freq.astype(np.float), self.power.astype(np.float),
+            statistic="mean", bins=binfreq)
 
         # compute the number of powers in each frequency bin
         nsamples = np.array([len(binno[np.where(binno == i)[0]])


### PR DESCRIPTION
This avoids crashes due to scipy refusing to cast longdoubles into floats (E.g. `cannot cast array data from dtype('float128') to dtype('float64') according to the rule 'safe'` ).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/130)
<!-- Reviewable:end -->
