### PR TITLE
Bugfix + Add method to analyze regular chunks of a lightcurve with generic functions

### DIFF
--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -501,7 +501,8 @@ def join_gtis(gti0, gti1):
     return np.sort(final_gti, axis=0)
 
 
-def time_intervals_from_gtis(gtis, chunk_length, epsilon=1e-5):
+def time_intervals_from_gtis(gtis, chunk_length, fraction_step=1,
+                             epsilon=1e-5):
     """Returns equal time intervals compatible with GTIs.
 
     Used to start each FFT/PDS/cospectrum from the start of a GTI,
@@ -513,7 +514,10 @@ def time_intervals_from_gtis(gtis, chunk_length, epsilon=1e-5):
         [[gti0_0, gti0_1], [gti1_0, gti1_1], ...]
     chunk_length : float
         Length of the chunks
-
+    fraction_step : float
+        If the step is not a full chunk_length but less (e.g. a moving window),
+        this indicates the ratio between step step and `chunk_length` (e.g.
+        0.5 means that the window shifts of half chunk_length)
     Returns
     -------
     spectrum_start_times : array-like
@@ -529,7 +533,7 @@ def time_intervals_from_gtis(gtis, chunk_length, epsilon=1e-5):
             continue
 
         newtimes = np.arange(g[0], g[1] - chunk_length + epsilon,
-                             np.longdouble(chunk_length),
+                             np.longdouble(chunk_length) * fraction_step,
                              dtype=np.longdouble)
         spectrum_start_times = \
             np.append(spectrum_start_times,
@@ -540,7 +544,8 @@ def time_intervals_from_gtis(gtis, chunk_length, epsilon=1e-5):
     return spectrum_start_times, spectrum_start_times + chunk_length
 
 
-def bin_intervals_from_gtis(gtis, chunk_length, time, dt=None, epsilon=0.001):
+def bin_intervals_from_gtis(gtis, chunk_length, time, dt=None, fraction_step=1,
+                            epsilon=0.001):
     """Similar to intervals_from_gtis, but given an input time array.
 
     Used to start each FFT/PDS/cospectrum from the start of a GTI,
@@ -564,6 +569,10 @@ def bin_intervals_from_gtis(gtis, chunk_length, time, dt=None, epsilon=0.001):
         Time resolution of the light curve.
     epsilon : float, default 0.001
         The tolerance, in fraction of dt, for the comparisons at the borders
+    fraction_step : float
+        If the step is not a full chunk_length but less (e.g. a moving window),
+        this indicates the ratio between step step and `chunk_length` (e.g.
+        0.5 means that the window shifts of half chunk_length)
 
     Examples
     --------
@@ -621,8 +630,8 @@ def bin_intervals_from_gtis(gtis, chunk_length, time, dt=None, epsilon=0.001):
         if time[stopbin - 1] > g[1] - dt/2 + epsilon*dt:
             stopbin -= 1
 
-        newbins = np.arange(startbin, stopbin - nbin + 1, nbin,
-                            dtype=np.long)
+        newbins = np.arange(startbin, stopbin - nbin + 1,
+                            int(nbin * fraction_step), dtype=np.long)
         spectrum_start_bins = \
             np.append(spectrum_start_bins,
                       newbins)

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -501,7 +501,7 @@ def join_gtis(gti0, gti1):
     return np.sort(final_gti, axis=0)
 
 
-def time_intervals_from_gtis(gtis, chunk_length):
+def time_intervals_from_gtis(gtis, chunk_length, epsilon=1e-5):
     """Returns equal time intervals compatible with GTIs.
 
     Used to start each FFT/PDS/cospectrum from the start of a GTI,
@@ -525,10 +525,10 @@ def time_intervals_from_gtis(gtis, chunk_length):
     """
     spectrum_start_times = np.array([], dtype=np.longdouble)
     for g in gtis:
-        if g[1] - g[0] < chunk_length:
+        if g[1] - g[0] + epsilon < chunk_length:
             continue
 
-        newtimes = np.arange(g[0], g[1] - chunk_length,
+        newtimes = np.arange(g[0], g[1] - chunk_length + epsilon,
                              np.longdouble(chunk_length),
                              dtype=np.longdouble)
         spectrum_start_times = \

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1032,6 +1032,38 @@ class Lightcurve(object):
 
         return list_of_lcs
 
-    def apply_gtis(self):
-        good = create_gti_mask(self.time, lc.gti)
+    def _apply_gtis(self):
+        """Apply GTIs to a light curve after modification.
 
+        Examples
+        --------
+        >>> import numpy as np
+        >>> time = np.arange(150)
+        >>> count = np.zeros_like(time) + 3
+        >>> lc = Lightcurve(time, count, gti=[[-0.5, 150.5]])
+        >>> lc.gti = [[-0.5, 2.5], [12.5, 14.5]]
+        >>> lc._apply_gtis()
+        >>> lc.n
+        5
+        >>> np.all(lc.time == np.array([0, 1, 2, 13, 14]))
+        True
+        >>> lc.gti = [[-0.5, 10.5]]
+        >>> lc._apply_gtis()
+        >>> lc.n
+        3
+        >>> np.all(lc.time == np.array([0, 1, 2]))
+        True
+        """
+        check_gtis(self.gti)
+
+        good = create_gti_mask(self.time, self.gti)
+
+        self.time = self.time[good]
+        self.counts = self.counts[good]
+        self.counts_err = self.counts_err[good]
+        self.countrate = self.countrate[good]
+        self.countrate_err = self.countrate_err[good]
+
+        self.meanrate = np.mean(self.countrate)
+        self.meancounts = np.mean(self.counts)
+        self.n = self.counts.shape[0]

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1033,27 +1033,7 @@ class Lightcurve(object):
         return list_of_lcs
 
     def _apply_gtis(self):
-        """Apply GTIs to a light curve after modification.
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> time = np.arange(150)
-        >>> count = np.zeros_like(time) + 3
-        >>> lc = Lightcurve(time, count, gti=[[-0.5, 150.5]])
-        >>> lc.gti = [[-0.5, 2.5], [12.5, 14.5]]
-        >>> lc._apply_gtis()
-        >>> lc.n
-        5
-        >>> np.all(lc.time == np.array([0, 1, 2, 13, 14]))
-        True
-        >>> lc.gti = [[-0.5, 10.5]]
-        >>> lc._apply_gtis()
-        >>> lc.n
-        3
-        >>> np.all(lc.time == np.array([0, 1, 2]))
-        True
-        """
+        """Apply GTIs to a light curve after modification."""
         check_gtis(self.gti)
 
         good = create_gti_mask(self.time, self.gti)

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -781,7 +781,7 @@ class Lightcurve(object):
         self.counts = np.asarray(new_counts)
         self.counts_err = np.asarray(new_counts_err)
 
-    def analyze_lc_chunks(self, chunk_length, func, **kwargs):
+    def analyze_lc_chunks(self, chunk_length, func, fraction_step=1, **kwargs):
         """Analyze chunks of the light curve with any function.
 
         Parameters
@@ -796,6 +796,10 @@ class Lightcurve(object):
 
         Other parameters
         ----------------
+        fraction_step : float
+            If the step is not a full chunk_length but less (e.g. a moving window),
+            this indicates the ratio between step step and `chunk_length` (e.g.
+            0.5 means that the window shifts of half chunk_length)
         kwargs : keyword arguments
             These additional keyword arguments, if present, they will be passed
             to `func`
@@ -810,7 +814,9 @@ class Lightcurve(object):
             The result of `func` for each chunk of the light curve
         """
         start, stop = bin_intervals_from_gtis(self.gti, chunk_length,
-                                              self.time, dt=self.dt)
+                                              self.time,
+                                              fraction_step=fraction_step,
+                                              dt=self.dt)
         start_times = self.time[start] - self.dt * 0.5
 
         # Remember that stop is one element above the last element, because

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -876,6 +876,21 @@ class Lightcurve(object):
             Higher time boundaries of all chunks.
         result : array of N elements
             The result of `func` for each chunk of the light curve
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> time = np.arange(0, 10, 0.1)
+        >>> counts = np.zeros_like(time) + 10
+        >>> lc = Lightcurve(time, counts)
+        >>> # Define a function that calculates the mean
+        >>> mean_func = lambda x: np.mean(x)
+        >>> # Calculate the mean in chunks of 5 seconds
+        >>> start, stop, res = lc.analyze_lc_chunks(5, mean_func)
+        >>> len(res) == 2
+        True
+        >>> np.all(res == 10)
+        True
         """
         start, stop = bin_intervals_from_gtis(self.gti, chunk_length,
                                               self.time,

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -4,6 +4,7 @@ Definition of :class:`Lightcurve`.
 :class:`Lightcurve` is used to create light curves out of photon counting data
 or to save existing light curves in a class that's easy to use.
 """
+from __future__ import division, print_function
 import logging
 import numpy as np
 import stingray.io as io

--- a/stingray/tests/test_gti.py
+++ b/stingray/tests/test_gti.py
@@ -128,6 +128,14 @@ class TestGTI(object):
         assert np.all(start_times == np.array([0, 128, 256, 1022]))
         assert np.all(stop_times == np.array([0, 128, 256, 1022]) + 128)
 
+    def test_time_intervals_from_gtis_frac(self):
+        """Test the division of start and end times to calculate spectra."""
+        start_times, stop_times = \
+            time_intervals_from_gtis([[0, 400], [1022, 1200],
+                                      [1210, 1220]], 128, fraction_step=0.5)
+        assert np.all(start_times == np.array([0, 64, 128, 192, 256, 1022]))
+        assert np.all(stop_times == start_times + 128)
+
     def test_bin_intervals_from_gtis(self):
         """Test the division of start and end times to calculate spectra."""
         times = np.arange(0.5, 13.5)
@@ -136,6 +144,16 @@ class TestGTI(object):
 
         assert np.all(start_bins == np.array([0, 2, 6]))
         assert np.all(stop_bins == np.array([2, 4, 8]))
+
+    def test_bin_intervals_from_gtis_frac(self):
+        """Test the division of start and end times to calculate spectra."""
+        times = np.arange(0.5, 13.5)
+        start_bins, stop_bins = \
+            bin_intervals_from_gtis([[0, 5], [6, 8]], 2, times,
+                                    fraction_step=0.5)
+
+        assert np.all(start_bins == np.array([0, 1, 2, 3, 6]))
+        assert np.all(stop_bins == np.array([2, 3, 4, 5, 8]))
 
     def test_gti_border_bins(self):
         times = np.arange(0.5, 2.5)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -98,7 +98,7 @@ class TestLightcurve(object):
         assert start[0] == 0.5
         assert np.all(start + lc.dt / 2 == res)
 
-    def test_analyze_lc_chunks_fvar(self):
+    def test_analyze_lc_chunks_fvar_fracstep(self):
         dt = 0.1
         tstart = 0
         tstop = 100
@@ -114,7 +114,7 @@ class TestLightcurve(object):
             from stingray.utils import excess_variance
             return excess_variance(lc, normalization='fvar')
 
-        start, stop, res = lc.analyze_lc_chunks(20, excvar)
+        start, stop, res = lc.analyze_lc_chunks(20, excvar, fraction_step=0.5)
         # excess_variance returns fvar and fvar_err
         res, res_err = res
 

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -89,6 +89,40 @@ class TestLightcurve(object):
         lc = Lightcurve(self.times, self.counts)
         assert lc.n == 4
 
+    def test_analyze_lc_chunks(self):
+        lc = Lightcurve(self.times, self.counts, gti=self.gti)
+
+        def func(lc):
+            return lc.time[0]
+        start, stop, res = lc.analyze_lc_chunks(2, func)
+        assert start[0] == 0.5
+        assert np.all(start + lc.dt / 2 == res)
+
+    def test_analyze_lc_chunks_fvar(self):
+        dt = 0.1
+        tstart = 0
+        tstop = 100
+        times = np.arange(tstart, tstop, dt)
+        gti = np.array([[tstart - dt/2, tstop - dt/2]])
+        # Simulate something *clearly* non-constant
+        counts = np.random.poisson(
+            10000 + 2000 * np.sin(2 * np.pi * times))
+
+        lc = Lightcurve(times, counts, gti=gti)
+
+        def excvar(lc):
+            from stingray.utils import excess_variance
+            return excess_variance(lc, normalization='fvar')
+
+        start, stop, res = lc.analyze_lc_chunks(20, excvar)
+        # excess_variance returns fvar and fvar_err
+        res, res_err = res
+
+        assert np.allclose(start[0], gti[0, 0])
+        assert np.all(res > 0)
+        # This must be a clear measurement of fvar
+        assert np.all(res > res_err)
+
     def test_bin_edges(self):
         bin_lo = [0.5,  1.5,  2.5,  3.5]
         bin_hi = [1.5,  2.5,  3.5,  4.5]

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -652,4 +652,16 @@ class TestLightcurveRebin(object):
     def test_change_mjdref(self):
         lc_new = self.lc.change_mjdref(57000)
         assert lc_new.mjdref == 57000
-    
+
+    def test_apply_gtis(self):
+        time = np.arange(150)
+        count = np.zeros_like(time) + 3
+        lc = Lightcurve(time, count, gti=[[-0.5, 150.5]])
+        lc.gti = [[-0.5, 2.5], [12.5, 14.5]]
+        lc._apply_gtis()
+        assert lc.n == 5
+        assert np.all(lc.time == np.array([0, 1, 2, 13, 14]))
+        lc.gti = [[-0.5, 10.5]]
+        lc._apply_gtis()
+        assert lc.n == 3
+        assert np.all(lc.time == np.array([0, 1, 2]))

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -304,9 +304,9 @@ def excess_variance(lc, normalization='fvar'):
     lc_actual_var = np.var(lc.counts)
     var_xs = lc_actual_var - lc_mean_var
     mean_lc = np.mean(lc.counts)
-    mean_ctvar = np.mean(mean_lc ** 2)
+    mean_ctvar = mean_lc ** 2
 
-    fvar = var_xs / mean_ctvar
+    fvar = np.sqrt(var_xs / mean_ctvar)
 
     N = len(lc.counts)
     var_xs_err_A = np.sqrt(2 / N) * lc_mean_var / mean_lc ** 2


### PR DESCRIPTION
This comes from the need of calculating excess variance in regular chunks of light curves (AGN stuff).

I made it a little more generic, so that people can pass their own statistics to be calculated on the light curve chunks. Excess variance is the example in `test_analyze_lc_chunks_fvar`.

Plus I fixed Fvar, that was missing a square root (screaming face)

EDIT: Plus I allowed to use rolling windows (steps of fractions of `chunk_length` in starting times), which involved also modifying slightly `bin_intervals_from_gtis`.

EDIT 2: Notebook here: https://github.com/StingraySoftware/notebooks/pull/16