### PR TITLE
Correct Poissonian errors on light curves

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -154,7 +154,8 @@ class Lightcurve(object):
                 err_low, err_high = poisson_conf_interval(np.asarray(counts),
                     interval='frequentist-confidence', sigma=1)
                 # calculate approximately symetric uncertainties
-                err = (np.absolute(err_low)+np.absolute(err_high))/2.0
+                err = (np.absolute(err_low) + np.absolute(err_high) -
+                       2 * np.asarray(counts))/2.0
                 # other estimators can be implemented for other statistics
             else:
                 simon("Stingray only uses poisson err_dist at the moment, "

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -151,6 +151,8 @@ class Lightcurve(object):
                                     "Please select one of these: ",
                                     "{}".format(valid_statistics))
             if err_dist.lower() == 'poisson':
+                # Instead of the simple square root, we use confidence
+                # intervals (should be valid for low fluxes too)
                 err_low, err_high = poisson_conf_interval(np.asarray(counts),
                     interval='frequentist-confidence', sigma=1)
                 # calculate approximately symmetric uncertainties

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -153,7 +153,7 @@ class Lightcurve(object):
             if err_dist.lower() == 'poisson':
                 err_low, err_high = poisson_conf_interval(np.asarray(counts),
                     interval='frequentist-confidence', sigma=1)
-                # calculate approximately symetric uncertainties
+                # calculate approximately symmetric uncertainties
                 err = (np.absolute(err_low) + np.absolute(err_high) -
                        2 * np.asarray(counts))/2.0
                 # other estimators can be implemented for other statistics


### PR DESCRIPTION
The confidence intervals, to be transformed in a proxy of the uncertainty, need the "mean" to be subtracted.
As they were calculated, these errors were just a number very close to the mean.

E.g. 
```In [1]: from astropy.stats import poisson_conf_interval

In [2]: import numpy as np

In [3]: a = np.random.poisson(1000, 10)

In [4]: m, M = poisson_conf_interval(a, sigma=1)

In [5]: poisson_std = np.sqrt(a)

In [7]: m, M, poisson_std
Out[7]: 
(array([ 1003.81304612,  1017.59629651,  1003.81304612,   921.14550276,
         1009.71997522,  1025.47308807,   997.90638693,   937.87123517,
          957.55162961,  1030.39631923]),
 array([ 1068.18695388,  1082.40370349,  1068.18695388,   982.85449724,
         1074.28002478,  1090.52691193,  1062.09361307,  1000.12876483,
         1020.44837039,  1095.60368077]),
 array([ 32.18695388,  32.40370349,  32.18695388,  30.85449724,
         32.28002478,  32.52691193,  32.09361307,  31.12876483,
         31.44837039,  32.60368077]))

In [8]: a- m, M -a, poisson_std
Out[8]: 
(array([ 32.18695388,  32.40370349,  32.18695388,  30.85449724,
         32.28002478,  32.52691193,  32.09361307,  31.12876483,
         31.44837039,  32.60368077]),
 array([ 32.18695388,  32.40370349,  32.18695388,  30.85449724,
         32.28002478,  32.52691193,  32.09361307,  31.12876483,
         31.44837039,  32.60368077]),
 array([ 32.18695388,  32.40370349,  32.18695388,  30.85449724,
         32.28002478,  32.52691193,  32.09361307,  31.12876483,
         31.44837039,  32.60368077]))

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/stingray/201)
<!-- Reviewable:end -->
