### PR TITLE
rebin_log returns a *spectrum instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,14 @@ matrix:
         - python: 3.5
           env: PIP_DEPENDENCIES='emcee statsmodels pytest-catchlog' SETUP_CMD='test --coverage'
 
+        # Try without using emcee
+        - python: 3.5
+          env: PIP_DEPENDENCIES='statsmodels pytest-catchlog' SETUP_CMD='test --coverage'
+
+        # Try without using statsmodels
+        - python: 3.5
+          env: PIP_DEPENDENCIES='emcee pytest-catchlog' SETUP_CMD='test --coverage'
+
         - python: 3.4
           env: NUMPY_VERSION=1.11
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
         # to repeat them for all configurations.
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='emcee statsmodels corner'
+        - PIP_DEPENDENCIES='emcee statsmodels corner pytest-catchlog'
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
@@ -59,7 +59,7 @@ matrix:
 
         # Try without using corner
         - python: 3.5
-          env: PIP_DEPENDENCIES='emcee statsmodels' SETUP_CMD='test --coverage'
+          env: PIP_DEPENDENCIES='emcee statsmodels pytest-catchlog' SETUP_CMD='test --coverage'
 
         - python: 3.4
           env: NUMPY_VERSION=1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ matrix:
     fast_finish: true
     include:
         - python: 3.5
-          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner' SETUP_CMD='test --remote-data --coverage'
+          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner  pytest-catchlog' SETUP_CMD='test --remote-data --coverage'
 
         - python: 2.7
-          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner' SETUP_CMD='test --remote-data'
+          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner  pytest-catchlog' SETUP_CMD='test --remote-data'
 
         #Try without importing h5py but importing numba
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ matrix:
     fast_finish: true
     include:
         - python: 3.5
-          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner  pytest-catchlog' SETUP_CMD='test --remote-data --coverage'
+          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner pytest-catchlog' SETUP_CMD='test --remote-data --coverage'
 
         - python: 2.7
-          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner  pytest-catchlog' SETUP_CMD='test --remote-data'
+          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner pytest-catchlog' SETUP_CMD='test --remote-data'
 
         #Try without importing h5py but importing numba
         - python: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
         CONDA_DEPENDENCIES: "scipy numpy nose h5py astropy matplotlib"
-        PIP_DEPENDENCIES: "emcee statsmodels"
+        PIP_DEPENDENCIES: "emcee statsmodels pytest-catchlog"
 
     matrix:
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -10,6 +10,7 @@ from stingray.lightcurve import Lightcurve
 from stingray.utils import rebin_data, simon
 from stingray.exceptions import StingrayError
 from stingray.gti import cross_two_gtis, bin_intervals_from_gtis, check_gtis
+import copy
 
 __all__ = ["Crossspectrum", "AveragedCrossspectrum", "coherence"]
 
@@ -413,7 +414,13 @@ class Crossspectrum(object):
         # last right bin edge
         binfreq = binfreq[:-1] + df/2
 
-        return binfreq, binpower, binpower_err, nsamples
+        new_spec = copy.copy(self)
+        new_spec.freq = binfreq
+        new_spec.power = binpower
+        new_spec.power_err = binpower_err
+        new_spec.m = nsamples
+
+        return new_spec
 
     def coherence(self):
         """

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -255,7 +255,7 @@ class Crossspectrum(object):
 
         return freqs[freqs > 0], cross
 
-    def rebin(self, df, method="mean"):
+    def rebin(self, df=None, f=None, method="mean"):
         """
         Rebin the cross spectrum to a new frequency resolution df.
 
@@ -264,11 +264,22 @@ class Crossspectrum(object):
         df: float
             The new frequency resolution
 
+        Other Parameters
+        ----------------
+        f: float
+            the rebin factor. If specified, it substitutes df with f*self.df
+
         Returns
         -------
         bin_cs = Crossspectrum object
             The newly binned cross spectrum
         """
+
+        if f is None and df is None:
+            raise ValueError('You need to specify at least one between f and '
+                             'df')
+        elif f is not None:
+            df = f * self.df
 
         # rebin cross spectrum to new resolution
         binfreq, bincs, binerr, step_size = \

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -504,7 +504,7 @@ class Lightcurve(object):
 
         return Lightcurve(time, counts, gti=gti, mjdref=mjdref, dt=dt)
 
-    def rebin(self, dt_new, method='sum'):
+    def rebin(self, dt_new=None, f=None, method='sum'):
         """
         Rebin the light curve to a new time resolution. While the new
         resolution need not be an integer multiple of the previous time
@@ -521,12 +521,23 @@ class Lightcurve(object):
             This keyword argument sets whether the counts in the new bins
             should be summed or averaged.
 
+        Other Parameters
+        ----------------
+        f: float
+            the rebin factor. If specified, it substitutes dt_new with
+            f*self.dt
 
         Returns
         -------
         lc_new: :class:`Lightcurve` object
             The :class:`Lightcurve` object with the new, binned light curve.
         """
+
+        if f is None and dt_new is None:
+            raise ValueError('You need to specify at least one between f and '
+                             'dt_new')
+        elif f is not None:
+            dt_new = f * self.dt
 
         if dt_new < self.dt:
             raise ValueError("New time resolution must be larger than "

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -1051,7 +1051,8 @@ class PSDParEst(ParameterEstimation):
 
         return pval
 
-    def simulate_highest_outlier(self, s_all, lpost, t0, max_post=True):
+    def simulate_highest_outlier(self, s_all, lpost, t0, max_post=True,
+                                 seed=None):
 
         # the number of simulations
         nsim = s_all.shape[0]
@@ -1059,11 +1060,13 @@ class PSDParEst(ParameterEstimation):
         # empty array for the simulation results
         max_y_all = np.zeros(nsim)
 
+        rng = np.random.RandomState(seed)
+
         # now I can loop over all simulated parameter sets to generate a PSD
         for i, s in enumerate(s_all):
 
             # generate fake PSD
-            sim_ps = self._generate_data(lpost, s)
+            sim_ps = self._generate_data(lpost, s, rng=rng)
 
             # make LogLikelihood objects for both:
             if not max_post:

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     use_corner = False
 
+import logging
+
 import numpy as np
 import scipy
 import scipy.optimize
@@ -39,9 +41,11 @@ try:
 except ImportError:
     comp_hessian = False
 
-from stingray.modeling.posterior import Posterior, LogLikelihood
 from astropy.modeling.fitting import _fitter_to_model_params, \
     _model_to_fit_params, _validate_model, _convert_input
+
+from stingray.modeling.posterior import Posterior, PSDPosterior, \
+    LogLikelihood, PSDLogLikelihood
 
 
 class OptimizationResults(object):
@@ -84,7 +88,7 @@ class OptimizationResults(object):
         else:
             if comp_hessian:
                 # calculate Hessian approximating with finite differences
-                print("Approximating Hessian with finite differences ...")
+                logging.info("Approximating Hessian with finite differences ...")
 
                 phess = approx_hess(self.p_opt, lpost)
 
@@ -131,7 +135,7 @@ class OptimizationResults(object):
 
     def print_summary(self, lpost):
 
-        print("The best-fit model parameters plus errors are:")
+        logging.info("The best-fit model parameters plus errors are:")
 
         fixed = [lpost.model.fixed[n] for n in lpost.model.param_names]
         tied = [lpost.model.tied[n] for n in lpost.model.param_names]
@@ -156,21 +160,21 @@ class OptimizationResults(object):
             elif tied[i]:
                 print("{:<20.5f} (Tied) ".format(lpost.model.parameters[i]))
 
-        print("\n")
+        logging.info("\n")
 
-        print("Fitting statistics: ")
-        print(" -- number of data points: %i"%(len(lpost.x)))
+        logging.info("Fitting statistics: ")
+        logging.info(" -- number of data points: %i"%(len(lpost.x)))
 
         try:
             self.deviance
         except AttributeError:
             self._compute_criteria(lpost)
 
-        print(" -- Deviance [-2 log L] D = %f.3"%self.deviance)
-        print(" -- The Akaike Information Criterion of the model is: " +
+        logging.info(" -- Deviance [-2 log L] D = %f.3"%self.deviance)
+        logging.info(" -- The Akaike Information Criterion of the model is: " +
               str(self.aic) + ".")
 
-        print(" -- The Bayesian Information Criterion of the model is: " +
+        logging.info(" -- The Bayesian Information Criterion of the model is: " +
               str(self.bic) + ".")
 
         try:
@@ -178,14 +182,14 @@ class OptimizationResults(object):
         except AttributeError:
             self._compute_statistics(lpost)
 
-        print(" -- The figure-of-merit function for this model " +
+        logging.info(" -- The figure-of-merit function for this model " +
               " is: %f.5f"%self.merit +
               " and the fit for %i dof is %f.3f"%(self.dof,
                                                   self.merit/self.dof))
 
-        print(" -- Summed Residuals S = %f.5f"%self.sobs)
-        print(" -- Expected S ~ %f.5 +/- %f.5"%(self.sexp, self.ssd))
-        print(" -- merit function (SSE) M = %f.5f \n\n"%self.merit)
+        logging.info(" -- Summed Residuals S = %f.5f"%self.sobs)
+        logging.info(" -- Expected S ~ %f.5 +/- %f.5"%(self.sexp, self.ssd))
+        logging.info(" -- merit function (SSE) M = %f.5f \n\n"%self.merit)
 
         return
 
@@ -358,7 +362,7 @@ class ParameterEstimation(object):
         # compute log likelihood ratio as difference between the deviances
         lrt = res1.deviance - res2.deviance
 
-        return lrt
+        return lrt, res1, res2
 
     def sample(self, lpost, t0, cov=None,
                nwalkers=500, niter=100, burnin=100, threads=1,
@@ -370,10 +374,14 @@ class ParameterEstimation(object):
 
         Parameters
         ----------
+        lpost : instance of a Posterior subclass
+            and instance of class Posterior or one of its subclasses
+            that defines the function to be minized (either in loglikelihood
+            or logposterior)
+
         t0 : iterable
             list or array containing the starting parameters. Its length
             must match `lpost.model.npar`.
-
 
         nwalkers : int
             The number of walkers (chains) to use during the MCMC procedure.
@@ -446,9 +454,187 @@ class ParameterEstimation(object):
             res.print_results()
 
         if plot:
-            res.plot_results(namestr + "_corner.pdf")
+            fig = res.plot_results(fig=None, save_plot=True,
+                                   filename=namestr + "_corner.pdf")
 
         return res
+
+    def _generate_model(self, lpost, pars):
+        """
+        Helper function that generates a fake PSD similar to the
+        one in the data, but with different parameters.
+
+        Parameters
+        ----------
+        lpost : instance of a Posterior or LogLikelihood subclass
+            The object containing the relevant information about the
+            data and the model
+
+        pars : iterable
+            A list of parameters to be passed to lpost.model in oder
+            to generate a model data set.
+
+        Returns:
+        --------
+        model_data : numpy.ndarray
+            An array of model values for each bin in lpost.x
+
+        """
+
+        assert isinstance(lpost, LogLikelihood) or isinstance(lpost, Posterior), \
+            "lpost must be of type LogLikelihood or Posterior or one of its " \
+            "subclasses!"
+
+        # assert pars is of correct length
+        assert len(pars) == lpost.npar, "pars must be a list " \
+                                        "of %i parameters"%lpost.npar
+        # get the model
+        m = lpost.model
+
+        # reset the parameters
+        _fitter_to_model_params(m, pars)
+
+        # make a model spectrum
+        model_data = lpost.model(lpost.x)
+
+        return model_data
+
+    @staticmethod
+    def _compute_pvalue(obs_val, sim):
+        """
+        Compute the p-value given an observed value of a test statistic
+        and some simulations of that same test statistic.
+
+        Parameters
+        ----------
+        obs_value : float
+            The observed value of the test statistic in question
+
+        sim: iterable
+            A list or array of simulated values for the test statistic
+
+        Returns
+        -------
+        pval : float [0, 1]
+            The p-value for the test statistic given the simulations.
+
+        """
+
+        # cast the simulations as a numpy array
+        sim = np.array(sim)
+
+        # find all simulations that are larger than
+        # the observed value
+        ntail = sim[sim > obs_val].shape[0]
+
+        # divide by the total number of simulations
+        pval = np.float(ntail) / np.float(sim.shape[0])
+
+        return pval
+
+    def calibrate_lrt(self, lpost1, t1, lpost2, t2, sample=None, neg=True,
+                      max_post=False,
+                      nsim=1000, niter=200, nwalkers=500, burnin=200,
+                      namestr="test"):
+
+        """
+        Calibrate the outcome of a Likelihood Ratio Test via MCMC.
+
+        In order to compare models via likelihood ratio test, one generally
+        aims to compute a p-value for the null hypothesis (generally the
+        simpler model). There are two special cases where the theoretical
+        distribution used to compute that p-value analytically given the
+        observed likelihood ratio (a chi-square distribution) is not
+        applicable:
+        * the models are not nested (i.e. Model 1 is not a special, simpler
+        case of Model 2),
+        * the parameter values fixed in Model 2 to retrieve Model 1 are at the
+        edges of parameter space (e.g. if one must set, say, an amplitude to
+        zero in order to remove a component in the more complex model, and
+        negative amplitudes are excluded a priori)
+
+        In these cases, the observed likelihood ratio must be calibrated via
+         simulations of the simpler model (Model 1), using MCMC to take into
+        account the uncertainty in the parameters. This function does
+        exactly that: it computes the likelihood ratio for the observed data,
+        and produces simulations to calibrate the likelihood ratio and
+        compute a p-value for observing the data under the assumption that
+        Model 1 istrue.
+
+        If `max_post=True`, the code will use MCMC to sample the posterior
+        of the parameters and simulate fake data from there.
+
+        If `max_post=False`, the code will use the covariance matrix derived
+        from the fit to simulate data sets for comparison.
+
+        Parameters
+        ----------
+        lpost1 : object of a subclass of Posterior
+            The posterior object for model 1
+
+        t1 : iterable
+            The starting parameters for model 1
+
+        lpost2 : object of a subclass of Posterior
+            The posterior object for model 2
+
+        t2 : iterable
+            The starting parameters for model 2
+
+        neg : bool, optional, default True
+            Boolean flag to decide whether to use the negative
+            log-likelihood or log-posterior
+
+        max_post: bool, optional, default False
+            If True, set the internal state to do the optimization with the
+            log-likelihood rather than the log-posterior.
+
+
+        Returns
+        -------
+        pvalue : float [0,1]
+            p-value 'n stuff
+
+        """
+
+        # compute the observed likelihood ratio
+        lrt_obs, res1, res2 = self.compute_lrt(lpost1, t1,
+                                               lpost2, t2,
+                                               neg=neg,
+                                               max_post=max_post)
+
+        # simulate parameter sets from the simpler model
+        if not max_post:
+            # using Maximum Likelihood, so I'm going to simulate parameters
+            # from a multivariate Gaussian
+
+            # set up the distribution
+            mvn = scipy.stats.multivariate_normal(mean=res1.p_opt,
+                                                  cov=res1.cov)
+
+            # sample parameters
+            s_all = mvn.rvs(size=nsim)
+
+        else:
+            if sample is None:
+                # sample the posterior using MCMC
+                sample = self.sample(lpost1, res1.p_opt, cov=res1.cov,
+                                       nwalkers=nwalkers, niter=niter,
+                                       burnin=burnin, namestr=namestr)
+
+            # pick nsim samples out of the posterior sample
+            s_all = sample[
+                np.random.choice(sample.shape[0], nsim, replace=False)]
+
+        # simulate LRTs
+        # this method is defined in the subclasses!
+        lrt_sim = self.simulate_lrts(s_all, lpost1, t1, lpost2, t2,
+                                      max_post=max_post, neg=neg)
+
+        # now I can compute the p-value:
+        pval = ParameterEstimation._compute_pvalue(lrt_obs, lrt_sim)
+
+        return pval
 
 
 class SamplingResults(object):
@@ -496,7 +682,7 @@ class SamplingResults(object):
         try:
             self.acor = sampler.acor
         except emcee.autocorr.AutocorrError:
-            print("Chains too short to compute autocorrelation lengths.")
+            logging.info("Chains too short to compute autocorrelation lengths.")
 
         self.rhat = self._compute_rhat(sampler)
 
@@ -535,22 +721,24 @@ class SamplingResults(object):
 
         """
 
-        print("-- The acceptance fraction is: %f.5"%self.acceptance)
+        logging.info("-- The acceptance fraction is: %f.5"%self.acceptance)
         try:
-            print("-- The autocorrelation time is: %f.5"%self.acor)
+            logging.info("-- The autocorrelation time is: %f.5"%self.acor)
         except AttributeError:
             pass
-        print("R_hat for the parameters is: " + str(self.rhat))
+        logging.info("R_hat for the parameters is: " + str(self.rhat))
 
-        print("-- Posterior Summary of Parameters: \n")
-        print("parameter \t mean \t\t sd \t\t 5% \t\t 95% \n")
-        print("---------------------------------------------\n")
+        logging.info("-- Posterior Summary of Parameters: \n")
+        logging.info("parameter \t mean \t\t sd \t\t 5% \t\t 95% \n")
+        logging.info("---------------------------------------------\n")
         for i in range(self.ndim):
-            print("theta[" + str(i) + "] \t " +
+            logging.info("theta[" + str(i) + "] \t " +
                   str(self.mean[i]) + "\t" + str(self.std[i]) + "\t" +
                   str(self.ci[0, i]) + "\t" + str(self.ci[1, i]) + "\n")
 
-    def plot_results(self, filename, nsamples=1000):
+    def plot_results(self, nsamples=1000, fig=None, save_plot=False,
+                     filename="test.pdf"):
+
         """
         Plot some results in a triangle plot.
         If installed, will use `corner` for the plotting
@@ -558,23 +746,37 @@ class SamplingResults(object):
         through pip), if not, uses its own code to make a triangle
         plot.
 
+        By default, this method returns a matplotlib.Figure object, but
+        if `save_plot=True`, the plot can be saved to file automatically,
+
         Parameters
         ----------
 
+        nsamples: int, default 1000
+            The maximum number of samples used for plotting.
+
+        fig: matplotlib.Figure instance, default None
+            If created externally, you can pass a Figure instance to this method.
+            If none is passed, the method will create one internally.
+
+        save_plot: bool, default False
+            If True, save the plot to file with a file name specified by the
+            keyword `filename`. If False, just return the `Figure` object
+
         filename: str
             Name of the output file with the figure
-        nsamples: int
-            The maximum number of samples used for plotting.
 
         """
         assert can_plot, "Need to have matplotlib installed for plotting"
         if use_corner:
-            corner.corner(self.samples, labels=None,
+            corner.corner(self.samples, labels=None, fig=fig, bins=int(20),
                           quantiles=[0.16, 0.5, 0.84],
                           show_titles=True, title_args={"fontsize": 12})
 
         else:
-            fig = plt.figure(figsize=(15, 15))
+            if fig is None:
+                fig = plt.figure(figsize=(15, 15))
+
             plt.subplots_adjust(top=0.925, bottom=0.025,
                                 left=0.025, right=0.975,
                                 wspace=0.2, hspace=0.2)
@@ -617,11 +819,12 @@ class SamplingResults(object):
 
                             ax.contour(xx, yy, zz, 7)
                         except ValueError:
-                            print("Not making contours.")
+                            logging.info("Not making contours.")
 
-        plt.savefig(filename, format='pdf')
-        plt.close()
-        return
+        if save_plot:
+            plt.savefig(filename, format='pdf')
+
+        return fig
 
 
 class PSDParEst(ParameterEstimation):
@@ -661,6 +864,156 @@ class PSDParEst(ParameterEstimation):
 
         return res
 
+    def _generate_data(self, lpost, pars):
+        """
+        Generate a fake power spectrum from a model.
+
+        Parameters:
+        ----------
+        lpost : instance of a Posterior or LogLikelihood subclass
+            The object containing the relevant information about the
+            data and the model
+
+        pars : iterable
+            A list of parameters to be passed to lpost.model in oder
+            to generate a model data set.
+
+        Returns:
+        --------
+        sim_ps : stingray.Powerspectrum object
+            The simulated Powerspectrum object
+
+        """
+
+        model_spectrum = self._generate_model(lpost, pars)
+
+        # use chi-square distribution to get fake data
+        model_powers = model_spectrum * \
+                       np.random.chisquare(2 * self.ps.m,
+                                           size=model_spectrum.shape[0]) \
+                                                / (2. * self.ps.m)
+
+        sim_ps = copy.copy(self.ps)
+
+        sim_ps.power = model_powers
+
+        return sim_ps
+
+    def simulate_lrts(self, s_all, lpost1, t1, lpost2, t2, max_post=True,
+                       neg=False):
+
+        nsim = s_all.shape[0]
+        lrt_sim = np.zeros(nsim)
+
+        # now I can loop over all simulated parameter sets to generate a PSD
+        for i, s in enumerate(s_all):
+
+            # generate fake PSD
+            sim_ps = self._generate_data(lpost1, s)
+
+            # make LogLikelihood objects for both:
+            if not max_post:
+                sim_lpost1 = PSDLogLikelihood(sim_ps.freq, sim_ps.power,
+                                              model=lpost1.model)
+                sim_lpost2 = PSDLogLikelihood(sim_ps.freq, sim_ps.power,
+                                              model=lpost2.model, m=sim_ps.m)
+            else:
+                # make a Posterior object
+                sim_lpost1 = PSDPosterior(sim_ps.freq, sim_ps.power,
+                                          lpost1.model, m=sim_ps.m)
+                sim_lpost1.logprior = lpost1.logprior
+
+                sim_lpost2 = PSDPosterior(sim_ps.freq, sim_ps.power,
+                                          lpost2.model, m=sim_ps.m)
+
+                sim_lpost2.logprior = lpost2.logprior
+
+            parest_sim = PSDParEst(sim_ps, max_post=max_post)
+
+            lrt_sim[i], _, _ = parest_sim.compute_lrt(sim_lpost1, t1,
+                                                      sim_lpost2, t2,
+                                                      neg=neg,
+                                                      max_post=max_post)
+        return lrt_sim
+
+
+    def calibrate_highest_outlier(self, lpost, t0, sample=None,
+                                  max_post=False,
+                                  nsim=1000, niter=200, nwalkers=500,
+                                  burnin=200, namestr="test"):
+
+        """
+
+        """
+        # fit the model to the data
+        res = self.fit(lpost, t0, neg=True)
+
+        # find the highest data/model outlier:
+        out_high, _, _ = self._compute_highest_outlier(lpost, res)
+        # simulate parameter sets from the simpler model
+        if not max_post:
+            # using Maximum Likelihood, so I'm going to simulate parameters
+            # from a multivariate Gaussian
+
+            # set up the distribution
+            mvn = scipy.stats.multivariate_normal(mean=res.p_opt,
+                                                  cov=res.cov)
+
+            # sample parameters
+            s_all = mvn.rvs(size=nsim)
+
+        else:
+            if sample is None:
+                # sample the posterior using MCMC
+                sample = self.sample(lpost, res.p_opt, cov=res.cov,
+                                       nwalkers=nwalkers, niter=niter,
+                                       burnin=burnin, namestr=namestr)
+
+            # pick nsim samples out of the posterior sample
+            s_all = sample[
+                np.random.choice(sample.shape[0], nsim, replace=False)]
+
+        # simulate LRTs
+        # this method is defined in the subclasses!
+        out_high_sim = self.simulate_highest_outlier(s_all, lpost, t0,
+                                                max_post=max_post)
+        # now I can compute the p-value:
+        pval = ParameterEstimation._compute_pvalue(out_high, out_high_sim)
+
+        return pval
+
+    def simulate_highest_outlier(self, s_all, lpost, t0, max_post=True):
+
+        # the number of simulations
+        nsim = s_all.shape[0]
+
+        # empty array for the simulation results
+        max_y_all = np.zeros(nsim)
+
+        # now I can loop over all simulated parameter sets to generate a PSD
+        for i, s in enumerate(s_all):
+
+            # generate fake PSD
+            sim_ps = self._generate_data(lpost, s)
+
+            # make LogLikelihood objects for both:
+            if not max_post:
+                sim_lpost = PSDLogLikelihood(sim_ps.freq, sim_ps.power,
+                                              model=lpost.model, m=sim_ps.m)
+            else:
+                # make a Posterior object
+                sim_lpost = PSDPosterior(sim_ps.freq, sim_ps.power,
+                                         lpost.model, m=sim_ps.m)
+                sim_lpost.logprior = lpost.logprior
+
+            parest_sim = PSDParEst(sim_ps, max_post=max_post)
+
+            res = parest_sim.fit(sim_lpost, t0, neg=True)
+            max_y_all[i], maxfreq, maxind = self._compute_highest_outlier(sim_lpost,
+                                                               res,
+                                                               nmax=1)
+        return np.hstack(max_y_all)
+
     def _compute_highest_outlier(self, lpost, res, nmax=1):
 
         residuals = 2.0 * lpost.y/ res.mfit
@@ -679,7 +1032,7 @@ class PSDParEst(ParameterEstimation):
 
     @staticmethod
     def _find_outlier(xdata, ratio, max_y):
-        max_ind = np.where(ratio == max_y)[0][0]+1
+        max_ind = np.where(ratio == max_y)[0][0]
         max_x = xdata[max_ind]
 
         return max_x, max_ind
@@ -688,7 +1041,7 @@ class PSDParEst(ParameterEstimation):
                  namestr='test', log=False):
 
         if not can_plot:
-            print("No matplotlib imported. Can't plot!")
+            logging.info("No matplotlib imported. Can't plot!")
         else:
             # make a figure
             f = plt.figure(figsize=(12, 10))
@@ -767,7 +1120,7 @@ class PSDParEst(ParameterEstimation):
             else:
                 s2.plot(self.ps.freq, pldif, color='black',
                         linestyle='steps-mid')
-                s2.plot(self.ps.power, np.ones(self.ps.power.shape[0]),
+                s2.plot(self.ps.freq, np.ones_like(self.ps.power),
                         color='blue', lw=2)
 
                 s2.set_xscale("log")

--- a/stingray/modeling/scripts.py
+++ b/stingray/modeling/scripts.py
@@ -114,7 +114,8 @@ def fit_powerspectrum(ps, model, starting_pars, max_post=False, priors=None,
 
     """
     if priors:
-        lpost = PSDPosterior(ps, model, priors=priors)
+        lpost = PSDPosterior(ps.freq, ps.power, model, priors=priors,
+                             m=ps.m)
     else:
         lpost = PSDLogLikelihood(ps.freq, ps.power, model, m=ps.m)
 
@@ -242,4 +243,3 @@ def fit_lorentzians(ps, nlor, starting_pars, fit_whitenoise=True,
 
     return fit_powerspectrum(ps, model, starting_pars, max_post=max_post,
                              priors=priors, fitmethod=fitmethod)
-

--- a/stingray/modeling/scripts.py
+++ b/stingray/modeling/scripts.py
@@ -99,7 +99,7 @@ def fit_powerspectrum(ps, model, starting_pars, max_post=False, priors=None,
     Now we have to guess starting parameters. For each Lorentzian, we have
     amplitude, centroid position and fwhm, and this pattern repeats for each
     Lorentzian in the fit. The white noise level is the last parameter.
-    >>> t0 = [80, 1., 1.5, 2.5]
+    >>> t0 = [80, 1.5, 2.5]
 
     Let's also make a model to test:
     >>> model_to_test = models.PowerLaw1D() + models.Const1D()

--- a/stingray/modeling/scripts.py
+++ b/stingray/modeling/scripts.py
@@ -119,6 +119,7 @@ def fit_powerspectrum(ps, model, starting_pars, max_post=False, priors=None,
     else:
         lpost = PSDLogLikelihood(ps.freq, ps.power, model, m=ps.m)
 
+
     parest = PSDParEst(ps, fitmethod=fitmethod, max_post=max_post)
     res = parest.fit(lpost, starting_pars, neg=True)
 

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -1084,8 +1084,9 @@ class TestPSDParEst(object):
     def test_calibrate_highest_outlier_works(self):
         m = 1
         nfreq = 100000
+        seed = 100
         freq = np.linspace(1, 10, nfreq)
-        rng = np.random.RandomState(100)
+        rng = np.random.RandomState(seed)
         noise = rng.exponential(size=nfreq)
         model = models.Const1D()
         model.amplitude = 2.0
@@ -1099,15 +1100,18 @@ class TestPSDParEst(object):
         ps.df = freq[1] - freq[0]
         ps.norm = "leahy"
 
+        nsim = 10
+
         loglike = PSDLogLikelihood(ps.freq, ps.power, model, m=1)
 
-        s_all = np.atleast_2d(np.ones(10) * 2.0).T
+        s_all = np.atleast_2d(np.ones(nsim) * 2.0).T
 
         pe = PSDParEst(ps)
 
         res = pe.fit(loglike, [2.0], neg=True)
 
         maxpow_sim = pe.simulate_highest_outlier(s_all, loglike, [2.0],
-                                                 max_post=False)
+                                                 max_post=False, seed=seed)
 
+        assert maxpow_sim.shape([0]) == nsim
         assert np.all(maxpow_sim > 20.00) and np.all(maxpow_sim < 31.0)

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -275,8 +275,12 @@ class OptimizationResultsSubclassDummy(OptimizationResults):
 
     def __init__(self, lpost, res, neg):
         self.neg = neg
-        self.result = res.fun
-        self.p_opt = res.x
+        if res is not None:
+            self.result = res.fun
+            self.p_opt = res.x
+        else:
+            self.result = None
+            self.p_opt = None
         self.model = lpost.model
 
 
@@ -458,6 +462,9 @@ class TestOptimizationResultInternalFunctions(object):
 
             assert np.all(optres.cov == hess_inv)
             assert np.all(optres.err == np.sqrt(np.diag(np.abs(hess_inv))))
+        else:
+            assert optres.cov is None
+            assert optres.err is None
 
     def test_print_summary_works(self, logger, caplog):
 

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -727,7 +727,7 @@ class TestPSDParEst(object):
         ps.df = self.ps.df
         ps.norm = "leahy"
 
-        pe = PSDParEst(ps)
+        pe = PSDParEst(ps, fitmethod="TNC")
         llike = PSDLogLikelihood(ps.freq, ps.power, model)
 
         true_pars = [self.x_0_0, self.fwhm_0,

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -1113,5 +1113,5 @@ class TestPSDParEst(object):
         maxpow_sim = pe.simulate_highest_outlier(s_all, loglike, [2.0],
                                                  max_post=False, seed=seed)
 
-        assert maxpow_sim.shape([0]) == nsim
+        assert maxpow_sim.shape[0] == nsim
         assert np.all(maxpow_sim > 20.00) and np.all(maxpow_sim < 31.0)

--- a/stingray/modeling/tests/test_posterior.py
+++ b/stingray/modeling/tests/test_posterior.py
@@ -49,7 +49,7 @@ class TestSetPrior(object):
         pl = models.PowerLaw1D()
         pl.x_0.fixed = True
 
-        cls.lpost = PSDPosterior(cls.ps, pl)
+        cls.lpost = PSDPosterior(cls.ps.freq, cls.ps.power, pl, m=cls.ps.m)
 
     def test_set_prior_runs(self):
         p_alpha = lambda alpha: ((-1. <= alpha) & (alpha <= 5.))/6.0
@@ -152,20 +152,23 @@ class TestPSDPosterior(object):
         cls.priors = {"amplitude":p_amplitude}
 
     def test_logprior_fails_without_prior(self):
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power, self.model,
+                             m=self.ps.m)
 
         with pytest.raises(AttributeError):
             lpost.logprior([1])
 
     def test_making_posterior(self):
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         assert lpost.x.all() == self.ps.freq.all()
         assert lpost.y.all() == self.ps.power.all()
 
     def test_correct_number_of_parameters(self):
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         with pytest.raises(IncorrectParameterError):
@@ -174,7 +177,8 @@ class TestPSDPosterior(object):
     def test_logprior(self):
         t0 = [2.0]
 
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         lp_test = lpost.logprior(t0)
@@ -188,7 +192,8 @@ class TestPSDPosterior(object):
 
         loglike = -np.sum(np.log(mean_model)) - np.sum(self.ps.power/mean_model)
 
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         loglike_test = lpost.loglikelihood(t0, neg=False)
@@ -201,7 +206,8 @@ class TestPSDPosterior(object):
         m = self.model(self.ps.freq[1:], t0)
         loglike = np.sum(self.ps.power[1:]/m + np.log(m))
 
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         loglike_test = lpost.loglikelihood(t0, neg=True)
@@ -211,7 +217,8 @@ class TestPSDPosterior(object):
     def test_posterior(self):
         t0 = [2.0]
         m = self.model(self.ps.freq[1:], t0)
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         post_test = lpost(t0, neg=False)
@@ -225,7 +232,8 @@ class TestPSDPosterior(object):
     def test_negative_posterior(self):
         t0 = [2.0]
         m = self.model(self.ps.freq[1:], t0)
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         post_test = lpost(t0, neg=True)
@@ -518,20 +526,23 @@ class TestPerPosteriorAveragedPeriodogram(object):
         cls.priors = {"amplitude":p_amplitude}
 
     def test_logprior_fails_without_prior(self):
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
 
         with pytest.raises(AttributeError):
             lpost.logprior([1])
 
     def test_making_posterior(self):
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         assert lpost.x.all() == self.ps.freq.all()
         assert lpost.y.all() == self.ps.power.all()
 
     def test_correct_number_of_parameters(self):
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         with pytest.raises(IncorrectParameterError):
@@ -540,7 +551,8 @@ class TestPerPosteriorAveragedPeriodogram(object):
     def test_logprior(self):
         t0 = [2.0]
 
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         lp_test = lpost.logprior(t0)
@@ -557,7 +569,8 @@ class TestPerPosteriorAveragedPeriodogram(object):
                                np.sum((2.0 / (2. * self.m) - 1.0) *
                                       np.log(self.ps.power)))
 
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         loglike_test = lpost.loglikelihood(t0, neg=False)
@@ -577,7 +590,8 @@ class TestPerPosteriorAveragedPeriodogram(object):
                                       np.log(self.ps.power)))
 
 
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         loglike_test = lpost.loglikelihood(t0, neg=True)
@@ -589,7 +603,8 @@ class TestPerPosteriorAveragedPeriodogram(object):
         self.model.amplitude = t0[0]
 
         mean_model = self.model(self.ps.freq)
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         post_test = lpost(t0, neg=False)
@@ -609,7 +624,8 @@ class TestPerPosteriorAveragedPeriodogram(object):
         self.model.amplitude = t0[0]
 
         mean_model = self.model(self.ps.freq)
-        lpost = PSDPosterior(self.ps, self.model)
+        lpost = PSDPosterior(self.ps.freq, self.ps.power,
+                             self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         post_test = lpost(t0, neg=True)
@@ -632,7 +648,7 @@ class TestPerPosteriorAveragedPeriodogram(object):
 
         t0 = [2.0]
         m = self.model(self.ps.freq[1:], t0)
-        lpost = PSDPosterior(ps_nan, self.model)
+        lpost = PSDPosterior(ps_nan.freq, ps_nan.power, self.model)
         lpost.logprior = set_logprior(lpost, self.priors)
 
         assert np.isclose(lpost(t0), logmin, 1e-5)

--- a/stingray/modeling/tests/test_scripts.py
+++ b/stingray/modeling/tests/test_scripts.py
@@ -78,9 +78,14 @@ class TestFitLorentzians(object):
         model.amplitude_0 = self.t0[0]
         # model.bounds = {}
 
+        t0 = np.array([self.amplitude_0, self.x_0_0, self.fwhm_0,
+              self.amplitude_1, self.fwhm_1,
+              self.amplitude_2, self.fwhm_2,
+              self.whitenoise])
+
         parest, res = fit_powerspectrum(self.ps, model,
-                                np.random.normal(self.t0,
-                                                 self.t0 / 10))
+                                np.random.normal(t0,
+                                                 t0 / 10))
 
         true_pars = [self.amplitude_0,
                      self.x_0_0, self.fwhm_0,
@@ -97,9 +102,15 @@ class TestFitLorentzians(object):
         model.amplitude_0.fixed = True
         # model.bounds = {}
 
+        t0 = np.array([self.x_0_0, self.fwhm_0,
+              self.amplitude_1, self.x_0_1, self.fwhm_1,
+              self.amplitude_2, self.x_0_2, self.fwhm_2,
+              self.whitenoise])
+
+
         parest, res = fit_powerspectrum(self.ps, model,
-                                  np.random.normal(self.t0,
-                                                   self.t0 / 10))
+                                  np.random.normal(t0,
+                                                   t0 / 10))
 
         true_pars = [self.x_0_0, self.fwhm_0,
                      self.amplitude_1, self.x_0_1, self.fwhm_1,

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -178,8 +178,8 @@ class Powerspectrum(Crossspectrum):
         Crossspectrum.__init__(self, lc1=lc, lc2=lc, norm=norm, gti=gti)
         self.nphots = self.nphots1
 
-    def rebin(self, df, method="mean"):
-        bin_ps = Crossspectrum.rebin(self, df=df, method=method)
+    def rebin(self, df=None, f=None, method="mean"):
+        bin_ps = Crossspectrum.rebin(self, df=df, f=f, method=method)
         bin_ps.nphots = bin_ps.nphots1
 
         return bin_ps

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -139,7 +139,8 @@ class TestCrossspectrum(object):
 
     def test_rebin_log(self):
         # For now, just verify that it doesn't crash
-        _ = self.cs.rebin_log(f=0.01)
+        new_cs = self.cs.rebin_log(f=0.1)
+        assert type(new_cs) == type(self.cs)
 
     def test_norm_leahy(self):
         cs = Crossspectrum(self.lc1, self.lc2, norm='leahy')

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -137,6 +137,10 @@ class TestCrossspectrum(object):
         new_cs = self.cs.rebin(df=1.5)
         assert new_cs.df == 1.5
 
+    def test_rebin_factor(self):
+        new_cs = self.cs.rebin(f=1.5)
+        assert new_cs.df == self.cs.df * 1.5
+
     def test_rebin_log(self):
         # For now, just verify that it doesn't crash
         new_cs = self.cs.rebin_log(f=0.1)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -610,11 +610,29 @@ class TestLightcurveRebin(object):
             self.lc.counts[0]*dt_new/self.lc.dt
         assert np.allclose(lc_binned.counts, counts_test)
 
+    def test_rebin_even_factor(self):
+        f = 200
+        dt_new = f * self.lc.dt
+        lc_binned = self.lc.rebin(f=f)
+        assert np.isclose(dt_new, f * self.lc.dt)
+        counts_test = np.zeros_like(lc_binned.time) + \
+            self.lc.counts[0]*dt_new/self.lc.dt
+        assert np.allclose(lc_binned.counts, counts_test)
+
     def test_rebin_odd(self):
         dt_new = 1.5
         lc_binned = self.lc.rebin(dt_new)
         assert np.isclose(lc_binned.dt, dt_new)
 
+        counts_test = np.zeros_like(lc_binned.time) + \
+            self.lc.counts[0]*dt_new/self.lc.dt
+        assert np.allclose(lc_binned.counts, counts_test)
+
+    def test_rebin_odd_factor(self):
+        f = 100.5
+        dt_new = f * self.lc.dt
+        lc_binned = self.lc.rebin(f=f)
+        assert np.isclose(dt_new, f * self.lc.dt)
         counts_test = np.zeros_like(lc_binned.time) + \
             self.lc.counts[0]*dt_new/self.lc.dt
         assert np.allclose(lc_binned.counts, counts_test)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -193,7 +193,7 @@ class TestPowerspectrum(object):
         had better be 'method'
         """
         ps = Powerspectrum(lc=self.lc, norm="Leahy")
-        assert ps.rebin.__defaults__[0] == "mean"
+        assert ps.rebin.__defaults__[2] == "mean"
 
     @pytest.mark.parametrize('df', [2, 3, 5, 1.5, 1, 85])
     def test_rebin(self, df):


### PR DESCRIPTION
Closes #150

Two changes here:

+ `rebin_log` returns a *spectrum instance, consistently with `rebin`

+ `rebin` now accept a rebin _factor_ instead of just the new resolution, both in `Lightcurve` and in {cross,power} spectra