### PR TITLE
ENH: Using numpy.random.RandomState instead seed value alone.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ distribute-*.tar.gz
 
 # Mac OSX
 .DS_Store
+
+# virtualenv
+.venv

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -8,7 +8,7 @@ import stingray.simulator.models as models
 
 class Simulator(object):
 
-    def __init__(self, dt=1, N=1024, mean=0, rms=1, red_noise=1, seed=None):
+    def __init__(self, dt=1, N=1024, mean=0, rms=1, red_noise=1, random_state=None):
         """
         Methods to simulate and visualize light curves.
 
@@ -24,10 +24,10 @@ class Simulator(object):
             fractional rms of the simulated light curve,
             actual rms is calculated by mean*rms
         red_noise: int, default 1
-            multiple of real length of light curve, by 
+            multiple of real length of light curve, by
             which to simulate, to avoid red noise leakage
-        seed: int, default None
-            seed value for random processes
+        random_state: int, numpy.random.RandomState instance, default None
+            seed value or random number generator for random processes
         """
 
         self.dt = dt
@@ -39,9 +39,8 @@ class Simulator(object):
 
         # Initialize a tuple of energy ranges with corresponding light curves
         self.channels = []
-        
-        if seed is not None:
-            np.random.seed(seed)
+
+        self.random_state = utils.get_random_state(random_state)
 
         assert rms<=1, 'Fractional rms must be less than 1.'
         assert dt>0, 'Time resolution must be greater than 0'
@@ -66,7 +65,7 @@ class Simulator(object):
             Returns
             -------
             lightCurve: `LightCurve` object
-        
+
         - x = simulate(s)
             For generating a light curve from user-provided spectrum.
 
@@ -133,7 +132,7 @@ class Simulator(object):
             lightCurve: `LightCurve` object
         """
 
-        if isinstance(args[0], numbers.Integral) and len(args) == 1: 
+        if isinstance(args[0], numbers.Integral) and len(args) == 1:
             return  self._simulate_power_law(args[0])
 
         elif len(args) == 1:
@@ -153,7 +152,7 @@ class Simulator(object):
 
     def simulate_channel(self, channel, *args):
         """
-        Simulate a lightcurve and add it to corresponding energy 
+        Simulate a lightcurve and add it to corresponding energy
         channel.
 
         Parameters
@@ -161,7 +160,7 @@ class Simulator(object):
         channel: str
             range of energy channel (e.g., 3.5-4.5)
 
-        *args: 
+        *args:
             see description of simulate() for details
 
         Returns
@@ -187,7 +186,7 @@ class Simulator(object):
         """
         Get multiple light curves belonging to the energy channels.
         """
-        
+
         return [lc[1] for lc in self.channels if lc[0] in channels]
 
     def get_all_channels(self):
@@ -203,7 +202,7 @@ class Simulator(object):
         """
 
         channel = [lc for lc in self.channels if lc[0] == channel]
-        
+
         if len(channel) == 0:
             raise KeyError('This channel does not exist or has already been deleted.')
         else:
@@ -229,12 +228,12 @@ class Simulator(object):
         """
         Return total number of energy channels.
         """
-        
+
         return len(self.channels)
 
     def simple_ir(self, start=0, width=1000, intensity=1):
         """
-        Construct a simple impulse response using start time, 
+        Construct a simple impulse response using start time,
         width and scaling intensity.
         To create a delta impulse response, set width to 1.
 
@@ -302,21 +301,21 @@ class Simulator(object):
         # Create a rising exponential of user-provided slope
         x = np.linspace(t1/dt, t2/dt, (t2-t1)/dt)
         h_rise = np.exp(rise*x)
-        
+
         # Evaluate a factor for scaling exponential
         factor = np.max(h_rise)/(p2-p1)
         h_secondary = (h_rise/factor) + p1
 
         # Create a decaying exponential until the end time
         x = np.linspace(t2/dt, t3/dt, (t3-t2)/dt)
-        h_decay = (np.exp((-decay)*(x-4/dt))) 
+        h_decay = (np.exp((-decay)*(x-4/dt)))
 
         # Add the three responses
         h = np.append(h_primary, h_secondary)
         h = np.append(h, h_decay)
 
         return h
-        
+
     def _simulate_power_law(self, B):
         """
         Generate LightCurve from a power law spectrum.
@@ -333,10 +332,10 @@ class Simulator(object):
 
         # Define frequencies at which to compute PSD
         w = np.fft.rfftfreq(self.red_noise*self.N, d=self.dt)[1:]
-        
+
         # Draw two set of 'N' guassian distributed numbers
-        a1 = np.random.normal(size=len(w))
-        a2 = np.random.normal(size=len(w))
+        a1 = self.random_state.normal(size=len(w))
+        a2 = self.random_state.normal(size=len(w))
 
         # Multiply by (1/w)^B to get real and imaginary parts
         real = a1 * np.power((1/w),B/2)
@@ -347,6 +346,9 @@ class Simulator(object):
         lc = Lightcurve(self.time, self._extract_and_scale(long_lc))
 
         return lc
+
+    def _simulate_emmanoulopoulos(self):
+        pass
 
     def _simulate_power_spectrum(self, s):
         """
@@ -368,8 +370,8 @@ class Simulator(object):
         self.red_noise = 1
 
         # Draw two set of 'N' guassian distributed numbers
-        a1 = np.random.normal(size=len(s))
-        a2 = np.random.normal(size=len(s))
+        a1 = self.random_state.normal(size=len(s))
+        a2 = self.random_state.normal(size=len(s))
 
         lc = self._find_inverse(a1*s, a2*s)
         lc = Lightcurve(self.time, self._extract_and_scale(lc))
@@ -402,21 +404,21 @@ class Simulator(object):
             s = eval(mod +'(w, p)')
 
             # Draw two set of 'N' guassian distributed numbers
-            a1 = np.random.normal(size=len(s))
-            a2 = np.random.normal(size=len(s))
+            a1 = self.random_state.normal(size=len(s))
+            a2 = self.random_state.normal(size=len(s))
 
             long_lc = self._find_inverse(a1*s, a2*s)
             lc = Lightcurve(self.time, self._extract_and_scale(long_lc))
 
             return lc
-        
+
         else:
             raise ValueError('Model is not defined!')
 
     def _simulate_impulse_response(self, s, h, mode='same'):
         """
         Generate LightCurve from impulse response. To get
-        accurate results, binning intervals (dt) of variability 
+        accurate results, binning intervals (dt) of variability
         signal 's' and impulse response 'h' must be equal.
 
         Parameters
@@ -444,10 +446,10 @@ class Simulator(object):
             lc = lc[:-(len(h) - 1)]
         elif mode == 'filtered':
             lc = lc[(len(h) - 1):-(len(h) - 1)]
-        
+
         time = self.dt * np.arange(len(lc))
         return Lightcurve(time, lc)
-        
+
     def _find_inverse(self, real, imaginary):
         """
         Forms complex numbers corresponding to real and imaginary
@@ -471,7 +473,7 @@ class Simulator(object):
         f = [complex(r, i) for r,i in zip(real,imaginary)]
 
         f = np.hstack([self.mean, f])
-        
+
         # Obtain real valued time series
         f_conj = np.conjugate(np.array(f))
 
@@ -501,8 +503,8 @@ class Simulator(object):
             lc = long_lc
         else:
             # Make random cut and extract light curve of length 'N'
-            extract = np.random.randint(self.N-1, self.red_noise*self.N - self.N+1)
-            lc = np.take(long_lc, range(extract, extract + self.N)) 
+            extract = self.random_state.randint(self.N-1, self.red_noise*self.N - self.N+1)
+            lc = np.take(long_lc, range(extract, extract + self.N))
 
         avg = np.mean(lc)
         std = np.std(lc)
@@ -523,7 +525,7 @@ class Simulator(object):
         -------
         power: numpy.ndarray
             The array of normalized squared absolute values of Fourier
-            amplitudes    
+            amplitudes
 
         """
         if seg_size is None:
@@ -550,7 +552,7 @@ class Simulator(object):
         """
 
         if format_ == 'pickle':
-            data = io.read(filename, 'pickle')        
+            data = io.read(filename, 'pickle')
             return data
         else:
             raise KeyError("Format not supported.")

--- a/stingray/simulator/tests/test_simulator.py
+++ b/stingray/simulator/tests/test_simulator.py
@@ -39,8 +39,11 @@ class TestSimulator(object):
         """
         Simulate with a random seed value.
         """
-        self.simulator = simulator.Simulator(N=1024, seed=12)
+        self.simulator = simulator.Simulator(N=1024, random_state=12)
         assert len(self.simulator.simulate(2).counts), 1024
+
+    def test_simulate_with_random_state(self):
+        self.simulator = simulator.Simulator(N=1024, random_state=np.random.RandomState(12))
 
     def test_simulate_with_incorrect_arguments(self):
         with pytest.raises(ValueError):

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -96,10 +96,14 @@ class TestUtils(object):
         assert np.all(cont == np.array([[1, 3], [4, 7]])), \
             'Contiguous region wrong'
 
-    def get_random_state(self):
-        assert utils.get_random_state(None) == np.random.mtrand._rand
-        assert utils.get_random_state(1).randn(20) == np.random.RandomState(1).randn(20)
-        assert utils.get_random_state(np.random.RandomState(20)) == np.random.RandomState(20)
+    def test_get_random_state(self):
+        # Life, Universe and Everything
+        lue = 42
+        random_state = np.random.RandomState(lue)
+
+        assert utils.get_random_state(None) is np.random.mtrand._rand
+        assert np.all(utils.get_random_state(lue).randn(lue) == np.random.RandomState(lue).randn(lue))
+        assert np.all(utils.get_random_state(np.random.RandomState(lue)).randn(lue) == np.random.RandomState(lue).randn(lue))
 
         with pytest.raises(ValueError):
             utils.get_random_state('foobar')

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -95,3 +95,11 @@ class TestUtils(object):
         cont = utils.contiguous_regions(array)
         assert np.all(cont == np.array([[1, 3], [4, 7]])), \
             'Contiguous region wrong'
+
+    def get_random_state(self):
+        assert utils.get_random_state(None) == np.random.mtrand._rand
+        assert utils.get_random_state(1).randn(20) == np.random.RandomState(1).randn(20)
+        assert utils.get_random_state(np.random.RandomState(20)) == np.random.RandomState(20)
+
+        with pytest.raises(ValueError):
+            utils.get_random_state('foobar')

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -208,6 +208,8 @@ def get_random_state(random_state = None):
         if isinstance(random_state, (numbers.Integral, np.integer)):
             random_state = np.random.RandomState(random_state)
         elif not isinstance(random_state, np.random.RandomState):
-            raise ValueError("{value} can't be used to generate a numpy.random.RandomState")
+            raise ValueError("{value} can't be used to generate a numpy.random.RandomState".format(
+                value = random_state
+            ))
 
     return random_state

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -201,11 +201,14 @@ def contiguous_regions(condition):
     idx.shape = (-1, 2)
     return idx
 
+def is_int(obj):
+    return isinstance(obj, (numbers.Integral, np.integer))
+
 def get_random_state(random_state = None):
     if not random_state:
         random_state = np.random.mtrand._rand
     else:
-        if isinstance(random_state, (numbers.Integral, np.integer)):
+        if is_int(random_state):
             random_state = np.random.RandomState(random_state)
         elif not isinstance(random_state, np.random.RandomState):
             raise ValueError("{value} can't be used to generate a numpy.random.RandomState".format(

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -2,9 +2,11 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 import sys
 import collections
+import numbers
 
 import warnings
 import numpy as np
+
 # If numba is installed, import jit. Otherwise, define an empty decorator with
 # the same name.
 
@@ -198,3 +200,14 @@ def contiguous_regions(condition):
     # Reshape the result into two columns
     idx.shape = (-1, 2)
     return idx
+
+def get_random_state(random_state = None):
+    if not random_state:
+        random_state = np.random.mtrand._rand
+    else:
+        if isinstance(random_state, (numbers.Integral, np.integer)):
+            random_state = np.random.RandomState(random_state)
+        elif not isinstance(random_state, np.random.RandomState):
+            raise ValueError("{value} can't be used to generate a numpy.random.RandomState")
+
+    return random_state


### PR DESCRIPTION
`Simulator` can now consider a custom generated `np.random.RandomState` object or a seed value. This seems good to be in convention of `RandomState`s as parameters instead of seed value alone. (`scipy` and `scikit-learn` have a similar implementation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/175)
<!-- Reviewable:end -->
