### PR TITLE
LagEnergySpectrum and RmsEnergySpectrum bug fixing

### DIFF
--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -163,18 +163,17 @@ class TestRMSEnergySpectrum(object):
             np.abs(self.rms.spectrum - self.rms.spectrum[0]) < \
                 self.rms.spectrum_error)
 
-    def test_rms_empty_evlist_warns(self):
-        import copy
-        ev = EventList(time=[], energy=[], gti=test_ev1.gti)
+    def test_rms_invalid_evlist_warns(self):
+        ev = EventList(time=[], energy=[], gti=self.rms.events1.gti)
         with pytest.warns(UserWarning) as record:
             rms = RmsEnergySpectrum(ev, [0., 100],
                                     (0.3, 12, 5, "lin"),
                                     bin_time=0.01,
                                     segment_size=100,
-                                    events2=test_ev2)
-        assert "Mean count rate is <= 0" in record[0].message.args[0]
-        assert np.allclose(rms_spec.spectrum, 0)
-        assert np.allclose(rms_spec.spectrum_error, 0)
+                                    events2=self.rms.events2)
+
+        assert np.allclose(rms.spectrum, 0)
+        assert np.allclose(rms.spectrum_error, 0)
 
 
 class TestLagEnergySpectrum(object):

--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -163,6 +163,19 @@ class TestRMSEnergySpectrum(object):
             np.abs(self.rms.spectrum - self.rms.spectrum[0]) < \
                 self.rms.spectrum_error)
 
+    def test_rms_empty_evlist_warns(self):
+        import copy
+        ev = EventList(time=[], energy=[], gti=test_ev1.gti)
+        with pytest.warns(UserWarning) as record:
+            rms = RmsEnergySpectrum(ev, [0., 100],
+                                    (0.3, 12, 5, "lin"),
+                                    bin_time=0.01,
+                                    segment_size=100,
+                                    events2=test_ev2)
+        assert "Mean count rate is <= 0" in record[0].message.args[0]
+        assert np.allclose(rms_spec.spectrum, 0)
+        assert np.allclose(rms_spec.spectrum_error, 0)
+
 
 class TestLagEnergySpectrum(object):
     @classmethod

--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -204,3 +204,15 @@ class TestLagEnergySpectrum(object):
 
         assert np.all(np.abs(self.lag.spectrum - 0.2) < \
                       3 * self.lag.spectrum_error)
+
+    def test_lag_invalid_evlist_warns(self):
+        ev = EventList(time=[], energy=[], gti=self.lag.events1.gti)
+        with pytest.warns(UserWarning) as record:
+            lag = LagEnergySpectrum(ev, [0., 0.5],
+                                    (0.3, 9, 4, "lin"), [9, 12],
+                                    bin_time=0.1,
+                                    segment_size=30,
+                                    events2=self.lag.events2)
+
+        assert np.allclose(lag.spectrum, 0)
+        assert np.allclose(lag.spectrum_error, 0)

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -190,6 +190,10 @@ class RmsEnergySpectrum(VarEnergySpectrum):
                 xspect = AveragedCrossspectrum(base_lc, ref_lc,
                                                segment_size=self.segment_size,
                                                norm='frac')
+            except AssertionError as e:
+                # Avoid "Mean count rate is <= 0. Something went wrong" assertion.
+                simon("AssertionError: " + str(e))
+            else:
                 good = (xspect.freq >= self.freq_interval[0]) & \
                        (xspect.freq < self.freq_interval[1])
                 rms_spec[i] = np.sqrt(np.sum(xspect.power[good]*xspect.df))
@@ -199,10 +203,6 @@ class RmsEnergySpectrum(VarEnergySpectrum):
                 # But the rms is the squared root. So,
                 # Error propagation
                 rms_spec_err[i] = 1 / (2 * rms_spec[i]) * root_sq_err_sum
-
-            except AssertionError as e:
-                # Avoid "Mean count rate is <= 0. Something went wrong" assertion.
-                simon("AssertionError: " + str(e))
 
         return rms_spec, rms_spec_err
 

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -218,6 +218,10 @@ class LagEnergySpectrum(VarEnergySpectrum):
             try:
                 xspect = AveragedCrossspectrum(base_lc, ref_lc,
                                                segment_size=self.segment_size)
+            except AssertionError as e:
+                # Avoid assertions in AveragedCrossspectrum.
+                simon("AssertionError: " + str(e))
+            else:
                 good = (xspect.freq >= self.freq_interval[0]) & \
                        (xspect.freq < self.freq_interval[1])
                 lag, lag_err = xspect.time_lag()
@@ -226,17 +230,15 @@ class LagEnergySpectrum(VarEnergySpectrum):
                 lag_spec[i] = np.mean(good_lag)
                 coh_check = coh > 1.2 / (1 + 0.2 * xspect.m)
                 if not np.all(coh_check[good]):
-                    simon("Coherence is not ideal over the specified energy range."
-                          " Lag values and uncertainties might be underestimated. "
-                          "See Epitropakis and Papadakis, A\&A 591, 1113, 2016")
+                    simon("Coherence is not ideal over the specified energy "
+                          "range. Lag values and uncertainties might be "
+                          "underestimated. See Epitropakis and Papadakis, "
+                          "A\&A 591, 1113, 2016")
 
                 # Root squared sum of errors of the spectrum
                 # Verified!
-                lag_spec_err[i] = np.sqrt(np.sum(good_lag_err**2) / len(good_lag))
-
-            except AssertionError as e:
-                # Avoid "Mean count rate is <= 0. Something went wrong" assertion.
-                simon("AssertionError: " + str(e))
+                lag_spec_err[i] = \
+                    np.sqrt(np.sum(good_lag_err**2) / len(good_lag))
 
         return lag_spec, lag_spec_err
 

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -74,7 +74,7 @@ class VarEnergySpectrum(object):
         events2 : stingray.events.EventList object
             event list for the second channel, if not the same. Useful if the
             reference band has to be taken from another detector.
-            
+
         Attributes
         ----------
         events1 : array-like
@@ -89,7 +89,7 @@ class VarEnergySpectrum(object):
             the spectral values, corresponding to each energy interval
         spectrum_error : array-like
             the errorbars corresponding to spectrum
-        
+
         """
         self.events1 = events
         self.events2 = assign_value_if_none(events2, events)
@@ -186,18 +186,23 @@ class RmsEnergySpectrum(VarEnergySpectrum):
         for i, eint in enumerate(self.energy_intervals):
             base_lc, ref_lc = self._construct_lightcurves(eint,
                                                           exclude=False)
-            xspect = AveragedCrossspectrum(base_lc, ref_lc,
-                                           segment_size=self.segment_size,
-                                           norm='frac')
-            good = (xspect.freq >= self.freq_interval[0]) & \
-                   (xspect.freq < self.freq_interval[1])
-            rms_spec[i] = np.sqrt(np.sum(xspect.power[good]*xspect.df))
+            try:
+                xspect = AveragedCrossspectrum(base_lc, ref_lc,
+                                               segment_size=self.segment_size,
+                                               norm='frac')
+                good = (xspect.freq >= self.freq_interval[0]) & \
+                       (xspect.freq < self.freq_interval[1])
+                rms_spec[i] = np.sqrt(np.sum(xspect.power[good]*xspect.df))
 
-            # Root squared sum of errors of the spectrum
-            root_sq_err_sum = np.sqrt(np.sum(xspect.power[good]**2))*xspect.df
-            # But the rms is the squared root. So,
-            # Error propagation
-            rms_spec_err[i] = 1 / (2 * rms_spec[i]) * root_sq_err_sum
+                # Root squared sum of errors of the spectrum
+                root_sq_err_sum = np.sqrt(np.sum(xspect.power[good]**2))*xspect.df
+                # But the rms is the squared root. So,
+                # Error propagation
+                rms_spec_err[i] = 1 / (2 * rms_spec[i]) * root_sq_err_sum
+
+            except AssertionError as e:
+                # Avoid "Mean count rate is <= 0. Something went wrong" assertion.
+                simon("AssertionError: " + str(e))
 
         return rms_spec, rms_spec_err
 
@@ -210,23 +215,28 @@ class LagEnergySpectrum(VarEnergySpectrum):
         lag_spec_err = np.zeros_like(lag_spec)
         for i, eint in enumerate(self.energy_intervals):
             base_lc, ref_lc = self._construct_lightcurves(eint)
-            xspect = AveragedCrossspectrum(base_lc, ref_lc,
-                                           segment_size=self.segment_size)
-            good = (xspect.freq >= self.freq_interval[0]) & \
-                   (xspect.freq < self.freq_interval[1])
-            lag, lag_err = xspect.time_lag()
-            good_lag, good_lag_err = lag[good], lag_err[good]
-            coh, coh_err = xspect.coherence()
-            lag_spec[i] = np.mean(good_lag)
-            coh_check = coh > 1.2 / (1 + 0.2 * xspect.m)
-            if not np.all(coh_check[good]):
-                simon("Coherence is not ideal over the specified energy range."
-                      " Lag values and uncertainties might be underestimated. "
-                      "See Epitropakis and Papadakis, A\&A 591, 1113, 2016")
+            try:
+                xspect = AveragedCrossspectrum(base_lc, ref_lc,
+                                               segment_size=self.segment_size)
+                good = (xspect.freq >= self.freq_interval[0]) & \
+                       (xspect.freq < self.freq_interval[1])
+                lag, lag_err = xspect.time_lag()
+                good_lag, good_lag_err = lag[good], lag_err[good]
+                coh, coh_err = xspect.coherence()
+                lag_spec[i] = np.mean(good_lag)
+                coh_check = coh > 1.2 / (1 + 0.2 * xspect.m)
+                if not np.all(coh_check[good]):
+                    simon("Coherence is not ideal over the specified energy range."
+                          " Lag values and uncertainties might be underestimated. "
+                          "See Epitropakis and Papadakis, A\&A 591, 1113, 2016")
 
-            # Root squared sum of errors of the spectrum
-            # Verified!
-            lag_spec_err[i] = np.sqrt(np.sum(good_lag_err**2) / len(good_lag))
+                # Root squared sum of errors of the spectrum
+                # Verified!
+                lag_spec_err[i] = np.sqrt(np.sum(good_lag_err**2) / len(good_lag))
+
+            except AssertionError as e:
+                # Avoid "Mean count rate is <= 0. Something went wrong" assertion.
+                simon("AssertionError: " + str(e))
 
         return lag_spec, lag_spec_err
 


### PR DESCRIPTION
Avoid loop crash if some CrossSpectra is wrong in LagEnergySpectrum or RmsEnergySpectrum, just added try catch for avoid "Mean count rate is <= 0. Something went wrong" assertion if some of the lightcurves of the interval are empty after being processed inside AveragedCrossspectrum.