### PR TITLE
rebin_log returns a Powerspectrum/Crossspectrum instance, allows rebin factor

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -10,6 +10,7 @@ from stingray.lightcurve import Lightcurve
 from stingray.utils import rebin_data, simon
 from stingray.exceptions import StingrayError
 from stingray.gti import cross_two_gtis, bin_intervals_from_gtis, check_gtis
+import copy
 
 __all__ = ["Crossspectrum", "AveragedCrossspectrum", "coherence"]
 
@@ -254,7 +255,7 @@ class Crossspectrum(object):
 
         return freqs[freqs > 0], cross
 
-    def rebin(self, df, method="mean"):
+    def rebin(self, df=None, f=None, method="mean"):
         """
         Rebin the cross spectrum to a new frequency resolution df.
 
@@ -263,11 +264,22 @@ class Crossspectrum(object):
         df: float
             The new frequency resolution
 
+        Other Parameters
+        ----------------
+        f: float
+            the rebin factor. If specified, it substitutes df with f*self.df
+
         Returns
         -------
         bin_cs = Crossspectrum object
             The newly binned cross spectrum
         """
+
+        if f is None and df is None:
+            raise ValueError('You need to specify at least one between f and '
+                             'df')
+        elif f is not None:
+            df = f * self.df
 
         # rebin cross spectrum to new resolution
         binfreq, bincs, binerr, step_size = \
@@ -413,7 +425,13 @@ class Crossspectrum(object):
         # last right bin edge
         binfreq = binfreq[:-1] + df/2
 
-        return binfreq, binpower, binpower_err, nsamples
+        new_spec = copy.copy(self)
+        new_spec.freq = binfreq
+        new_spec.power = binpower
+        new_spec.power_err = binpower_err
+        new_spec.m = nsamples
+
+        return new_spec
 
     def coherence(self):
         """

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -63,6 +63,7 @@ class Crossspectrum(object):
             The first light curve data for the channel/band of interest.
 
         lc2: lightcurve.Lightcurve object, optional, default None
+        lc2: lightcurve.Lightcurve object, optional, default None
             The light curve data for the reference band.
 
         norm: {'frac', 'abs', 'leahy', 'none'}, default 'none'
@@ -703,7 +704,7 @@ class AveragedCrossspectrum(Crossspectrum):
         .. [1] http://iopscience.iop.org/article/10.1086/310430/pdf
 
         """
-        if self.m < 50:
+        if np.any(self.m < 50):
             simon("Number of segments used in averaging is "
                   "significantly low. The result might not follow the "
                   "expected statistical distributions.")

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -7,16 +7,12 @@ import scipy.fftpack
 import scipy.optimize
 
 from stingray.lightcurve import Lightcurve
-from stingray.utils import rebin_data, simon
+from stingray.utils import rebin_data, simon, rebin_data_log
 from stingray.exceptions import StingrayError
 from stingray.gti import cross_two_gtis, bin_intervals_from_gtis, check_gtis
 import copy
 
 __all__ = ["Crossspectrum", "AveragedCrossspectrum", "coherence"]
-
-
-def _root_squared_mean(array):
-    return np.sqrt(np.sum(array**2)) / len(array)
 
 
 def coherence(lc1, lc2):
@@ -62,7 +58,6 @@ class Crossspectrum(object):
         lc1: lightcurve.Lightcurve object, optional, default None
             The first light curve data for the channel/band of interest.
 
-        lc2: lightcurve.Lightcurve object, optional, default None
         lc2: lightcurve.Lightcurve object, optional, default None
             The light curve data for the reference band.
 
@@ -137,6 +132,13 @@ class Crossspectrum(object):
         self.lc2 = lc2
 
         self._make_crossspectrum(lc1, lc2)
+        # These are needed to calculate coherence
+        self._make_auxil_pds(lc1, lc2)
+
+    def _make_auxil_pds(self, lc1, lc2):
+        if lc1 is not lc2 and isinstance(lc1, Lightcurve):
+            self.pds1 = Crossspectrum(lc1, lc1, norm='none')
+            self.pds2 = Crossspectrum(lc2, lc2, norm='none')
 
     def _make_crossspectrum(self, lc1, lc2):
 
@@ -285,11 +287,11 @@ class Crossspectrum(object):
         # rebin cross spectrum to new resolution
         binfreq, bincs, binerr, step_size = \
             rebin_data(self.freq, self.power, df, self.power_err,
-                       method=method)
+                       method=method, dx=self.df)
 
         # make an empty cross spectrum object
         # note: syntax deliberate to work with subclass Powerspectrum
-        bin_cs = self.__class__()
+        bin_cs = copy.copy(self)
 
         # store the binned periodogram in the new object
         bin_cs.freq = binfreq
@@ -299,6 +301,23 @@ class Crossspectrum(object):
         bin_cs.norm = self.norm
         bin_cs.nphots1 = self.nphots1
         bin_cs.power_err = binerr
+
+        if hasattr(self, 'unnorm_power'):
+            _, binpower_unnorm, _, _ = \
+                rebin_data(self.freq, self.unnorm_power, df,
+                           method=method, dx=self.df)
+
+            bin_cs.unnorm_power = binpower_unnorm
+
+        if hasattr(self, 'cs_all'):
+            cs_all = []
+            for c in self.cs_all:
+                cs_all.append(c.rebin(df=df, f=f, method=method))
+            bin_cs.cs_all = cs_all
+        if hasattr(self, 'pds1'):
+            bin_cs.pds1 = self.pds1.rebin(df=df, f=f, method=method)
+        if hasattr(self, 'pds2'):
+            bin_cs.pds2 = self.pds2.rebin(df=df, f=f, method=method)
 
         try:
             bin_cs.nphots2 = self.nphots2
@@ -394,43 +413,40 @@ class Crossspectrum(object):
             frequency bin
         """
 
-        minfreq = self.freq[1] * 0.5  # frequency to start from
-        maxfreq = self.freq[-1]  # maximum frequency to end
-        binfreq = [minfreq, minfreq + self.df]  # first
-        df = self.freq[1]  # the frequency resolution of the first bin
-
-        # until we reach the maximum frequency, increase the width of each
-        # frequency bin by f
-        while binfreq[-1] <= maxfreq:
-            binfreq.append(binfreq[-1] + df*(1.0+f))
-            df = binfreq[-1] - binfreq[-2]
-
-        # compute the mean of the powers that fall into each new frequency bin.
-        # we cast to np.double due to scipy's bad handling of longdoubles
-        binpower, bin_edges, binno = scipy.stats.binned_statistic(
-            self.freq.astype(np.double), self.power.astype(np.double),
-            statistic="mean", bins=binfreq)
-
-        binpower_err, bin_edges, binno = scipy.stats.binned_statistic(
-            self.freq.astype(np.double), self.power_err.astype(np.double),
-            statistic=_root_squared_mean, bins=binfreq)
-
-        # compute the number of powers in each frequency bin
-        nsamples = np.array([len(binno[np.where(binno == i)[0]])
-                             for i in range(np.max(binno))])
+        binfreq, binpower, binpower_err, nsamples = \
+            rebin_data_log(self.freq, self.power, f,
+                           y_err=self.power_err, dx=self.df)
 
         # the frequency resolution
         df = np.diff(binfreq)
 
         # shift the lower bin edges to the middle of the bin and drop the
         # last right bin edge
-        binfreq = binfreq[:-1] + df/2
+        binfreq = binfreq[:-1] + df / 2
 
         new_spec = copy.copy(self)
         new_spec.freq = binfreq
         new_spec.power = binpower
         new_spec.power_err = binpower_err
-        new_spec.m = nsamples
+        new_spec.m = nsamples * self.m
+
+
+        if hasattr(self, 'unnorm_power'):
+            _, binpower_unnorm, _, _ = \
+                rebin_data_log(self.freq, self.unnorm_power, f, dx=self.df)
+
+            new_spec.unnorm_power = binpower_unnorm
+
+        if hasattr(self, 'pds1'):
+            new_spec.pds1 = self.pds1.rebin_log(f)
+        if hasattr(self, 'pds2'):
+            new_spec.pds2 = self.pds2.rebin_log(f)
+
+        if hasattr(self, 'cs_all'):
+            cs_all = []
+            for c in self.cs_all:
+                cs_all.append(c.rebin_log(f))
+            new_spec.cs_all = cs_all
 
         return new_spec
 
@@ -452,10 +468,8 @@ class Crossspectrum(object):
         """
         # this computes the averaged power spectrum, but using the
         # cross spectrum code to avoid circular imports
-        ps1 = Crossspectrum(self.lc1, self.lc1)
-        ps2 = Crossspectrum(self.lc2, self.lc2)
 
-        return self.unnorm_power.real/(ps1.unnorm_power.real * ps2.unnorm_power.real)
+        return self.unnorm_power.real/(self.pds1.power.real * self.pds2.power.real)
 
     def _phase_lag(self):
         """Return the fourier phase lag of the cross spectrum."""
@@ -560,6 +574,16 @@ class AveragedCrossspectrum(Crossspectrum):
         Crossspectrum.__init__(self, lc1, lc2, norm, gti=gti)
 
         return
+
+    def _make_auxil_pds(self, lc1, lc2):
+        # A way to say that this is actually not a power spectrum
+        if lc1 is not lc2 and isinstance(lc1, Lightcurve):
+            self.pds1 = AveragedCrossspectrum(lc1, lc1,
+                                              segment_size=self.segment_size,
+                                              norm='none', gti=lc1.gti)
+            self.pds2 = AveragedCrossspectrum(lc2, lc2,
+                                              segment_size=self.segment_size,
+                                              norm='none', gti=lc2.gti)
 
     def _make_segment_spectrum(self, lc1, lc2, segment_size):
 
@@ -717,22 +741,9 @@ class AveragedCrossspectrum(Crossspectrum):
         unnorm_power_avg /= self.m
         num = np.absolute(unnorm_power_avg)**2
 
-        # this computes the averaged power spectrum, but using the
-        # cross spectrum code to avoid circular imports
-        aps1 = AveragedCrossspectrum(self.lc1, self.lc1,
-                                     segment_size=self.segment_size)
-        aps2 = AveragedCrossspectrum(self.lc2, self.lc2,
-                                     segment_size=self.segment_size)
-
-        unnorm_powers_avg_1 = np.zeros_like(aps1.cs_all[0].unnorm_power.real)
-        for ps in aps1.cs_all:
-            unnorm_powers_avg_1 += ps.unnorm_power.real
-        unnorm_powers_avg_1 /= aps1.m
-
-        unnorm_powers_avg_2 = np.zeros_like(aps2.cs_all[0].unnorm_power.real)
-        for ps in aps2.cs_all:
-            unnorm_powers_avg_2 += ps.unnorm_power.real
-        unnorm_powers_avg_2 /= aps2.m
+        # The normalization was 'none'!
+        unnorm_powers_avg_1 = self.pds1.power.real
+        unnorm_powers_avg_2 = self.pds2.power.real
 
         coh = num / (unnorm_powers_avg_1 * unnorm_powers_avg_2)
 

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -504,7 +504,7 @@ class Lightcurve(object):
 
         return Lightcurve(time, counts, gti=gti, mjdref=mjdref, dt=dt)
 
-    def rebin(self, dt_new, method='sum'):
+    def rebin(self, dt_new=None, f=None, method='sum'):
         """
         Rebin the light curve to a new time resolution. While the new
         resolution need not be an integer multiple of the previous time
@@ -521,12 +521,23 @@ class Lightcurve(object):
             This keyword argument sets whether the counts in the new bins
             should be summed or averaged.
 
+        Other Parameters
+        ----------------
+        f: float
+            the rebin factor. If specified, it substitutes dt_new with
+            f*self.dt
 
         Returns
         -------
         lc_new: :class:`Lightcurve` object
             The :class:`Lightcurve` object with the new, binned light curve.
         """
+
+        if f is None and dt_new is None:
+            raise ValueError('You need to specify at least one between f and '
+                             'dt_new')
+        elif f is not None:
+            dt_new = f * self.dt
 
         if dt_new < self.dt:
             raise ValueError("New time resolution must be larger than "

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -936,7 +936,7 @@ class Lightcurve(object):
             new_lc = Lightcurve(self.time[start:stop], self.counts[start:stop],
                                 err=self.counts_err[start:stop],
                                 mjdref=self.mjdref, gti=[self.gti[i]],
-                                dt=self.dt)
+                                dt=self.dt, err_dist=self.err_dist)
             list_of_lcs.append(new_lc)
 
         return list_of_lcs

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -178,8 +178,8 @@ class Powerspectrum(Crossspectrum):
         Crossspectrum.__init__(self, lc1=lc, lc2=lc, norm=norm, gti=gti)
         self.nphots = self.nphots1
 
-    def rebin(self, df, method="mean"):
-        bin_ps = Crossspectrum.rebin(self, df=df, method=method)
+    def rebin(self, df=None, f=None, method="mean"):
+        bin_ps = Crossspectrum.rebin(self, df=df, f=f, method=method)
         bin_ps.nphots = bin_ps.nphots1
 
         return bin_ps

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -137,9 +137,14 @@ class TestCrossspectrum(object):
         new_cs = self.cs.rebin(df=1.5)
         assert new_cs.df == 1.5
 
+    def test_rebin_factor(self):
+        new_cs = self.cs.rebin(f=1.5)
+        assert new_cs.df == self.cs.df * 1.5
+
     def test_rebin_log(self):
         # For now, just verify that it doesn't crash
-        _ = self.cs.rebin_log(f=0.01)
+        new_cs = self.cs.rebin_log(f=0.1)
+        assert type(new_cs) == type(self.cs)
 
     def test_norm_leahy(self):
         cs = Crossspectrum(self.lc1, self.lc2, norm='leahy')

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -5,6 +5,7 @@ import warnings
 from stingray import Lightcurve, AveragedPowerspectrum
 from stingray import Crossspectrum, AveragedCrossspectrum, coherence
 from stingray import StingrayError
+import copy
 
 np.random.seed(20160528)
 
@@ -123,6 +124,26 @@ class TestCrossspectrum(object):
         lc_ = Lightcurve(time, counts)
         with pytest.raises(StingrayError):
             cs = Crossspectrum(self.lc1, lc_)
+
+    def test_make_crossspectrum_diff_lc_stat(self):
+        lc_ = copy.copy(self.lc1)
+        lc_.err_dist = 'gauss'
+
+        with pytest.warns(UserWarning) as record:
+            cs = Crossspectrum(self.lc1, lc_)
+        assert np.any(["different statistics" in r.message.args[0]
+                       for r in record])
+
+    def test_make_crossspectrum_bad_lc_stat(self):
+        lc1 = copy.copy(self.lc1)
+        lc1.err_dist = 'gauss'
+        lc2 = copy.copy(self.lc1)
+        lc2.err_dist = 'gauss'
+
+        with pytest.warns(UserWarning) as record:
+            cs = Crossspectrum(lc1, lc2)
+        assert np.any(["is not poisson" in r.message.args[0]
+                       for r in record])
 
     def test_make_crossspectrum_diff_dt(self):
         counts = np.array([1]*10000)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -51,10 +51,13 @@ class TestCoherence(object):
         assert np.abs(np.mean(coh)) < 1
 
     def test_high_coherence(self):
+        import copy
         t = np.arange(1280)
         a = np.random.poisson(100, len(t))
         lc = Lightcurve(t, a)
-        c = AveragedCrossspectrum(lc, lc, 128)
+        lc2 = Lightcurve(t, copy.copy(a))
+        c = AveragedCrossspectrum(lc, lc2, 128)
+
         coh, _ = c.coherence()
         np.testing.assert_almost_equal(np.mean(coh).real, 1.0)
 
@@ -136,15 +139,18 @@ class TestCrossspectrum(object):
     def test_rebin(self):
         new_cs = self.cs.rebin(df=1.5)
         assert new_cs.df == 1.5
+        new_cs.time_lag()
 
     def test_rebin_factor(self):
         new_cs = self.cs.rebin(f=1.5)
         assert new_cs.df == self.cs.df * 1.5
+        new_cs.time_lag()
 
     def test_rebin_log(self):
         # For now, just verify that it doesn't crash
         new_cs = self.cs.rebin_log(f=0.1)
         assert type(new_cs) == type(self.cs)
+        new_cs.time_lag()
 
     def test_norm_leahy(self):
         cs = Crossspectrum(self.lc1, self.lc2, norm='leahy')
@@ -310,8 +316,6 @@ class TestAveragedCrossspectrum(object):
 
             assert len(coh[0]) == 4999
             assert len(coh[1]) == 4999
-
-            assert len(w) == 3
             assert issubclass(w[-1].category, UserWarning)
 
     def test_failure_when_normalization_not_recognized(self):
@@ -319,6 +323,22 @@ class TestAveragedCrossspectrum(object):
             self.cs = AveragedCrossspectrum(self.lc1, self.lc2,
                                             segment_size=1,
                                             norm="wrong")
+
+    def test_rebin(self):
+        new_cs = self.cs.rebin(df=1.5)
+        assert new_cs.df == 1.5
+        new_cs.time_lag()
+
+    def test_rebin_factor(self):
+        new_cs = self.cs.rebin(f=1.5)
+        assert new_cs.df == self.cs.df * 1.5
+        new_cs.time_lag()
+
+    def test_rebin_log(self):
+        # For now, just verify that it doesn't crash
+        new_cs = self.cs.rebin_log(f=0.1)
+        assert type(new_cs) == type(self.cs)
+        new_cs.time_lag()
 
     def test_timelag(self):
         from ..simulator.simulator import Simulator

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -610,11 +610,29 @@ class TestLightcurveRebin(object):
             self.lc.counts[0]*dt_new/self.lc.dt
         assert np.allclose(lc_binned.counts, counts_test)
 
+    def test_rebin_even_factor(self):
+        f = 200
+        dt_new = f * self.lc.dt
+        lc_binned = self.lc.rebin(f=f)
+        assert np.isclose(dt_new, f * self.lc.dt)
+        counts_test = np.zeros_like(lc_binned.time) + \
+            self.lc.counts[0]*dt_new/self.lc.dt
+        assert np.allclose(lc_binned.counts, counts_test)
+
     def test_rebin_odd(self):
         dt_new = 1.5
         lc_binned = self.lc.rebin(dt_new)
         assert np.isclose(lc_binned.dt, dt_new)
 
+        counts_test = np.zeros_like(lc_binned.time) + \
+            self.lc.counts[0]*dt_new/self.lc.dt
+        assert np.allclose(lc_binned.counts, counts_test)
+
+    def test_rebin_odd_factor(self):
+        f = 100.5
+        dt_new = f * self.lc.dt
+        lc_binned = self.lc.rebin(f=f)
+        assert np.isclose(dt_new, f * self.lc.dt)
         counts_test = np.zeros_like(lc_binned.time) + \
             self.lc.counts[0]*dt_new/self.lc.dt
         assert np.allclose(lc_binned.counts, counts_test)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -193,7 +193,7 @@ class TestPowerspectrum(object):
         had better be 'method'
         """
         ps = Powerspectrum(lc=self.lc, norm="Leahy")
-        assert ps.rebin.__defaults__[0] == "mean"
+        assert ps.rebin.__defaults__[2] == "mean"
 
     @pytest.mark.parametrize('df', [2, 3, 5, 1.5, 1, 85])
     def test_rebin(self, df):

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -345,32 +345,50 @@ class TestAveragedPowerspectrum(object):
         segment_size = 0.5
         assert AveragedPowerspectrum(lc_all, segment_size)
 
-        def rebin_several_averagedps(self, df):
-            """
-            TODO: Not sure how to write tests for the rebin method!
-            """
+    @pytest.mark.parametrize('df', [2, 3, 5, 1.5, 1, 85])
+    def test_rebin(self, df):
+        """
+        TODO: Not sure how to write tests for the rebin method!
+        """
 
-            aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
-                                        norm="Leahy")
-            bin_aps = aps.rebin(df)
-            assert np.isclose(bin_aps.freq[1]-bin_aps.freq[0], bin_aps.df,
-                              atol=1e-4, rtol=1e-4)
-            assert np.isclose(bin_aps.freq[0],
-                              (aps.freq[0]-aps.df*0.5+bin_aps.df*0.5),
-                              atol=1e-4, rtol=1e-4)
+        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+                                    norm="Leahy")
+        bin_aps = aps.rebin(df)
+        assert np.isclose(bin_aps.freq[1]-bin_aps.freq[0], bin_aps.df,
+                          atol=1e-4, rtol=1e-4)
+        assert np.isclose(bin_aps.freq[0],
+                          (aps.freq[0]-aps.df*0.5+bin_aps.df*0.5),
+                          atol=1e-4, rtol=1e-4)
 
-        def test_rebin_averagedps(self):
-            df_all = [2, 3, 5, 1.5, 10, 45]
-            for df in df_all:
-                yield self.rebin_several, df
+    @pytest.mark.parametrize('f', [2, 3, 5, 1.5, 1, 85])
+    def test_rebin_factor(self, f):
+        """
+        TODO: Not sure how to write tests for the rebin method!
+        """
 
-        def test_rebin_with_invalid_type_attribute(self):
-            new_df = 2
-            aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
-                                        norm='leahy')
-            aps.type = 'invalid_type'
-            with pytest.raises(AttributeError):
-                assert aps.rebin(df=new_df)
+        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+                                    norm="Leahy")
+        bin_aps = aps.rebin(f=f)
+        assert np.isclose(bin_aps.freq[1]-bin_aps.freq[0], bin_aps.df,
+                          atol=1e-4, rtol=1e-4)
+        assert np.isclose(bin_aps.freq[0],
+                          (aps.freq[0]-aps.df*0.5+bin_aps.df*0.5),
+                          atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.parametrize('df', [0.01, 0.1])
+    def test_rebin_log(self, df):
+        # For now, just verify that it doesn't crash
+        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+                                    norm="Leahy")
+        bin_aps = aps.rebin_log(df)
+
+    def test_rebin_with_invalid_type_attribute(self):
+        new_df = 2
+        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+                                    norm='leahy')
+        aps.type = 'invalid_type'
+        with pytest.raises(AttributeError):
+            assert aps.rebin(df=new_df)
 
     def test_list_with_nonsense_component(self):
         n_lcs = 10


### PR DESCRIPTION
Closes #150, reboots #233

~Two changes here~:

+ `rebin_log` returns a *spectrum instance, consistently with `rebin`

+ `rebin` now accept a rebin _factor_ instead of just the new resolution, both in `Lightcurve` and in {cross,power} spectra

EDIT: Actually things turned out to be far more complicated than this. Tests did not contain the case of calculating lags from rebinned cross spectra. Well, this was were things went terribly wrong: `coherence` wanted some power spectra, that needed to be binned exactly like the main spectrum. So, in the end, I did this:

+ In `{Averaged,}Crossspectrum`, calculate the cross spectrum _and_ the power spectra of the input light curves. This operation (`_make_auxil_spectra`) was put into an `if lc1 is not lc2` condition so that this doesn't become an infinite recursion...

+ When rebinning, rebin the cross spectrum plus each spectrum in the `cs_all` attribute _and_ the input lc's power spectra.