### PR TITLE
Resolves AveragedCrossSpectrum's coherence error

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -514,11 +514,11 @@ class AveragedCrossspectrum(Crossspectrum):
             lc1_seg = lightcurve.Lightcurve(time_1, counts_1)
             lc2_seg = lightcurve.Lightcurve(time_2, counts_2)
             cs_seg = Crossspectrum(lc1_seg, lc2_seg, norm=self.norm)
-            cs_all.append(cs_seg)
+            self.cs_all.append(cs_seg)
             nphots1_all.append(np.sum(lc1_seg.counts))
             nphots2_all.append(np.sum(lc2_seg.counts))
 
-        return cs_all, nphots1_all, nphots2_all
+        return self.cs_all, nphots1_all, nphots2_all
 
     def _make_crossspectrum(self, lc1, lc2):
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -499,7 +499,7 @@ class AveragedCrossspectrum(Crossspectrum):
 
         check_gtis(self.gti)
 
-        cs_all = []
+        self.cs_all = []
         nphots1_all = []
         nphots2_all = []
 


### PR DESCRIPTION
Fixes AverageCrossSpectrum's coherence error after rebin. Makes `cs_all` a class attribute by changing it to `self.cs_all` which fixes #189.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/191)
<!-- Reviewable:end -->
