### PR TITLE
added bin edges support

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -48,6 +48,12 @@ class Lightcurve(object):
         time: numpy.ndarray
             The array of midpoints of time bins.
 
+        bin_lo:
+            The array of lower time stamp of time bins.
+
+        bin_hi:
+            The array of higher time stamp of time bins.
+
         counts: numpy.ndarray
             The counts per bin corresponding to the bins in `time`.
 
@@ -97,6 +103,9 @@ class Lightcurve(object):
 
         self.time = np.asarray(time)
         self.dt = time[1] - time[0]
+
+        self.bin_lo = self.time - 0.5 * self.dt
+        self.bin_hi = self.time + 0.5 * self.dt
 
         if input_counts:
             self.counts = np.asarray(counts)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -52,6 +52,13 @@ class TestLightcurve(object):
         lc = Lightcurve(self.times, self.counts)
         assert lc.n == 4
 
+    def test_bin_edges(self):
+        bin_lo = [0.5,  1.5,  2.5,  3.5]
+        bin_hi = [1.5,  2.5,  3.5,  4.5]
+        lc = Lightcurve(self.times, self.counts)
+        assert np.allclose(lc.bin_lo, bin_lo)
+        assert np.allclose(lc.bin_hi, bin_hi)
+
     def test_lightcurve_from_toa(self):
         lc = Lightcurve.make_lightcurve(self.times, self.dt)
 


### PR DESCRIPTION
Hi,
This PR addresses a part of [issue-90](https://github.com/StingraySoftware/stingray/issues/90). It is to support bin edges, with `bin_lo` containing lower time stamps of all bins and `bin_hi` the corresponding higher ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/170)
<!-- Reviewable:end -->
