### PR TITLE
Add MJDREF information

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -133,8 +133,6 @@ class Crossspectrum(object):
         self.gti = gti
         self.lc1 = lc1
         self.lc2 = lc2
-        if self.lc2.mjdref != self.lc1.mjdref:
-            raise ValueError("MJDref is different in the two light curves")
 
         self._make_crossspectrum(lc1, lc2)
 
@@ -146,6 +144,9 @@ class Crossspectrum(object):
 
         if not isinstance(lc2, Lightcurve):
             raise TypeError("lc2 must be a lightcurve.Lightcurve object")
+
+        if self.lc2.mjdref != self.lc1.mjdref:
+            raise ValueError("MJDref is different in the two light curves")
 
         # Then check that GTIs make sense
         if self.gti is None:

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -133,6 +133,9 @@ class Crossspectrum(object):
         self.gti = gti
         self.lc1 = lc1
         self.lc2 = lc2
+        if self.lc2.mjdref != self.lc1.mjdref:
+            raise ValueError("MJDref is different in the two light curves")
+
         self._make_crossspectrum(lc1, lc2)
 
     def _make_crossspectrum(self, lc1, lc2):

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -122,7 +122,8 @@ class EventList(object):
             tseg = self.gti[-1][1] - tstart
 
         return Lightcurve.make_lightcurve(self.time, dt, tstart=tstart,
-                                          gti=self.gti, tseg=tseg)
+                                          gti=self.gti, tseg=tseg,
+                                          mjdref=self.mjdref)
 
     @staticmethod
     def from_lc(lc):

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -21,7 +21,7 @@ valid_statistics = ["poisson", "gauss", None]
 
 class Lightcurve(object):
     def __init__(self, time, counts, err=None, input_counts=True,
-                 gti=None, err_dist='poisson'):
+                 gti=None, err_dist='poisson', mjdref=0):
         """
         Make a light curve object from an array of time stamps and an
         array of counts.
@@ -62,6 +62,9 @@ class Lightcurve(object):
             uncertainties and other statistical values apropriately.
             Default makes no assumptions and keep errors equal to zero.
 
+        mjdref: float
+            MJD reference (useful in most high-energy mission data)
+
 
         Attributes
         ----------
@@ -97,6 +100,10 @@ class Lightcurve(object):
 
         dt: float
             The time resolution of the light curve.
+
+        mjdref: float
+            MJD reference date (tstart / 86400 gives the date in MJD at the
+            start of the observation)
 
         tseg: float
             The total duration of the light curve.
@@ -155,6 +162,7 @@ class Lightcurve(object):
                       "Sorry for the inconvenience.")
                 err = np.zeros_like(counts)
 
+        self.mjdref = mjdref
         self.time = np.asarray(time)
         self.dt = time[1] - time[0]
 
@@ -204,7 +212,7 @@ class Lightcurve(object):
             The amount of time that the light curve will be shifted
         """
         new_lc = Lightcurve(self.time + time_shift, self.counts,
-                            gti=self.gti + time_shift)
+                            gti=self.gti + time_shift, mjdref=self.mjdref)
         new_lc.countrate = self.countrate
         new_lc.counts = self.counts
         new_lc.counts_err = self.counts_err
@@ -243,6 +251,9 @@ class Lightcurve(object):
             raise ValueError("Time arrays of both light curves must be "
                              "of same dimension and equal.")
 
+        if self.mjdref != other.mjdref:
+            raise ValueError("MJDref is different in the two light curves")
+
         new_counts = np.add(self.counts, other.counts)
 
         if self.err_dist.lower() != other.err_dist.lower():
@@ -261,7 +272,8 @@ class Lightcurve(object):
         common_gti = cross_two_gtis(self.gti, other.gti)
 
         lc_new = Lightcurve(self.time, new_counts,
-                            err=new_counts_err, gti=common_gti)
+                            err=new_counts_err, gti=common_gti,
+                            mjdref=self.mjdref)
 
         return lc_new
 
@@ -297,6 +309,10 @@ class Lightcurve(object):
             raise ValueError("Time arrays of both light curves must be "
                              "of same dimension and equal.")
 
+        if self.mjdref != other.mjdref:
+            raise ValueError("MJDref is different in the two light curves")
+
+
         new_counts = np.subtract(self.counts, other.counts)
 
         if self.err_dist.lower() != other.err_dist.lower():
@@ -315,7 +331,8 @@ class Lightcurve(object):
         common_gti = cross_two_gtis(self.gti, other.gti)
 
         lc_new = Lightcurve(self.time, new_counts,
-                            err=new_counts_err, gti=common_gti)
+                            err=new_counts_err, gti=common_gti,
+                            mjdref=self.mjdref)
 
         return lc_new
 
@@ -338,7 +355,8 @@ class Lightcurve(object):
         array([100, 100, 100])
         """
         lc_new = Lightcurve(self.time, -1*self.counts,
-                            err=self.counts_err, gti=self.gti)
+                            err=self.counts_err, gti=self.gti,
+                            mjdref=self.mjdref)
 
         return lc_new
 
@@ -388,7 +406,7 @@ class Lightcurve(object):
         elif isinstance(index, slice):
             new_counts = self.counts[index.start:index.stop:index.step]
             new_time = self.time[index.start:index.stop:index.step]
-            return Lightcurve(new_time, new_counts)
+            return Lightcurve(new_time, new_counts, mjdref=self.mjdref)
         else:
             raise IndexError("The index must be either an integer or a slice "
                              "object !")
@@ -413,7 +431,7 @@ class Lightcurve(object):
         return baseline
 
     @staticmethod
-    def make_lightcurve(toa, dt, tseg=None, tstart=None, gti=None):
+    def make_lightcurve(toa, dt, tseg=None, tstart=None, gti=None, mjdref=0):
 
         """
         Make a light curve out of photon arrival times.
@@ -482,7 +500,7 @@ class Lightcurve(object):
 
         counts = np.asarray(counts)
 
-        return Lightcurve(time, counts, gti=gti)
+        return Lightcurve(time, counts, gti=gti, mjdref=mjdref)
 
     def rebin(self, dt_new, method='sum'):
         """
@@ -516,7 +534,8 @@ class Lightcurve(object):
             utils.rebin_data(self.time, self.counts, dt_new,
                              yerr=self.counts_err, method=method)
 
-        lc_new = Lightcurve(bin_time, bin_counts, err=bin_err)
+        lc_new = Lightcurve(bin_time, bin_counts, err=bin_err,
+                            mjdref=self.mjdref)
         return lc_new
 
     def join(self, other):
@@ -556,6 +575,9 @@ class Lightcurve(object):
         >>> lc.counts
         array([ 300,  100,  400,  600, 1200,  800])
         """
+        if self.mjdref != other.mjdref:
+            raise ValueError("MJDref is different in the two light curves")
+
         if self.dt != other.dt:
             utils.simon("The two light curves have different bin widths.")
 
@@ -618,7 +640,8 @@ class Lightcurve(object):
 
         gti = join_gtis(self.gti, other.gti)
 
-        lc_new = Lightcurve(new_time, new_counts, err=new_counts_err, gti=gti)
+        lc_new = Lightcurve(new_time, new_counts, err=new_counts_err, gti=gti,
+                            mjdref=self.mjdref)
 
         return lc_new
 
@@ -894,7 +917,8 @@ class Lightcurve(object):
             stop = stop_bins[i]
             # Note: GTIs are consistent with default in this case!
             new_lc = Lightcurve(self.time[start:stop], self.counts[start:stop],
-                                err=self.counts_err[start:stop])
+                                err=self.counts_err[start:stop],
+                                mjdref=self.mjdref)
             list_of_lcs.append(new_lc)
 
         return list_of_lcs

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -202,6 +202,22 @@ class Lightcurve(object):
                                               self.tstart + self.tseg]]))
         check_gtis(self.gti)
 
+    def change_mjdref(self, new_mjdref):
+        """Change the MJDREF of the light curve.
+
+        Times will be now referred to this new MJDREF
+
+        Parameters
+        ----------
+        new_mjdref : float
+            New MJDREF
+        """
+        time_shift = (new_mjdref - self.mjdref) * 86400
+
+        new_lc = self.shift(time_shift)
+        new_lc.mjdref = new_mjdref
+        return new_lc
+
     def shift(self, time_shift):
         """
         Shift the light curve and the GTIs in time.

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -116,7 +116,8 @@ class VarEnergySpectrum(object):
                                              self.bin_time,
                                              tstart=tstart,
                                              tseg=tstop - tstart,
-                                             gti=gti)
+                                             gti=gti,
+                                             mjdref=self.events1.mjdref)
 
         if exclude:
             ref_intervals = self._decide_ref_intervals(channel_band,
@@ -125,7 +126,7 @@ class VarEnergySpectrum(object):
             ref_intervals = [self.ref_band]
 
         ref_lc = Lightcurve(base_lc.time, np.zeros_like(base_lc.counts),
-                            gti=base_lc.gti)
+                            gti=base_lc.gti, mjdref=base_lc.mjdref)
 
         for i in ref_intervals:
             good = (energies2 >= i[0]) & (energies2 < i[1])
@@ -133,7 +134,8 @@ class VarEnergySpectrum(object):
                                                 self.bin_time,
                                                 tstart=tstart,
                                                 tseg=tstop - tstart,
-                                                gti=gti)
+                                                gti=gti,
+                                                mjdref=self.events2.mjdref)
             ref_lc = ref_lc + new_lc
 
         return base_lc, ref_lc


### PR DESCRIPTION
In real-life applications, when loading observations from different instruments, the reference MJD will always be needed. It is also useful in order to save the light curves with a clear time reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/197)
<!-- Reviewable:end -->
