### PR TITLE
Lightcurve's sort method speed-up

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -764,17 +764,9 @@ class Lightcurve(object):
             The :class:`Lightcurve` object with truncated time and counts
             arrays.
         """
-        new_counts = sorted(self.counts, reverse=reverse)
-        new_time = []
-        new_counts_err = []
-        for count in np.unique(new_counts):
-            for index in np.where(self.counts == count)[0]:
-                new_time.append(self.time[index])
-                new_counts_err.append(self.counts_err[index])
 
-        if reverse:
-            new_time.reverse()
-            new_counts_err.reverse()
+        new_counts, new_time, new_counts_err = zip(*sorted(zip(self.counts, self.time, self.counts_err) , reverse=reverse))
+
 
         self.time = np.asarray(new_time)
         self.counts = np.asarray(new_counts)


### PR DESCRIPTION
I've changed the implementation and reduced the time complexity from O(N^2) to an O( N Log(N) ). The problem in the old implementation is that it sorts the lc.time and then searches for the consequent count for each new time. The new implementation uses the zip function that zips the arrays time, counts, count_err. What's good about the zip function is that after we sort the time array, it moves the zipped arrays accordingly, and that is exactly what we are trying to do. 
