### PR TITLE
Fixes Type Error in EventList.from_lc

### DIFF
--- a/stingray/events.py
+++ b/stingray/events.py
@@ -142,7 +142,7 @@ class EventList(object):
         """
 
         # Multiply times by number of counts
-        times = [[i] * j for i,j in zip(lc.time, lc.counts)]
+        times = [[i] * int(j) for i,j in zip(lc.time, lc.counts)]
         # Concatenate all lists
         times = [i for j in times for i in j]
 


### PR DESCRIPTION
Running following code,
![image](https://user-images.githubusercontent.com/10584638/29724044-7aad2cbc-89e0-11e7-9294-99680c45fe6e.png)
Produced Type Error,
![image](https://user-images.githubusercontent.com/10584638/29724073-8e54128a-89e0-11e7-9d75-6f6f309c8cc7.png)

This PR fixes this. j in lc.counts has to be int to produce required number of array elements.
![image](https://user-images.githubusercontent.com/10584638/29724135-bd8b63b4-89e0-11e7-80fb-6ddad4d180ed.png)
