### PR TITLE
Fix un-escaped underscores in reST

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -683,7 +683,7 @@ class Lightcurve(object):
         filename: str
             Name of the LightCurve object to be created.
 
-        format_: str
+        format\_: str
             Available options are 'pickle', 'hdf5', 'ascii'
         """
 
@@ -709,14 +709,14 @@ class Lightcurve(object):
         filename: str
             Name of the LightCurve object to be read.
 
-        format_: str
+        format\_: str
             Available options are 'pickle', 'hdf5', 'ascii'
 
         Returns
         --------
-        If format_ is 'ascii': astropy.table is returned.
-        If format_ is 'hdf5': dictionary with key-value pairs is returned.
-        If format_ is 'pickle': class object is set.
+        If format\_ is 'ascii': astropy.table is returned.
+        If format\_ is 'hdf5': dictionary with key-value pairs is returned.
+        If format\_ is 'pickle': class object is set.
         """
 
         if format_ == 'ascii' or format_ == 'hdf5':


### PR DESCRIPTION
Part of the issues related to the warnings in travis build for the sphinx docs.

See #166

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/167)
<!-- Reviewable:end -->
