### PR TITLE
[WIP] Import mission files with 'read' method

### DIFF
--- a/stingray/fitsdb.py
+++ b/stingray/fitsdb.py
@@ -1,0 +1,36 @@
+
+def load_events():
+	"""Load column names and corresponding extensions for fits event 
+	files of different missions.
+	"""
+	
+	config = {'RXTE': [{'TIME':'EVENTS'}, {'PI':'EVENTS'}, {'TIMEZERO':'EVENTS'}, {'MJDREF':'EVENTS'},
+					{'TSTART':'EVENTS'}, {'TSTOP':'EVENTS'}, {'START':'SGTI'}, {'STOP':'SGTI'}]
+			'XMM': [{'TIME':'EVENTS'}, {'PI':'EVENTS'}, {'TIMEZERO':'EVENTS'}, {'MJDREF':'EVENTS'},
+					{'TSTART':'EVENTS'}, {'TSTOP':'EVENTS'}, {'START':'GTI'}, {'STOP':'GTI'}],
+			'NuSTAR': [{'TIME':'EVENTS'}, {'PI':'EVENTS'}, {'TIMEZERO':'EVENTS'}, {'MJDREF':'EVENTS'},
+					{'TSTART':'EVENTS'}, {'TSTOP':'EVENTS'}, {'START':'GTI'}, {'STOP':'GTI'}]}
+
+	return config
+
+def load_lcurve():
+	"""Load column names and corresponding extensions for fits lightcurve 
+	files of different missions.
+	"""
+	
+	config = {'RXTE': ['','','','',''],
+			'XMM': ['','','','',''],
+			'NuSTAR': ['','','','','']}
+
+	return config
+
+def load_spectrum():
+	"""Load column names and corresponding extensions for fits spectrum file
+	of different missions.
+	"""
+	
+	config = {'RXTE': ['','','','',''],
+			'XMM': ['','','','',''],
+			'NuSTAR': ['','','','','']}
+
+	return config

--- a/stingray/fitsdb.py
+++ b/stingray/fitsdb.py
@@ -1,36 +1,51 @@
 
-def load_events():
+def load_events(mission):
 	"""Load column names and corresponding extensions for fits event 
 	files of different missions.
+
+	Parameter
+	---------
+	mission: str
+		Name of the mission. Accepts 'RXTE', 'XMM' and 'NuSTAR'
 	"""
 	
-	config = {'RXTE': [{'TIME':'EVENTS'}, {'PI':'EVENTS'}, {'TIMEZERO':'EVENTS'}, {'MJDREF':'EVENTS'},
-					{'TSTART':'EVENTS'}, {'TSTOP':'EVENTS'}, {'START':'SGTI'}, {'STOP':'SGTI'}]
-			'XMM': [{'TIME':'EVENTS'}, {'PI':'EVENTS'}, {'TIMEZERO':'EVENTS'}, {'MJDREF':'EVENTS'},
-					{'TSTART':'EVENTS'}, {'TSTOP':'EVENTS'}, {'START':'GTI'}, {'STOP':'GTI'}],
-			'NuSTAR': [{'TIME':'EVENTS'}, {'PI':'EVENTS'}, {'TIMEZERO':'EVENTS'}, {'MJDREF':'EVENTS'},
-					{'TSTART':'EVENTS'}, {'TSTOP':'EVENTS'}, {'START':'GTI'}, {'STOP':'GTI'}]}
+	config = {'RXTE': {'TIME':'EVENTS', 'PI':'EVENTS', 'TIMEZERO':'EVENTS', 'MJDREF':'EVENTS',
+					'TSTART':'EVENTS', 'TSTOP':'EVENTS', 'START':'SGTI', 'STOP':'SGTI'},
+			'XMM': {'TIME':'EVENTS', 'PI':'EVENTS', 'TIMEZERO':'EVENTS', 'MJDREF':'EVENTS',
+					'TSTART':'EVENTS', 'TSTOP':'EVENTS', 'START':'GTI', 'STOP':'GTI'},
+			'NuSTAR': {'TIME':'EVENTS', 'PI':'EVENTS', 'TIMEZERO':'EVENTS', 'MJDREF':'EVENTS',
+					'TSTART':'EVENTS', 'TSTOP':'EVENTS', 'START':'GTI', 'STOP':'GTI'}}
 
-	return config
+	return config[mission]
 
-def load_lcurve():
+def load_lcurve(mission):
 	"""Load column names and corresponding extensions for fits lightcurve 
 	files of different missions.
+
+	Parameter
+	---------
+	mission: str
+		Name of the mission. Accepts 'RXTE', 'XMM' and 'NuSTAR'
 	"""
 	
 	config = {'RXTE': ['','','','',''],
 			'XMM': ['','','','',''],
 			'NuSTAR': ['','','','','']}
 
-	return config
+	return config[mission]
 
-def load_spectrum():
+def load_spectrum(mission):
 	"""Load column names and corresponding extensions for fits spectrum file
 	of different missions.
+
+	Parameter
+	---------
+	mission: str
+		Name of the mission. Accepts 'RXTE', 'XMM' and 'NuSTAR'
 	"""
-	
+
 	config = {'RXTE': ['','','','',''],
 			'XMM': ['','','','',''],
 			'NuSTAR': ['','','','','']}
 
-	return config
+	return config[mission]

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -309,8 +309,7 @@ def common_name(str1, str2, default='common'):
     return common_str
 
 def split_numbers(number):
-    """
-    Split high precision number(s) into doubles.
+    """Split high precision number(s) into doubles.
     TODO: Consider the option of using a third number to specify shift.
 
     Parameters
@@ -337,8 +336,7 @@ def split_numbers(number):
     return np.double(number_I), np.double(number_F)
 
 def _save_pickle_object(object, filename):
-    """
-    Save a class object in pickle format.
+    """Save a class object in pickle format.
 
     Parameters
     ----------
@@ -354,8 +352,7 @@ def _save_pickle_object(object, filename):
         pickle.dump(object, f)
 
 def _retrieve_pickle_object(filename):
-    """
-    Retrieves a pickled class object.
+    """Retrieves a pickled class object.
 
     Parameters
     ----------
@@ -371,8 +368,7 @@ def _retrieve_pickle_object(filename):
         return pickle.load(f)
 
 def _save_hdf5_object(object, filename):
-    """
-    Save a class object in hdf5 format.
+    """Save a class object in hdf5 format.
 
     Parameters
     ----------
@@ -416,8 +412,7 @@ def _save_hdf5_object(object, filename):
                     pass
 
 def _retrieve_hdf5_object(filename):
-    """
-    Retrieves an hdf5 format class object.
+    """Retrieves an hdf5 format class object.
 
     Parameters
     ----------
@@ -473,8 +468,7 @@ def _retrieve_hdf5_object(filename):
     return data
 
 def _save_ascii_object(object, filename, fmt="%.18e", **kwargs):
-    """
-    Save an array to a text file.
+    """Save an array to a text file.
 
     Parameters
     ----------
@@ -503,8 +497,7 @@ def _save_ascii_object(object, filename, fmt="%.18e", **kwargs):
     pass
 
 def _retrieve_ascii_object(filename, **kwargs):
-    """
-    Helper function to retrieve ascii objects from file.
+    """Helper function to retrieve ascii objects from file.
     Uses astropy.Table for reading and storing the data.
 
     Parameters
@@ -570,8 +563,7 @@ def _retrieve_ascii_object(filename, **kwargs):
         return data[cols]
 
 def _save_fits_object(object, filename, **kwargs):
-    """
-    Save a class object in fits format.
+    """Save a class object in fits format.
 
     Parameters
     ----------
@@ -667,8 +659,7 @@ def _save_fits_object(object, filename, **kwargs):
     tbhdu.writeto(filename)
 
 def _retrieve_fits_object(filename, **kwargs):
-    """
-    Retrieves a fits format class object.
+    """Retrieves a fits format class object.
 
     Parameters
     ----------
@@ -751,9 +742,7 @@ def _retrieve_fits_object(filename, **kwargs):
     return data
 
 def _lookup_format(var):
-    """
-    Looks up relevant format in fits.
-    """
+    """Looks up relevant format in fits."""
 
     lookup = {"<type 'int'>":"J", "<type 'float'>":"E", 
         "<type 'numpy.int64'>": "K", "<type 'numpy.float64'>":"D", 
@@ -769,9 +758,7 @@ def _lookup_format(var):
         return "D"
 
 def _isattribute(data):
-    """
-    Check if data is a single number or an array.
-    """
+    """Check if data is a single number or an array."""
 
     if isinstance(data, np.ndarray) or isinstance(data, list):
         return False
@@ -779,8 +766,7 @@ def _isattribute(data):
         return True
 
 def write(input_, filename, format_='pickle', **kwargs):
-    """
-    Pickle a class instance. For parameters depending on
+    """Pickle a class instance. For parameters depending on
     `format_`, see individual function definitions.
 
     Parameters
@@ -818,8 +804,7 @@ def write(input_, filename, format_='pickle', **kwargs):
         utils.simon('Format not understood.')
 
 def read(filename, format_='pickle', **kwargs):
-    """
-    Return a pickled class instance.
+    """Return a pickled class instance.
 
     Parameters
     ----------
@@ -857,8 +842,7 @@ def read(filename, format_='pickle', **kwargs):
         utils.simon('Format not understood.')
         
 def savefig(filename, **kwargs):
-    """
-    Save a figure plotted by Matplotlib.
+    """Save a figure plotted by Matplotlib.
 
     Note : This function is supposed to be used after the ``plot``
     function. Otherwise it will save a blank image with no plot.

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -197,9 +197,10 @@ class TestFileFormats(object):
 
     def test_fits_data_recovery(self):
         test_object = TestIOReadWrite()
-        write(test_object, 'test.fits', 'fits')
+        write(test_object, 'test.fits', 'fits', tnames=['EVENTS', 'GTI'],
+            colsassign={'number':'GTI', 'array':'GTI'})
         rec_object = read('test.fits', 'fits', cols = ['number', 'str', 'list',
-            'array','long_array','long_number'])
+            'array','long_array','long_number'], colsassign={'number':'GTI', 'array':'GTI'})
 
         assert rec_object['NUMBER'] == test_object.number
         assert rec_object['STR'] == test_object.str

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -212,6 +212,11 @@ class TestFileFormats(object):
         del rec_object
         os.remove('test.fits')
 
+    def test_events_mission_read(self):
+        """Read an events mission fits file."""
+        fname = os.path.join(datadir, 'monol_testA.evt')
+        read(fname, 'fits')
+
     def test_savefig_matplotlib_not_installed(self):
         from ..io import savefig
         try:


### PR DESCRIPTION
Referring to the discussion in Issue #137, I first tried to implemented @matteobachetti's solution but that seemed to involve a lot of code duplication and use of _if else's_.

The current PR alters the `_retrieve_fits_object()`, which now works as follows:

1- Mission of the fits file is recognised by inspecting `TELESCOP` parameter in primary header. 
2(a) - If mission is one of NuSTAR, RXTE or XMM, column names and corresponding extensions are imported from `fitsdb.py`
2(b)- If mission parameter is not found, column names and corresponding extensions are set to user-provided input.

Currently, the `read()` method is able to read fits events files from different missions. I would add support for lightcurves and spectrum later.

Before progressing further, I would like to see if there are any recommendations/comments?
@matteobachetti @dhuppenkothen

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/138)

<!-- Reviewable:end -->
