### PR TITLE
Fix excess variance error bar; allow normalized excess variance; fix GTI behavior during slicing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,14 +72,15 @@ matrix:
         - python: 3.4
           env: NUMPY_VERSION=1.11
 
+        - python: 3.6
+          env: SETUP_CMD='build_docs -w'
+
         # Try older scipy versions
         - python: 2.7
           env: SCIPY_VERSION=0.16.0
         - python: 2.7
           env: SCIPY_VERSION=0.14.0
 
-        - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development
@@ -93,8 +94,6 @@ matrix:
         - python: 2.7
           env: SCIPY_VERSION=0.14.0
 
-        - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ environment:
         PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
-        CONDA_DEPENDENCIES: "scipy numpy nose h5py astropy matplotlib"
-        PIP_DEPENDENCIES: "emcee statsmodels pytest-catchlog"
+        CONDA_DEPENDENCIES: "scipy numpy nose h5py astropy matplotlib statsmodels"
+        PIP_DEPENDENCIES: "emcee pytest-catchlog"
 
     matrix:
 

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -379,14 +379,23 @@ def baseline_als(y, lam, p, niter=10):
 
 def excess_variance(lc, normalization='fvar'):
     """Calculate the excess variance.
+
     Vaughan et al. 2003, MNRAS 345, 1271 give three measurements of source
-    intrinsic variance: the *excess variance*, defined as
-    .. math:: \sigma_{XS} = S^2 - \overline{\sigma_{err}^2}
-    the *normalized excess variance*, defined as
-    .. math:: \sigma_{NXS} = \sigma_{XS} / \overline{x^2}
-    and the *fractional mean square variability amplitude*, or
-    :math:`F_{var}`, defined as
-    .. math:: F_{var} = \sqrt{\dfrac{\sigma_{XS}}{\overline{x^2}}}
+    intrinsic variance: if a light curve has a total variance of :math:`S^2`,
+    and each point has an errorbar :math:`\sigma_{err}`, the *excess variance*
+    is defined as
+
+    .. math:: \sigma_{XS} = S^2 - \overline{\sigma_{err}}^2;
+
+    the *normalized excess variance* is the excess variance divided by the
+    square of the mean intensity:
+
+    .. math:: \sigma_{NXS} = \dfrac{\sigma_{XS}}{\overline{x}^2};
+
+    the *fractional mean square variability amplitude*, or
+    :math:`F_{var}`, is finally defined as
+
+    .. math:: F_{var} = \sqrt{\dfrac{\sigma_{XS}}{\overline{x}^2}}
 
     Parameters
     ----------

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -379,16 +379,23 @@ def baseline_als(y, lam, p, niter=10):
 
 def excess_variance(lc, normalization='fvar'):
     """Calculate the excess variance.
-
-    Vaughan+03
+    Vaughan et al. 2003, MNRAS 345, 1271 give three measurements of source
+    intrinsic variance: the *excess variance*, defined as
+    .. math:: \sigma_{XS} = S^2 - \overline{\sigma_{err}^2}
+    the *normalized excess variance*, defined as
+    .. math:: \sigma_{NXS} = \sigma_{XS} / \overline{x^2}
+    and the *fractional mean square variability amplitude*, or
+    :math:`F_{var}`, defined as
+    .. math:: F_{var} = \sqrt{\dfrac{\sigma_{XS}}{\overline{x^2}}}
 
     Parameters
     ----------
     lc : a :class:`Lightcurve` object
     normalization : str
-        if 'fvar', return normalized square-root excess variance. If 'none',
-        return the unnormalized variance
-
+        if 'fvar', return the fractional mean square variability :math:`F_{var}`.
+        If 'none', return the unnormalized excess variance variance
+        :math:`\sigma_{XS}`. If 'norm_xs', return the normalized excess variance
+        :math:`\sigma_{XS}`
     Returns
     -------
     var_xs : float
@@ -399,20 +406,23 @@ def excess_variance(lc, normalization='fvar'):
     var_xs = lc_actual_var - lc_mean_var
     mean_lc = np.mean(lc.counts)
     mean_ctvar = mean_lc ** 2
+    var_nxs = var_xs / mean_lc ** 2
 
     fvar = np.sqrt(var_xs / mean_ctvar)
 
     N = len(lc.counts)
-    var_xs_err_A = np.sqrt(2 / N) * lc_mean_var / mean_lc ** 2
-    var_xs_err_B = np.sqrt(mean_lc ** 2 / N) * 2 * fvar / mean_lc
-    var_xs_err = np.sqrt(var_xs_err_A ** 2 + var_xs_err_B ** 2)
+    var_nxs_err_A = np.sqrt(2 / N) * lc_mean_var / mean_lc ** 2
+    var_nxs_err_B = np.sqrt(mean_lc ** 2 / N) * 2 * fvar / mean_lc
+    var_nxs_err = np.sqrt(var_nxs_err_A ** 2 + var_nxs_err_B ** 2)
 
-    fvar_err = var_xs_err / (2 * fvar)
+    fvar_err = var_nxs_err / (2 * fvar)
 
     if normalization == 'fvar':
         return fvar, fvar_err
+    elif normalization == 'norm_xs':
+        return var_nxs, var_nxs_err
     elif normalization == 'none' or normalization is None:
-        return var_xs, var_xs_err
+        return var_xs, var_nxs_err * mean_lc **2
 
 
 def create_window(N, window_type='uniform'):


### PR DESCRIPTION
This has been triggered by Issue 282 in DAVE. That's probably not an issue, but I did find a mistake in the error bar calculation for the unnormalized excess variance. I took the chance to document the function better and to allow both normalized and unnormalized excess variance.

ADD: During tests of this new functionality, I discovered a bug in the slice operation with light curves, where GTIs were forgotten. I fixed this and tested it properly.