### PR TITLE
Speedup tests and cleanup travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,19 +72,11 @@ matrix:
         - python: 3.4
           env: NUMPY_VERSION=1.11
 
-        ## Here allowed failures start
-        # Try older numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.8
-        - python: 2.7
-          env: NUMPY_VERSION=1.7
         # Try older scipy versions
         - python: 2.7
           env: SCIPY_VERSION=0.16.0
         - python: 2.7
           env: SCIPY_VERSION=0.14.0
-        - python: 2.6
-          env: SETUP_CMD='test'
 
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
@@ -95,18 +87,11 @@ matrix:
           env: ASTROPY_VERSION=development
 
     allow_failures:
-        # Try older numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.8
-        - python: 2.7
-          env: NUMPY_VERSION=1.7
         # Try older scipy versions
         - python: 2.7
           env: SCIPY_VERSION=0.16.0
         - python: 2.7
           env: SCIPY_VERSION=0.14.0
-        - python: 2.6
-          env: SETUP_CMD='test'
 
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'

--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -17,7 +17,7 @@ class TestAll(object):
         cls.tstart = 0
         cls.tend = 25.25
         cls.tseg = cls.tend - cls.tstart
-        cls.dt = 0.00606
+        cls.dt = 0.01212
         cls.times = np.arange(cls.tstart, cls.tend, cls.dt) + cls.dt / 2
         cls.counts = \
             100 + 20 * np.cos(2 * np.pi * cls.times * cls.pulse_frequency)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -121,7 +121,7 @@ class TestPowerspectrum(object):
         assert np.isclose(rms_ps, rms_lc, atol=0.01)
 
     def test_leahy_norm_correct(self):
-        time = np.linspace(0, 10.0, 1e6)
+        time = np.linspace(0, 10.0, 1e5)
         counts = np.random.poisson(1000, size=time.shape[0])
 
         lc = Lightcurve(time, counts)
@@ -417,18 +417,18 @@ class TestAveragedPowerspectrum(object):
 
     def test_leahy_correct_for_multiple(self):
 
-        n = 100
+        n = 10
         lc_all = []
         for i in range(n):
-            time = np.arange(0.0, 10.0, 10. / 100000)
+            time = np.arange(0.0, 10.0, 10. / 10000)
             counts = np.random.poisson(1000, size=time.shape[0])
             lc = Lightcurve(time, counts)
             lc_all.append(lc)
 
-        ps = AveragedPowerspectrum(lc_all, 10.0, norm="leahy")
+        ps = AveragedPowerspectrum(lc_all, 1.0, norm="leahy")
 
-        assert np.isclose(np.mean(ps.power), 2.0, atol=1e-3, rtol=1e-3)
-        assert np.isclose(np.std(ps.power), 2.0 / np.sqrt(n), atol=0.1, rtol=0.1)
+        assert np.isclose(np.mean(ps.power), 2.0, atol=1e-2, rtol=1e-2)
+        assert np.isclose(np.std(ps.power), 2.0 / np.sqrt(n*10), atol=0.1, rtol=0.1)
 
 
 class TestClassicalSignificances(object):

--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -137,7 +137,7 @@ class TestRMSEnergySpectrum(object):
     def setup_class(cls):
         from ..simulator.simulator import Simulator
 
-        simulator = Simulator(0.1, 10000, rms=0.4, mean=200)
+        simulator = Simulator(0.1, 1000, rms=0.4, mean=200)
         test_lc = simulator.simulate(1)
         test_ev1, test_ev2 = EventList(), EventList()
         test_ev1.simulate_times(test_lc)
@@ -154,7 +154,7 @@ class TestRMSEnergySpectrum(object):
     def test_correct_rms_values(self):
         # Assert that it is close to 0.4 (since we don't have infinite spectral
         # coverage, it will be a little less!)
-        assert np.allclose(self.rms.spectrum, 0.37, 0.05)
+        assert np.allclose(self.rms.spectrum, 0.4, 0.05)
 
     def test_correct_rms_errorbars(self):
 
@@ -181,7 +181,7 @@ class TestLagEnergySpectrum(object):
     def setup_class(cls):
         from ..simulator.simulator import Simulator
         dt = 0.1
-        simulator = Simulator(dt, 10000, rms=0.4, mean=200)
+        simulator = Simulator(dt, 1000, rms=0.4, mean=200)
         test_lc1 = simulator.simulate(2)
         test_lc2 = Lightcurve(test_lc1.time,
                               np.array(np.roll(test_lc1.counts, 2)),


### PR DESCRIPTION
+ Cleanup .travis-ci.yml from Python and bumpy versions unsupported by Astropy

+ Speedup some test suites that were above 30 s each (I leave test_parameterestimation to @dhuppenkothen's next PR)