### PR TITLE
== operator for lc

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -434,26 +434,26 @@ class Lightcurve(object):
                              "object !")
 
     def __eq__(self,other_lc):
-    """
-        Compares two :class:`Lightcurve` objects.
-        
-        Light curves are equal only if their counts as well as times at which those counts occur equal.
-        
-        Example
-        -------
-        >>> time = [1, 2, 3]
-        >>> count1 = [100, 200, 300]
-        >>> count2 = [100, 200, 300]
-        >>> lc1 = Lightcurve(time, count1)
-        >>> lc2 = Lightcurve(time, count2)
-        >>> lc1 == lc2
-        True
-    """
-    if not isinstance(other_lc, Lightcurve):
-        raise ValueError('Lightcurve can only be compared with a Lightcurve Object')
-    if (np.allclose(self.time, other_lc.time) and np.allclose(self.counts, other_lc.counts)):
-        return True
-    return False
+	    """
+	        Compares two :class:`Lightcurve` objects.
+	        
+	        Light curves are equal only if their counts as well as times at which those counts occur equal.
+	        
+	        Example
+	        -------
+	        >>> time = [1, 2, 3]
+	        >>> count1 = [100, 200, 300]
+	        >>> count2 = [100, 200, 300]
+	        >>> lc1 = Lightcurve(time, count1)
+	        >>> lc2 = Lightcurve(time, count2)
+	        >>> lc1 == lc2
+	        True
+	    """
+	    if not isinstance(other_lc, Lightcurve):
+	        raise ValueError('Lightcurve can only be compared with a Lightcurve Object')
+	    if (np.allclose(self.time, other_lc.time) and np.allclose(self.counts, other_lc.counts)):
+	        return True
+	    return False
 
     def baseline(self, lam, p, niter=10):
         """Calculate the baseline of the light curve, accounting for GTIs.

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -433,6 +433,28 @@ class Lightcurve(object):
             raise IndexError("The index must be either an integer or a slice "
                              "object !")
 
+    def __eq__(self,other_lc):
+    """
+        Compares two :class:`Lightcurve` objects.
+        
+        Light curves are equal only if their counts as well as times at which those counts occur equal.
+        
+        Example
+        -------
+        >>> time = [1, 2, 3]
+        >>> count1 = [100, 200, 300]
+        >>> count2 = [100, 200, 300]
+        >>> lc1 = Lightcurve(time, count1)
+        >>> lc2 = Lightcurve(time, count2)
+        >>> lc1 == lc2
+        True
+    """
+    if not isinstance(other_lc, Lightcurve):
+        raise ValueError('Lightcurve can only be compared with a Lightcurve Object')
+    if (np.allclose(self.time, other_lc.time) and np.allclose(self.counts, other_lc.counts)):
+        return True
+    return False
+
     def baseline(self, lam, p, niter=10):
         """Calculate the baseline of the light curve, accounting for GTIs.
 

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -750,3 +750,36 @@ class TestLightcurveRebin(object):
         lc._apply_gtis()
         assert lc.n == 3
         assert np.all(lc.time == np.array([0, 1, 2]))
+
+    def test_eq_operator(self):
+        time = [1, 2, 3]
+        count1 = [100, 200, 300]
+        count2 = [100, 200, 300]
+        lc1 = Lightcurve(time, count1)
+        lc2 = Lightcurve(time, count2)
+        assert lc1 == lc2
+
+    def test_eq_bad_lc(self):
+        time = [1, 2, 3]
+        count1 = [100, 200, 300]
+        count2 = [100, 200, 300]
+        lc1 = Lightcurve(time, count1)
+        with pytest.raises(ValueError):
+            lc1 == count2
+
+    def test_eq_different_times(self):
+        time1 = [1, 2, 3]
+        time2 = [2, 3, 4]
+        count1 = [100, 200, 300]
+        count2 = [100, 200, 300]
+        lc1 = Lightcurve(time1, count1)
+        lc2 = Lightcurve(time2, count2)
+        assert not lc1 == lc2
+
+    def test_eq_different_counts(self):
+        time = [1, 2, 3, 4]
+        count1 = [5, 10, 15, 20]
+        count2 = [2, 4, 5, 8]
+        lc1 = Lightcurve(time, count1)
+        lc2 = Lightcurve(time, count2)
+        assert not lc1 == lc2


### PR DESCRIPTION
== operator is overloaded to compare two lightcurves. For now, only condition for two lc's to be equal is that their times and count arrays are equal. I think it covers all other properties since they are calculated from these two basic inputs to lightcurve.