### PR TITLE
ParammeterEstimation: SamplingResults.plot_results bug fix

### DIFF
--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -876,7 +876,7 @@ class SamplingResults(object):
         """
         assert can_plot, "Need to have matplotlib installed for plotting"
         if use_corner:
-            corner.corner(self.samples, labels=None, fig=fig, bins=int(20),
+            fig = corner.corner(self.samples, labels=None, fig=fig, bins=int(20),
                           quantiles=[0.16, 0.5, 0.84],
                           show_titles=True, title_args={"fontsize": 12})
 


### PR DESCRIPTION
Solved bug when fig is None and using corner.