### PR TITLE
Fix sphinx-build failure with Python 3 and coveralls failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,4 +136,4 @@ after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='stingray/tests/coveragerc'; fi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,10 @@ except ImportError:
 from astropy_helpers.sphinx.conf import *
 
 # Get configuration information from setup.cfg
-from distutils import config
+try:
+    import configparser as config
+except ImportError:
+    from distutils import config
 conf = config.ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))


### PR DESCRIPTION
`distutils.config` was moved to a separate module named `configparser ` in Python 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/160)
<!-- Reviewable:end -->
