### PR TITLE
Fixed behaviour of sort

### DIFF
--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -227,6 +227,7 @@ def create_gti_mask_complete(time, gtis, safe_interval=0, min_length=0,
                               np.zeros_like(time) +
                               np.median(np.diff(time)))
 
+    dt = assign_value_if_none(dt, np.median(dt_array) / 2)
     mask = np.zeros(len(time), dtype=bool)
 
     if not isinstance(safe_interval, collections.Iterable):

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -225,9 +225,8 @@ def create_gti_mask_complete(time, gtis, safe_interval=0, min_length=0,
 
     dt = assign_value_if_none(dt,
                               np.zeros_like(time) +
-                              np.median(np.diff(time)))
+                              np.median(np.diff(np.sort(time)) / 2))
 
-    dt = assign_value_if_none(dt, np.median(dt_array) / 2)
     mask = np.zeros(len(time), dtype=bool)
 
     if not isinstance(safe_interval, collections.Iterable):

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -861,7 +861,7 @@ class Lightcurve(object):
 
     def sort(self, reverse=False):
         """
-        Sort a Lightcurve object in accordance by time.
+        Sort a Lightcurve object by time.
 
         A Lightcurve can be sorted in either increasing or decreasing order
         using this method. The time array gets sorted and the counts array is
@@ -902,7 +902,7 @@ class Lightcurve(object):
 
     def sort_counts(self, reverse=False):
         """
-        Sort a Lightcurve object in accordance by counts.
+        Sort a Lightcurve object by counts.
 
         A Lightcurve can be sorted in either increasing or decreasing order
         using this method. The counts array gets sorted and the time array is

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -66,7 +66,6 @@ class Lightcurve(object):
         mjdref: float
             MJD reference (useful in most high-energy mission data)
 
-
         Attributes
         ----------
         time: numpy.ndarray
@@ -183,7 +182,6 @@ class Lightcurve(object):
         self.bin_hi = self.time + 0.5 * self.dt
 
         self.err_dist = err_dist
-
 
         if unsorted:
             self.tstart = np.min(self.time) - 0.5 * self.dt

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -164,9 +164,11 @@ class Lightcurve(object):
         self.mjdref = mjdref
         self.time = np.asarray(time)
         dt_array = np.diff(np.sort(self.time))
+        dt_array_unsorted = np.diff(self.time)
+        unsorted = np.any(dt_array_unsorted < 0)
 
         if dt is None:
-            if np.any(np.diff(self.time) < 0):
+            if unsorted:
                 logging.warning("The light curve is unordered! This may cause "
                                 "unexpected behaviour in some methods! Use "
                                 "sort() to order the light curve in time and "
@@ -182,8 +184,13 @@ class Lightcurve(object):
 
         self.err_dist = err_dist
 
-        self.tstart = np.min(self.time) - 0.5*self.dt
-        self.tseg = np.max(self.time) - np.min(self.time) + self.dt
+
+        if unsorted:
+            self.tstart = np.min(self.time) - 0.5 * self.dt
+            self.tseg = np.max(self.time) - np.min(self.time) + self.dt
+        else:
+            self.tstart = self.time[0] - 0.5*self.dt
+            self.tseg = self.time[-1] - self.time[0] + self.dt
 
         self.gti = \
             np.asarray(assign_value_if_none(gti,

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -230,7 +230,6 @@ class Lightcurve(object):
                   "This could cause problems with Fourier transforms. "
                   "Please make the input time evenly sampled.")
 
-
     def change_mjdref(self, new_mjdref):
         """Change the MJDREF of the light curve.
 
@@ -291,8 +290,9 @@ class Lightcurve(object):
                   "We are setting the errors to zero to avoid complications.")
             new_counts_err = np.zeros_like(new_counts)
         elif self.err_dist.lower() in valid_statistics:
-                new_counts_err = np.sqrt(np.add(self.counts_err[mask_self]**2,
-                                                other.counts_err[mask_other]**2))
+                new_counts_err = \
+                    np.sqrt(np.add(self.counts_err[mask_self]**2,
+                                   other.counts_err[mask_other]**2))
             # More conditions can be implemented for other statistics
         else:
             raise StingrayError("Statistics not recognized."
@@ -450,7 +450,7 @@ class Lightcurve(object):
             raise IndexError("The index must be either an integer or a slice "
                              "object !")
 
-    def __eq__(self,other_lc):
+    def __eq__(self, other_lc):
         """
         Compares two :class:`Lightcurve` objects.
 
@@ -468,7 +468,8 @@ class Lightcurve(object):
         """
         if not isinstance(other_lc, Lightcurve):
             raise ValueError('Lightcurve can only be compared with a Lightcurve Object')
-        if (np.allclose(self.time, other_lc.time) and np.allclose(self.counts, other_lc.counts)):
+        if (np.allclose(self.time, other_lc.time) and
+                np.allclose(self.counts, other_lc.counts)):
             return True
         return False
 
@@ -619,7 +620,6 @@ class Lightcurve(object):
             raise ValueError("New time resolution must be larger than "
                              "old time resolution!")
 
-
         if self.gti is None:
 
             bin_time, bin_counts, bin_err, _ = \
@@ -629,7 +629,7 @@ class Lightcurve(object):
         else:
             bin_time, bin_counts, bin_err = [], [], []
             gti_new = []
-            for g  in self.gti:
+            for g in self.gti:
                 if g[1] - g[0] < dt_new:
                     continue
                 else:
@@ -697,7 +697,7 @@ class Lightcurve(object):
         if self.dt != other.dt:
             utils.simon("The two light curves have different bin widths.")
 
-        if( self.tstart < other.tstart ):
+        if(self.tstart < other.tstart):
             first_lc = self
             second_lc = other
         else:
@@ -717,7 +717,6 @@ class Lightcurve(object):
                 simon("Lightcurves have different statistics!"
                       "We are setting the errors to zero.")
 
-
             elif self.err_dist.lower() in valid_statistics:
                 valid_err = True
             # More conditions can be implemented for other statistics
@@ -725,7 +724,6 @@ class Lightcurve(object):
                 raise StingrayError("Statistics not recognized."
                                     " Please use one of these: "
                                     "{}".format(valid_statistics))
-
 
             from collections import Counter
             counts = Counter()
@@ -737,10 +735,11 @@ class Lightcurve(object):
 
             for i, time in enumerate(second_lc.time):
 
-                if (counts.get(time) != None): #Common time
-
-                    counts[time] = (counts[time] + second_lc.counts[i]) / 2  #avg
-                    counts_err[time] = np.sqrt(( ((counts_err[time]**2) + (second_lc.counts_err[i] **2)) / 2))
+                if counts.get(time) is not None:  # Common time
+                    counts[time] = (counts[time] + second_lc.counts[i]) / 2
+                    counts_err[time] = \
+                        np.sqrt(((counts_err[time] **2 ) +
+                                 (second_lc.counts_err[i] ** 2)) / 2)
 
                 else:
                     counts[time] = second_lc.counts[i]
@@ -759,7 +758,8 @@ class Lightcurve(object):
 
             new_time = np.concatenate([first_lc.time, second_lc.time])
             new_counts = np.concatenate([first_lc.counts, second_lc.counts])
-            new_counts_err = np.concatenate([first_lc.counts_err, second_lc.counts_err])
+            new_counts_err = \
+                np.concatenate([first_lc.counts_err, second_lc.counts_err])
 
         new_time = np.asarray(new_time)
         new_counts = np.asarray(new_counts)
@@ -770,7 +770,6 @@ class Lightcurve(object):
                             mjdref=self.mjdref, dt=self.dt)
 
         return lc_new
-
 
     def truncate(self, start=0, stop=None, method="index"):
         """
@@ -890,10 +889,9 @@ class Lightcurve(object):
             arrays.
         """
 
-        new_time, new_counts, new_counts_err = zip(*sorted(zip(self.time,
-                                                               self.counts,
-                                                               self.counts_err)
-                                                           , reverse=reverse))
+        new_time, new_counts, new_counts_err = \
+            zip(*sorted(zip(self.time, self.counts, self.counts_err),
+                        reverse=reverse))
 
         new_lc = Lightcurve(new_time, new_counts, err=new_counts_err,
                             gti=self.gti, dt=self.dt, mjdref=self.mjdref)
@@ -939,6 +937,7 @@ class Lightcurve(object):
                             gti=self.gti, dt=self.dt, mjdref=self.mjdref)
 
         return new_lc
+
     def estimate_chunk_length(self, min_total_counts=100, min_time_bins=100):
         """Choose a reasonable chunk length.
 
@@ -1005,8 +1004,8 @@ class Lightcurve(object):
         Other parameters
         ----------------
         fraction_step : float
-            If the step is not a full chunk_length but less (e.g. a moving window),
-            this indicates the ratio between step step and `chunk_length` (e.g.
+            If the step is not a full chunk_length but less (e.g. a moving
+            window), this indicates the ratio between step step and `chunk_length` (e.g.
             0.5 means that the window shifts of half chunk_length)
         kwargs : keyword arguments
             These additional keyword arguments, if present, they will be passed

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -564,22 +564,42 @@ class TestLightcurve(object):
         assert lc2.mjdref == lc.mjdref
 
     def test_sort(self):
+        _times = [2, 1, 3, 4]
+        _counts = [40, 10, 20, 5]
+        lc = Lightcurve(_times, _counts, mjdref=57000)
+        mjdref = lc.mjdref
+
+        lc_new = lc.sort()
+
+        assert np.all(lc_new.counts == np.array([10, 40, 20, 5]))
+        assert np.all(lc_new.time == np.array([1, 2, 3, 4]))
+        assert lc_new.mjdref == mjdref
+
+        lc_new = lc.sort(reverse=True)
+
+        assert np.all(lc_new.counts == np.array([5, 20, 40,  10]))
+        assert np.all(lc_new.time == np.array([4, 3, 2, 1]))
+        assert lc_new.mjdref == mjdref
+
+    def test_sort_counts(self):
         _times = [1, 2, 3, 4]
         _counts = [40, 10, 20, 5]
         lc = Lightcurve(_times, _counts, mjdref=57000)
         mjdref = lc.mjdref
 
-        lc.sort()
+        lc_new = lc.sort_counts()
 
-        assert np.all(lc.counts == np.array([5, 10, 20, 40]))
-        assert np.all(lc.time == np.array([4, 2, 3, 1]))
-        assert lc.mjdref == mjdref
+        assert np.all(lc_new.counts == np.array([5, 10, 20, 40]))
+        assert np.all(lc_new.time == np.array([4, 2, 3, 1]))
+        assert lc_new.mjdref == mjdref
 
-        lc.sort(reverse=True)
+        lc_new = lc.sort_counts(reverse=True)
 
-        assert np.all(lc.counts == np.array([40, 20, 10,  5]))
-        assert np.all(lc.time == np.array([1, 3, 2, 4]))
-        assert lc.mjdref == mjdref
+        assert np.all(lc_new.counts == np.array([40, 20, 10,  5]))
+        assert np.all(lc_new.time == np.array([1, 3, 2, 4]))
+        assert lc_new.mjdref == mjdref
+
+
 
     def test_sort_reverse(self):
         times = np.arange(1000)


### PR DESCRIPTION
`sort()` currently sorts only by counts. This is great, but it's not what I expected for a time series (I expected it to sort by time). It also turns out there are some issues that appear when the time bins are out of order. 

This PR should fix those issues, and implements `sort()` as sorting by time bin, and `sort_counts()` to sort by counts.