### PR TITLE
Use fast_finish and some refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,9 @@ matrix:
           env: NUMPY_VERSION=1.6
         # Try older scipy versions
         - python: 2.7
-          SCIPY_VERSION=0.16.0
+          env: SCIPY_VERSION=0.16.0
         - python: 2.7
-          SCIPY_VERSION=0.14.0
+          env: SCIPY_VERSION=0.14.0
         - python: 2.6
           env: SETUP_CMD='test'
         - python: 3.3
@@ -99,9 +99,9 @@ matrix:
           env: NUMPY_VERSION=1.6
         # Try older scipy versions
         - python: 2.7
-          SCIPY_VERSION=0.16.0
+          env: SCIPY_VERSION=0.16.0
         - python: 2.7
-          SCIPY_VERSION=0.14.0
+          env: SCIPY_VERSION=0.14.0
         - python: 2.6
           env: SETUP_CMD='test'
         - python: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     - 3.6
@@ -42,6 +40,7 @@ env:
         - SETUP_CMD='test'
 
 matrix:
+    fast_finish: true
     include:
 
         #Try without importing h5py
@@ -63,18 +62,33 @@ matrix:
         - python: 3.5
           env: SETUP_CMD='test --coverage'
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
-        - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
-
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development
 
+        # Check for sphinx doc build warnings - we do this first because it
+        # may run for a long time
+        - python: 2.7
+          env: SETUP_CMD='build_sphinx -w'
         - python: 3.5
           env: ASTROPY_VERSION=development
-
+        # Try older numpy versions
+        - python: 2.7
+          env: NUMPY_VERSION=1.8
+        - python: 2.7
+          env: NUMPY_VERSION=1.7
+        - python: 2.7
+          env: NUMPY_VERSION=1.6
+        # Try older scipy versions
+        - python: 2.7
+          SCIPY_VERSION=0.16.0
+        - python: 2.7
+          SCIPY_VERSION=0.14.0
+        - python: 2.6
+          env: SETUP_CMD='test'
+        - python: 3.3
+          env: SETUP_CMD='test'
+        
     allow_failures:
         # Try older numpy versions
         - python: 2.7
@@ -85,15 +99,14 @@ matrix:
           env: NUMPY_VERSION=1.6
         # Try older scipy versions
         - python: 2.7
-          env: SCIPY_VERSION=0.16.0
+          SCIPY_VERSION=0.16.0
         - python: 2.7
-          env: SCIPY_VERSION=0.15.0
-        - python: 2.7
-          env: SCIPY_VERSION=0.14.0
-
+          SCIPY_VERSION=0.14.0
         - python: 2.6
+          env: SETUP_CMD='test'
         - python: 3.3
-
+          env: SETUP_CMD='test'
+ 
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
 


### PR DESCRIPTION
Return from Travis after all compulsory tests have returned, don't wait for tests allowed to fail. Rearrange so that tests allowed to fail are last

[EDIT: FYI: it's working. In one of the two Travis CI checks below, the tick appeared as soon as the "important" builds were done, even if the failure-allowed ones were still running. This saves some time.]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/190)
<!-- Reviewable:end -->