### PR TITLE
Fix failing tests in Astropy development version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ addons:
             - texlive-latex-extra
             - dvipng
 
+branches:
+  only:
+    - "master"
+
 env:
     global:
         # The following versions are the 'default' for tests, unless

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - 2.7
-    - 3.5
     - 3.6
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
@@ -40,7 +39,7 @@ env:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
         # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
+        - SETUP_CMD='test --coverage'
 
 matrix:
     fast_finish: true
@@ -57,33 +56,15 @@ matrix:
         - python: 3.5
           env: PIP_DEPENDENCIES='emcee statsmodels' SETUP_CMD='test --coverage'
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
-          env: SETUP_CMD='test --coverage'
-
-        # Do a coverage test in Python 3.
-        - python: 3.5
-          env: SETUP_CMD='test --coverage'
-
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
-
         - python: 3.4
           env: NUMPY_VERSION=1.11
-         # Check for sphinx doc build warnings - we do this first because it
-         # may run for a long time
-        - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
-        - python: 3.5
-          env: ASTROPY_VERSION=development
+
+        ## Here allowed failures start
         # Try older numpy versions
         - python: 2.7
           env: NUMPY_VERSION=1.8
         - python: 2.7
           env: NUMPY_VERSION=1.7
-        - python: 2.7
-          env: NUMPY_VERSION=1.6
         # Try older scipy versions
         - python: 2.7
           env: SCIPY_VERSION=0.16.0
@@ -91,8 +72,14 @@ matrix:
           env: SCIPY_VERSION=0.14.0
         - python: 2.6
           env: SETUP_CMD='test'
-        - python: 3.3
-          env: SETUP_CMD='test'
+
+        - python: 2.7
+          env: SETUP_CMD='build_sphinx -w'
+        # Try Astropy development version
+        - python: 2.7
+          env: ASTROPY_VERSION=development
+        - python: 3.5
+          env: ASTROPY_VERSION=development
 
     allow_failures:
         # Try older numpy versions
@@ -100,16 +87,12 @@ matrix:
           env: NUMPY_VERSION=1.8
         - python: 2.7
           env: NUMPY_VERSION=1.7
-        - python: 2.7
-          env: NUMPY_VERSION=1.6
         # Try older scipy versions
         - python: 2.7
           env: SCIPY_VERSION=0.16.0
         - python: 2.7
           env: SCIPY_VERSION=0.14.0
         - python: 2.6
-          env: SETUP_CMD='test'
-        - python: 3.3
           env: SETUP_CMD='test'
 
         - python: 2.7

--- a/docs/simulator.rst
+++ b/docs/simulator.rst
@@ -1,8 +1,7 @@
 .. _stingray-simulator:
 
-***************************************
 Stingray Simulator (`stingray.simulator`)
-***************************************
+*****************************************
 
 Introduction
 ============
@@ -51,7 +50,7 @@ Simulate Method
 Stingray provides multiple ways to simulate a light curve. However, all these methods follow a common recipe::
 
   >>> sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125)
-  >>> simulator.simulate(...)
+  >>> lc = sim.simulate(2)
 
 Using Power-Law Spectrum
 ------------------------
@@ -162,13 +161,15 @@ The `simulator` class provides the functionality to simulate light curves indepe
   1
   >>> lc = sim.get_channel('3.5 - 4.5')
   >>> sim.delete_channel('3.5 - 4.5')
-  0
 
 Alternatively, assume that we have light curves in the simulated energy channels `3.5 - 4.5`, `4.5 - 5.5` and `5.5 - 6.5`. These channels can be retreived or deleted in single commands. 
 
-  >>> sim.countchannels()
-  3
-  >>> sim.get_channels(['3.5 - 4.5','4.5 - 5.5','5.5 - 6.5'])
+  >>> sim.count_channels()
+  0
+  >>> sim.simulate_channel('3.5 - 4.5', 2)
+  >>> sim.simulate_channel('4.5 - 5.5', 2)
+  >>> sim.simulate_channel('5.5 - 6.5', 2)
+  >>> chans = sim.get_channels(['3.5 - 4.5','4.5 - 5.5','5.5 - 6.5'])
   >>> sim.delete_channels(['3.5 - 4.5','4.5 - 5.5','5.5 - 6.5'])
 
 Reference/API

--- a/stingray/modeling/scripts.py
+++ b/stingray/modeling/scripts.py
@@ -99,11 +99,11 @@ def fit_powerspectrum(ps, model, starting_pars, max_post=False, priors=None,
     Now we have to guess starting parameters. For each Lorentzian, we have
     amplitude, centroid position and fwhm, and this pattern repeats for each
     Lorentzian in the fit. The white noise level is the last parameter.
-    >>> t0 = [80, 1.5, 2.5]
+    >>> t0 = [80, 1., 1.5, 2.5]
 
     Let's also make a model to test:
     >>> model_to_test = models.PowerLaw1D() + models.Const1D()
-    >>> model_to_test.x_0_0.fixed = True
+    >>> model_to_test.amplitude_1.fixed = True
 
     We're ready for doing the fit:
     >>> parest, res = fit_powerspectrum(ps, model_to_test, t0)

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -22,6 +22,7 @@ def _decode_energy_specification(energy_spec):
     True
     >>> a = _decode_energy_specification((1, 4, 2, 'log'))
     >>> np.all(a == [1, 2, 4])
+    True
     """
     if not isinstance(energy_spec, tuple):
         raise ValueError("Energy specification must be a tuple")


### PR DESCRIPTION
Closes #194 

Astropy now doesn't bundle Pytest, and the behavior of newer versions of Pytest is a little different (for example it does doctests). These two small fixes should settle it.

BTW, this forces us to be thorough also when we write documentation. All doctest-formatted tests will run :)