### PR TITLE
Fixed variable name

### DIFF
--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -29,7 +29,7 @@ class Simulator(object):
         red_noise : int, default 1
             multiple of real length of light curve, by
             which to simulate, to avoid red noise leakage
-        seed : int, default None
+        random_state : int, default None
             seed value for random processes
         """
 


### PR DESCRIPTION
The `random_state` variable of the Simulator.simulate method was shown as `seed` in the help text.