### PR TITLE
Faster lightcurve __init__

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -17,7 +17,7 @@ __all__ = ["Lightcurve"]
 
 
 class Lightcurve(object):
-    def __init__(self, time, counts, input_counts=True, gti=None):
+    def __init__(self, time, counts, input_counts=True, gti=None, validate_dt = True):
         """
         Make a light curve object from an array of time stamps and an
         array of counts.
@@ -120,11 +120,19 @@ class Lightcurve(object):
 
         # Issue a warning if the input time iterable isn't regularly spaced,
         # i.e. the bin sizes aren't equal throughout.
-        #dt_array = np.diff(self.time)
-        #if not (np.allclose(dt_array, np.repeat(self.dt, dt_array.shape[0]))):
-        #    simon("Bin sizes in input time array aren't equal throughout! "
-        #          "This could cause problems with Fourier transforms. "
-        #          "Please make the input time evenly sampled.")
+        if(validate_dt):
+           # new check
+           for i in range (len(self.time)-1):
+                   if( self.dt != (self.time[i+1] - self.time[i]) ):
+                       simon("Bin sizes in input time array aren't equal throughout! "
+                             "This could cause problems with Fourier transforms. "
+                             "Please make the input time evenly sampled.")
+                       break
+           #dt_array = np.diff(self.time)
+           #if not (np.allclose(dt_array, np.repeat(self.dt, dt_array.shape[0]))):
+           #    simon("Bin sizes in input time array aren't equal throughout! "
+           #          "This could cause problems with Fourier transforms. "
+           #          "Please make the input time evenly sampled.")
 
         self.tseg = self.time[-1] - self.time[0] + self.dt
         self.tstart = self.time[0] - 0.5*self.dt

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -120,11 +120,11 @@ class Lightcurve(object):
 
         # Issue a warning if the input time iterable isn't regularly spaced,
         # i.e. the bin sizes aren't equal throughout.
-        dt_array = np.diff(self.time)
-        if not (np.allclose(dt_array, np.repeat(self.dt, dt_array.shape[0]))):
-            simon("Bin sizes in input time array aren't equal throughout! "
-                  "This could cause problems with Fourier transforms. "
-                  "Please make the input time evenly sampled.")
+        #dt_array = np.diff(self.time)
+        #if not (np.allclose(dt_array, np.repeat(self.dt, dt_array.shape[0]))):
+        #    simon("Bin sizes in input time array aren't equal throughout! "
+        #          "This could cause problems with Fourier transforms. "
+        #          "Please make the input time evenly sampled.")
 
         self.tseg = self.time[-1] - self.time[0] + self.dt
         self.tstart = self.time[0] - 0.5*self.dt


### PR DESCRIPTION
This is a part of a solution to the issue no #164.
The commented function is used to check and issue a warning if the given bins are not of the same sizes.
But it takes very very longtime (~160s when used with 10^8 bins). By removing it, the run time decreased from 220s to 60s.
So I'd like to discuss an alternative way we can achieve the check with less cost.

![with_allclose2](https://cloud.githubusercontent.com/assets/23017651/24582641/4624cadc-1734-11e7-967f-424b0667a279.png)

![without_allclose](https://cloud.githubusercontent.com/assets/23017651/24582640/4602d508-1734-11e7-806e-49eb838f4d80.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/180)
<!-- Reviewable:end -->
