### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,13 +73,13 @@ Contents
 Future Additions
 ----------------
 - bicoherence
-- spectral-timing functionality
+- phase-resolved spectroscopy of QPOs
+- Fourier-frequency-resolved spectroscopy
 - power colours
 - full HEASARC-compatible mission support
-- graphical interface (see StingraySoftware/DAVE)
-- (...) Feel free to propose! Use the `Issues`_ page!
 - pulsar searches with $H$-test
 - binary pulsar searches
+- (...) Feel free to propose! Use the `Issues`_ page!
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Contents
 - cross spectra, r.m.s. spectra and lags (time vs energy, time vs frequency)
 - covariance spectra
 - bispectra
-- Bayesian QPO searches
+- Bayesian quasi-periodic oscillation searches
 - simulate a light curve with a given power spectrum
 - simulate a light curve from another light curve and a 1-d (time) or 2-d (time-energy) impulse response
 - simulate an event list from a given light curve _and_ with a given energy spectrum
@@ -73,7 +73,7 @@ Contents
 Future Additions
 ----------------
 - bicoherence
-- phase-resolved spectroscopy of QPOs
+- phase-resolved spectroscopy of quasi-periodic oscillations
 - Fourier-frequency-resolved spectroscopy
 - power colours
 - full HEASARC-compatible mission support


### PR DESCRIPTION
Changed "spectral-timing functionality" to "phase-resolved spectroscopy of QPOs" to be more precise, added "fourier frequency resolved spectroscopy", and moved the "add your own!" to the end of the list.