### PR TITLE
Fix the `rebin_data()` method

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -201,8 +201,8 @@ class Crossspectrum(object):
         """
 
         # rebin cross spectrum to new resolution
-        binfreq, bincs, step_size = utils.rebin_data(self.freq[1:],
-                                                     self.power[1:], df,
+        binfreq, bincs, step_size = utils.rebin_data(self.freq,
+                                                     self.power, df,
                                                      method=method)
 
         # make an empty cross spectrum object
@@ -210,8 +210,8 @@ class Crossspectrum(object):
         bin_cs = self.__class__()
 
         # store the binned periodogram in the new object
-        bin_cs.freq = np.hstack([binfreq[0]-self.df, binfreq])
-        bin_cs.power = np.hstack([self.power[0], bincs])
+        bin_cs.freq = binfreq
+        bin_cs.power = bincs
         bin_cs.df = df
         bin_cs.n = self.n
         bin_cs.norm = self.norm

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -241,7 +241,7 @@ class Crossspectrum(object):
         bin_cs.norm = self.norm
         bin_cs.nphots1 = self.nphots1
         bin_cs.nphots2 = self.nphots2
-        bin_cs.m = int(step_size)
+        bin_cs.m = int(step_size)*self.m
 
         return bin_cs
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1,5 +1,4 @@
 from __future__ import division
-__all__ = ["Crossspectrum", "AveragedCrossspectrum", "coherence"]
 
 import numpy as np
 import scipy
@@ -11,6 +10,8 @@ import stingray.lightcurve as lightcurve
 import stingray.utils as utils
 from stingray.exceptions import StingrayError
 from stingray.gti import cross_two_gtis, bin_intervals_from_gtis, check_gtis
+
+__all__ = ["Crossspectrum", "AveragedCrossspectrum", "coherence"]
 
 
 def coherence(lc1, lc2):
@@ -40,6 +41,7 @@ def coherence(lc1, lc2):
     cs = Crossspectrum(lc1, lc2, norm='none')
 
     return cs.coherence()
+
 
 class Crossspectrum(object):
 
@@ -97,16 +99,16 @@ class Crossspectrum(object):
             raise TypeError("norm must be a string")
 
         if norm.lower() not in ["frac", "abs", "leahy", "none"]:
-            raise ValueError( "norm must be 'frac', 'abs', 'leahy', or 'none'!")
+            raise ValueError("norm must be 'frac', 'abs', 'leahy', or 'none'!")
 
         self.norm = norm.lower()
 
-        ## check if input data is a Lightcurve object, if not make one or
-        ## make an empty Crossspectrum object if lc1 == None or lc2 == None
+        # check if input data is a Lightcurve object, if not make one or
+        # make an empty Crossspectrum object if lc1 == None or lc2 == None
         if lc1 is None or lc2 is None:
             if lc1 is not None or lc2 is not None:
-                 raise TypeError("You can't do a cross spectrum with just one "
-                         "light curve!")
+                raise TypeError("You can't do a cross spectrum with just one "
+                                "light curve!")
             else:
                 self.freq = None
                 self.power = None
@@ -123,7 +125,7 @@ class Crossspectrum(object):
 
     def _make_crossspectrum(self, lc1, lc2):
 
-        ## make sure the inputs work!
+        # make sure the inputs work!
         if not isinstance(lc1, lightcurve.Lightcurve):
             raise TypeError("lc1 must be a lightcurve.Lightcurve object")
 
@@ -143,15 +145,15 @@ class Crossspectrum(object):
         lc1 = lc1.split_by_gti()[0]
         lc2 = lc2.split_by_gti()[0]
 
-        ## total number of photons is the sum of the
-        ## counts in the light curve
+        # total number of photons is the sum of the
+        # counts in the light curve
         self.nphots1 = np.float64(np.sum(lc1.counts))
         self.nphots2 = np.float64(np.sum(lc2.counts))
 
         self.meancounts1 = np.mean(lc1.counts)
         self.meancounts2 = np.mean(lc2.counts)
 
-        ## the number of data points in the light curve
+        # the number of data points in the light curve
 
         if lc1.counts.shape[0] != lc2.counts.shape[0]:
             raise StingrayError("Light curves do not have same number "
@@ -163,24 +165,24 @@ class Crossspectrum(object):
 
         self.n = lc1.counts.shape[0]
 
-        ## the frequency resolution
+        # the frequency resolution
         self.df = 1.0/lc1.tseg
 
-        ## the number of averaged periodograms in the final output
-        ## This should *always* be 1 here
+        # the number of averaged periodograms in the final output
+        # This should *always* be 1 here
         self.m = 1
 
-        ## make the actual Fourier transform and compute cross spectrum
+        # make the actual Fourier transform and compute cross spectrum
         self.freq, self.unnorm_power = self._fourier_cross(lc1, lc2)
 
-        ## If co-spectrum is desired, normalize here. Otherwise, get raw back
-        ## with the imaginary part still intact.
+        # If co-spectrum is desired, normalize here. Otherwise, get raw back
+        # with the imaginary part still intact.
         self.power = self._normalize_crossspectrum(self.unnorm_power, lc1.tseg)
 
     def _fourier_cross(self, lc1, lc2):
         """
         Fourier transform the two light curves, then compute the cross spectrum.
-        computed as CS = lc1 x lc2* (where lc2 is the one that gets
+        Computed as CS = lc1 x lc2* (where lc2 is the one that gets
         complex-conjugated)
 
         Parameters
@@ -190,8 +192,8 @@ class Crossspectrum(object):
             interest or channel of interest.
 
         lc2: lightcurve.Lightcurve object
-            Another light curve to be Fourier transformed. This is the reference
-            band.
+            Another light curve to be Fourier transformed.
+            This is the reference band.
 
         Returns
         -------
@@ -273,7 +275,7 @@ class Crossspectrum(object):
         actual_mean = np.sqrt(self.meancounts1 * self.meancounts2)
 
         assert actual_mean > 0.0, \
-                "Mean count rate is <= 0. Something went wrong."
+            "Mean count rate is <= 0. Something went wrong."
 
         if self.norm.lower() == 'leahy':
             c = unnorm_power.real
@@ -394,7 +396,8 @@ class Crossspectrum(object):
 
 class AveragedCrossspectrum(Crossspectrum):
 
-    def __init__(self, lc1=None, lc2=None, segment_size=None, norm='none', gti=None):
+    def __init__(self, lc1=None, lc2=None, segment_size=None,
+                 norm='none', gti=None):
         """
         Make an averaged cross spectrum from a light curve by segmenting two
         light curves, Fourier-transforming each segment and then averaging the
@@ -413,10 +416,11 @@ class AveragedCrossspectrum(Crossspectrum):
             reference band.
 
         segment_size: float
-            The size of each segment to average. Note that if the total duration
-            of each Lightcurve object in lc1 or lc2 is not an integer multiple
-            of the segment_size, then any fraction left-over at the end of the
-            time series will be lost. Otherwise you introduce artefacts.
+            The size of each segment to average. Note that if the total
+            duration of each Lightcurve object in lc1 or lc2 is not an
+            integer multiple of the segment_size, then any fraction left-over
+            at the end of the time series will be lost. Otherwise you introduce
+            artefacts.
 
         norm: {'frac', 'abs', 'leahy', 'none'}, default 'none'
             The normalization of the (real part of the) cross spectrum.
@@ -453,7 +457,8 @@ class AveragedCrossspectrum(Crossspectrum):
 
         gti: 2-d float array
             [[gti0_0, gti0_1], [gti1_0, gti1_1], ...] -- Good Time intervals.
-            They are calculated by taking the common GTI between the two light curves
+            They are calculated by taking the common GTI between the
+            two light curves
 
         """
         self.type = "crossspectrum"
@@ -522,14 +527,14 @@ class AveragedCrossspectrum(Crossspectrum):
 
         else:
             self.cs_all, nphots1_all, nphots2_all = [], [], []
-            ## TODO: should be using izip from iterables if lc1 or lc2 could
-            ## be long
+            # TODO: should be using izip from iterables if lc1 or lc2 could
+            # be long
             for lc1_seg, lc2_seg in zip(lc1, lc2):
 
                 if self.type == "crossspectrum":
                     cs_sep, nphots1_sep, nphots2_sep = \
                         self._make_segment_spectrum(lc1_seg, lc2_seg,
-                                                            self.segment_size)
+                                                    self.segment_size)
                     nphots2_all.append(nphots2_sep)
                 elif self.type == "powerspectrum":
                     cs_sep, nphots1_sep = \

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -73,20 +73,20 @@ class Lightcurve(object):
 
         """
         if not np.all(np.isfinite(time)):
-            raise ValueError( "There are inf or NaN values in "
-                              "your time array!")
+            raise ValueError("There are inf or NaN values in "
+                             "your time array!")
 
         if not np.all(np.isfinite(counts)):
-            raise ValueError( "There are inf or NaN values in "
-                              "your counts array!")
+            raise ValueError("There are inf or NaN values in "
+                             "your counts array!")
 
         if len(time) != len(counts):
             raise StingrayError("time are counts array are not "
-                                         "of the same length!")
+                                "of the same length!")
 
         if len(time) <= 1:
-            raise StingrayError("A single or no data points can not create " \
-                              "a lightcurve!")
+            raise StingrayError("A single or no data points can not create "
+                                "a lightcurve!")
 
         self.time = np.asarray(time)
         self.dt = time[1] - time[0]
@@ -159,7 +159,7 @@ class Lightcurve(object):
             assert np.all(np.equal(self.time, other.time))
         except (ValueError, AssertionError):
             raise ValueError("Time arrays of both light curves must be "
-                                 "of same dimension and equal.")
+                             "of same dimension and equal.")
 
         new_counts = np.add(self.counts, other.counts)
         common_gti = cross_two_gtis(self.gti, other.gti)
@@ -198,7 +198,7 @@ class Lightcurve(object):
             assert np.all(np.equal(self.time, other.time))
         except (ValueError, AssertionError):
             raise ValueError("Time arrays of both light curves must be "
-                                 "of same dimension and equal.")
+                             "of same dimension and equal.")
 
         new_counts = np.subtract(self.counts, other.counts)
         common_gti = cross_two_gtis(self.gti, other.gti)
@@ -375,8 +375,8 @@ class Lightcurve(object):
         """
 
         if dt_new < self.dt:
-            raise ValueError("New time resolution must be larger than " \
-                                  "old time resolution!")
+            raise ValueError("New time resolution must be larger than "
+                             "old time resolution!")
 
         bin_time, bin_counts, _ = utils.rebin_data(self.time,
                                                    self.counts,
@@ -451,8 +451,8 @@ class Lightcurve(object):
             except IndexError:
                 count2 = None
 
-            if not count1 is None:
-                if not count2 is None:
+            if count1 is not None:
+                if count2 is not None:
                     # Average the overlapping counts
                     new_counts.append((count1 + count2) / 2)
                 else:
@@ -516,8 +516,8 @@ class Lightcurve(object):
         """
 
         if not isinstance(method, str):
-            raise TypeError("method key word argument is not " \
-                                        "a string !")
+            raise TypeError("method key word argument is not "
+                            "a string !")
 
         if method.lower() not in ['index', 'time']:
             raise ValueError("Unknown method type " + method + ".")
@@ -534,7 +534,7 @@ class Lightcurve(object):
         gti = \
             cross_two_gtis(self.gti,
                            np.asarray([[self.time[start] - 0.5 * self.dt,
-                                        time_new[-1] + 0.5 * self.dt]]) )
+                                        time_new[-1] + 0.5 * self.dt]]))
 
         return Lightcurve(time_new, counts_new, gti=gti)
 
@@ -676,7 +676,7 @@ class Lightcurve(object):
 
         if format_ == 'ascii':
             io.write(np.array([self.time, self.counts]).T,
-              filename, format_, fmt=["%s", "%s"])
+                     filename, format_, fmt=["%s", "%s"])
 
         elif format_ == 'pickle':
             io.write(self, filename, format_)
@@ -716,7 +716,9 @@ class Lightcurve(object):
             utils.simon("Format not understood.")
 
     def split_by_gti(self):
-        """Splits the `LightCurve` into a list of `LightCurve`s , using GTIs."""
+        """
+        Splits the `LightCurve` into a list of `LightCurve`s , using GTIs.
+        """
         list_of_lcs = []
 
         start_bins, stop_bins = gti_border_bins(self.gti, self.time)

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -39,8 +39,8 @@ class Lightcurve(object):
         gti: 2-d float array, default None
             [[gti0_0, gti0_1], [gti1_0, gti1_1], ...]
             Good Time Intervals. They are *not* applied to the data by default.
-            They will be used by other methods to have an indication of the 
-            "safe" time intervals to use during analysis. 
+            They will be used by other methods to have an indication of the
+            "safe" time intervals to use during analysis.
 
         Attributes
         ----------
@@ -334,7 +334,7 @@ class Lightcurve(object):
 
         return Lightcurve(time, counts, gti=gti)
 
-    def rebin_lightcurve(self, dt_new, method='sum'):
+    def rebin(self, dt_new, method='sum'):
         """
         Rebin the light curve to a new time resolution. While the new
         resolution need not be an integer multiple of the previous time

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     _H5PY_INSTALLED = False
 
+
 class TestLightcurve(object):
 
     @classmethod
@@ -325,7 +326,7 @@ class TestLightcurve(object):
 
         lc.sort()
 
-        assert np.all(lc.counts == np.array([ 5, 10, 20, 40]))
+        assert np.all(lc.counts == np.array([5, 10, 20, 40]))
         assert np.all(lc.time == np.array([4, 2, 3, 1]))
 
         lc.sort(reverse=True)
@@ -388,14 +389,14 @@ class TestLightcurve(object):
 
     def test_io_with_ascii(self):
         lc = Lightcurve(self.times, self.counts)
-        lc.write('ascii_lc.txt',format_='ascii')
+        lc.write('ascii_lc.txt', format_='ascii')
         lc.read('ascii_lc.txt', format_='ascii')
         os.remove('ascii_lc.txt')
 
     def test_io_with_pickle(self):
         lc = Lightcurve(self.times, self.counts)
         lc.write('lc.pickle', format_='pickle')
-        lc.read('lc.pickle',format_='pickle')
+        lc.read('lc.pickle', format_='pickle')
         assert np.all(lc.time == self.times)
         assert np.all(lc.counts == self.counts)
         assert np.all(lc.gti == self.gti)
@@ -406,14 +407,14 @@ class TestLightcurve(object):
         lc.write('lc.hdf5', format_='hdf5')
 
         if _H5PY_INSTALLED:
-            data = lc.read('lc.hdf5',format_='hdf5')
+            data = lc.read('lc.hdf5', format_='hdf5')
             assert np.all(data['time'] == self.times)
             assert np.all(data['counts'] == self.counts)
             assert np.all(data['gti'] == self.gti)
             os.remove('lc.hdf5')
 
         else:
-            lc.read('lc.pickle',format_='pickle')
+            lc.read('lc.pickle', format_='pickle')
             assert np.all(lc.time == self.times)
             assert np.all(lc.counts == self.counts)
             assert np.all(lc.gti == self.gti)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -138,7 +138,7 @@ class TestLightcurve(object):
     def test_init_with_diff_array_lengths(self):
         time = [1, 2, 3]
         counts = [2, 2, 2, 2]
-        
+
         with pytest.raises(StingrayError):
             lc = Lightcurve(time, counts)
 
@@ -296,7 +296,7 @@ class TestLightcurve(object):
 
     def test_truncate_by_time_stop_less_than_start(self):
         lc = Lightcurve(self.times, self.counts)
- 
+
         with pytest.raises(ValueError):
             lc1 = lc.truncate(start=2, stop=1, method='time')
 
@@ -404,7 +404,7 @@ class TestLightcurve(object):
     def test_io_with_hdf5(self):
         lc = Lightcurve(self.times, self.counts)
         lc.write('lc.hdf5', format_='hdf5')
-        
+
         if _H5PY_INSTALLED:
             data = lc.read('lc.hdf5',format_='hdf5')
             assert np.all(data['time'] == self.times)
@@ -449,7 +449,7 @@ class TestLightcurveRebin(object):
 
     def test_rebin_even(self):
         dt_new = 2.0
-        lc_binned = self.lc.rebin_lightcurve(dt_new)
+        lc_binned = self.lc.rebin(dt_new)
         assert np.isclose(lc_binned.dt, dt_new)
         counts_test = np.zeros_like(lc_binned.time) + \
             self.lc.counts[0]*dt_new/self.lc.dt
@@ -457,7 +457,7 @@ class TestLightcurveRebin(object):
 
     def test_rebin_odd(self):
         dt_new = 1.5
-        lc_binned = self.lc.rebin_lightcurve(dt_new)
+        lc_binned = self.lc.rebin(dt_new)
         assert np.isclose(lc_binned.dt, dt_new)
 
         counts_test = np.zeros_like(lc_binned.time) + \
@@ -468,7 +468,7 @@ class TestLightcurveRebin(object):
         """
         TODO: Not sure how to write tests for the rebin method!
         """
-        lc_binned = self.lc.rebin_lightcurve(dt)
+        lc_binned = self.lc.rebin(dt)
         assert len(lc_binned.time) == len(lc_binned.counts)
 
     def test_rebin_equal_numbers(self):

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -197,7 +197,10 @@ class TestPowerspectrum(object):
         """
         ps = Powerspectrum(lc=self.lc, norm="Leahy")
         bin_ps = ps.rebin(df)
-        assert np.isclose(bin_ps.freq[0], bin_ps.df, atol=1e-4, rtol=1e-4)
+        assert np.isclose(bin_ps.freq[1]-bin_ps.freq[0], bin_ps.df,
+                          atol=1e-4, rtol=1e-4)
+        assert np.isclose(bin_ps.freq[0], (ps.freq[0]-ps.df*0.5+bin_ps.df*0.5),
+                          atol=1e-4, rtol=1e-4)
 
     def test_rebin(self):
         df_all = [2, 3, 5, 1.5, 1, 85]

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -156,8 +156,7 @@ class TestPowerspectrum(object):
         with pytest.raises(Exception):
             ps = Powerspectrum(lc=self.lc, norm="rms")
             rms_ps, rms_err = ps.compute_rms(min_freq=ps.freq[0],
-                                            max_freq=ps.freq[-1])
-
+                                             max_freq=ps.freq[-1])
 
     def test_fractional_rms_error(self):
         """

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -54,7 +54,9 @@ class TestRebinData(object):
     def test_rebin_data_should_raise_error_when_method_is_different_than_allowed(self):
         dx_new = 2.0
         with pytest.raises(ValueError):
-            utils.rebin_data(self.x, self.y, dx_new, method='not_allowed_method')
+            utils.rebin_data(self.x, self.y, dx_new,
+                             method='not_allowed_method')
+
 
 class TestUtils(object):
 
@@ -81,7 +83,7 @@ class TestUtils(object):
     def test_look_for_array(self):
         assert utils.look_for_array_in_array(np.arange(2), np.arange(1, 3))
         assert not utils.look_for_array_in_array(np.arange(2),
-                                                  np.arange(2, 4))
+                                                 np.arange(2, 4))
 
     def test_assign_value_if_none(self):
         assert utils.assign_value_if_none(None, 2) == 2
@@ -93,4 +95,3 @@ class TestUtils(object):
         cont = utils.contiguous_regions(array)
         assert np.all(cont == np.array([[1, 3], [4, 7]])), \
             'Contiguous region wrong'
-

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -28,7 +28,7 @@ def simon(message, **kwargs):
     kwargs : dict
         The rest of the arguments that are passed to warnings.warn
     """
-    
+
     warnings.warn("SIMON says: {0}".format(message), **kwargs)
 
 
@@ -107,7 +107,8 @@ def rebin_data(x, y, dx_new, method='sum'):
     if (tseg / dx_new % 1) > 0:
         ybin = ybin[:-1]
 
-    xbin = np.arange(ybin.shape[0]) * dx_new + x[0] - dx_old + dx_new
+    new_x0 = (x[0] - (0.5*dx_old)) + (0.5*dx_new)
+    xbin = np.arange(ybin.shape[0]) * dx_new + new_x0
 
     return xbin, ybin, step_size
 
@@ -120,7 +121,7 @@ def look_for_array_in_array(array1, array2):
 
 def is_string(s):  # pragma : no cover
     """Portable function to answer this question."""
-    
+
     PY2 = sys.version_info[0] == 2
     if PY2:
         return isinstance(s, basestring)  # NOQA
@@ -130,7 +131,7 @@ def is_string(s):  # pragma : no cover
 
 def is_iterable(stuff):
     """Test if stuff is an iterable."""
-    
+
     return isinstance(stuff, collections.Iterable)
 
 def order_list_of_arrays(data, order):
@@ -151,7 +152,7 @@ def optimal_bin_time(fftlen, tbin):
     slightly shorter than the original, that will produce a power-of-two number
     of FFT bins.
     """
-    
+
     return fftlen / (2 ** np.ceil(np.log2(fftlen / tbin)))
 
 def contiguous_regions(condition):
@@ -174,7 +175,7 @@ def contiguous_regions(condition):
     -----
     From : http://stackoverflow.com/questions/4494404/find-large-number-of-consecutive-values-
     fulfilling-condition-in-a-numpy-array
-    """  
+    """
 
     # NOQA
     # Find the indicies of changes in "condition"

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -14,6 +14,7 @@ except:
     def jit(fun):
         return fun
 
+
 def simon(message, **kwargs):
     """The Statistical Interpretation MONitor.
 
@@ -116,8 +117,10 @@ def rebin_data(x, y, dx_new, method='sum'):
 def assign_value_if_none(value, default):
     return default if value is None else value
 
+
 def look_for_array_in_array(array1, array2):
     return next((i for i in array1 if i in array2), None)
+
 
 def is_string(s):  # pragma : no cover
     """Portable function to answer this question."""
@@ -133,6 +136,7 @@ def is_iterable(stuff):
     """Test if stuff is an iterable."""
 
     return isinstance(stuff, collections.Iterable)
+
 
 def order_list_of_arrays(data, order):
     if hasattr(data, 'items'):
@@ -154,6 +158,7 @@ def optimal_bin_time(fftlen, tbin):
     """
 
     return fftlen / (2 ** np.ceil(np.log2(fftlen / tbin)))
+
 
 def contiguous_regions(condition):
     """Find contiguous True regions of the boolean array "condition".
@@ -193,4 +198,3 @@ def contiguous_regions(condition):
     # Reshape the result into two columns
     idx.shape = (-1, 2)
     return idx
-


### PR DESCRIPTION
Fixes #82 

the `rebin_data()`  method now consistently  returns the mid-points of combined bins.
Both for Lightcurves and Powerspectra.

 - renamed `Lightcurve.rebin_lightcurve` to `Lightcurve.rebin()` (to be consistent with `Powerspectrum.rebin`).
 - Fixes `Powerspectrum.rebin()` legacy code when we were still using the 0th frequency.
 - Fixes test in `test_powerspectrum` where we test if `freq[0]==df`, which is not True for binned Powerspectra.
 - Merge master branch changes into this

Reviews are welcome ^_^

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/140)
<!-- Reviewable:end -->
