### PR TITLE
Substitute max() with np.max, and same for min, everywhere

### DIFF
--- a/stingray/events.py
+++ b/stingray/events.py
@@ -50,6 +50,9 @@ class EventList(object):
         pi : integer, numpy.ndarray
             PI channels
 
+        notes : str
+            Any useful annotations
+
         Attributes
         ----------
         time: numpy.ndarray

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -19,8 +19,8 @@ __all__ = ['EventList']
 
 
 class EventList(object):
-    def __init__(self, time=None, energy=None, ncounts=None, mjdref=0, dt=0, notes="",
-            gti=None, pi=None):
+    def __init__(self, time=None, energy=None, ncounts=None, mjdref=0, dt=0,
+                 notes="", gti=None, pi=None):
         """
         Make an event list object from an array of time stamps
 
@@ -208,12 +208,13 @@ class EventList(object):
         # Calculate cumulative probability
         cum_prob = np.cumsum(prob)
 
-        # Draw N random numbers between 0 and 1, where N is the size of event list
+        # Draw N random numbers between 0 and 1, where N is the size of event
+        # list
         R = ra.uniform(0, 1, self.ncounts)
 
         # Assign energies to events corresponding to the random numbers drawn
         self.energy = np.array([energy[np.argwhere(cum_prob ==
-            min(cum_prob[(cum_prob - r) > 0]))] for r in R])
+            np.min(cum_prob[(cum_prob - r) > 0]))] for r in R])
 
     def join(self, other):
         """
@@ -274,7 +275,8 @@ class EventList(object):
         if (self.energy is None) and (other.energy is None):
             ev_new.energy = None
         elif (self.energy is None) or (other.energy is None):
-            self.energy = assign_value_if_none(self.energy, np.zeros_like(self.time))
+            self.energy = assign_value_if_none(self.energy,
+                                               np.zeros_like(self.time))
             other.energy = assign_value_if_none(other.energy,
                                              np.zeros_like(other.time))
 
@@ -284,14 +286,14 @@ class EventList(object):
 
         if self.gti is None and other.gti is not None and len(self.time) > 0:
             self.gti = \
-                assign_value_if_none(self.gti,
-                                     np.asarray([[self.time[0] - self.dt / 2,
-                                                  self.time[-1] + self.dt / 2]]))
+                assign_value_if_none(
+                    self.gti, np.asarray([[self.time[0] - self.dt / 2,
+                                           self.time[-1] + self.dt / 2]]))
         if other.gti is None and self.gti is not None and len(other.time) > 0:
             other.gti = \
-                assign_value_if_none(other.gti,
-                                     np.asarray([[other.time[0] - other.dt / 2,
-                                                  other.time[-1] + other.dt / 2]]))
+                assign_value_if_none(
+                    other.gti, np.asarray([[other.time[0] - other.dt / 2,
+                                            other.time[-1] + other.dt / 2]]))
 
         if (self.gti is None) and (other.gti is None):
             ev_new.gti = None
@@ -345,8 +347,9 @@ class EventList(object):
                 else:
                     values.append(None)
                     
-            return EventList(time=values[0], energy=values[1], ncounts=values[2],
-                mjdref=values[3], dt=values[4], notes=values[5], gti=values[6], pi=values[7])
+            return EventList(time=values[0], energy=values[1],
+                             ncounts=values[2], mjdref=values[3], dt=values[4],
+                             notes=values[5], gti=values[6], pi=values[7])
 
         elif format_ == 'pickle':
             return data

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -263,7 +263,7 @@ def cross_two_gtis(gti0, gti1):
             st = gti_start[this_series][st_pos]
             so = gti_start[other_series][so_pos]
 
-            s = max([st, so])
+            s = np.max([st, so])
         except:  # pragma: no cover
             continue
 
@@ -429,8 +429,8 @@ def append_gtis(gti0, gti1):
 def join_gtis(gti0, gti1):
     """Union of two GTIs.
 
-    If GTIs are mutually exclusive, it calls `append_gtis`. Otherwise we put the
-    extremes of partially overlapping GTIs on an ideal line and look at the
+    If GTIs are mutually exclusive, it calls `append_gtis`. Otherwise we put
+    the extremes of partially overlapping GTIs on an ideal line and look at the
     number of opened and closed intervals. When the number of closed and opened
     intervals is the same, the full GTI is complete and we close it.
 

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -903,7 +903,7 @@ class SamplingResults(object):
                         ntemp, binstemp, patchestemp = \
                             ax.hist(samples[:, i], 30, normed=True,
                                     histtype='stepfilled')
-                        ax.axis([ymin, ymax, 0, max(ntemp)*1.2])
+                        ax.axis([ymin, ymax, 0, np.max(ntemp)*1.2])
 
                     else:
 
@@ -1243,8 +1243,8 @@ class PSDParEst(ParameterEstimation):
 
                 p1, = s1.plot(logx, logy, color='black', linestyle='steps-mid')
                 p2, = s1.plot(logx, logpar1, color='blue', lw=2)
-                s1.set_xlim([min(logx), max(logx)])
-                s1.set_ylim([min(logy)-1.0, max(logy)+1])
+                s1.set_xlim([np.min(logx), np.max(logx)])
+                s1.set_ylim([np.min(logy)-1.0, np.max(logy)+1])
                 if self.ps.norm == "leahy":
                     s1.set_ylabel('log(Leahy-Normalized Power)', fontsize=18)
                 elif self.ps.norm == "rms":
@@ -1261,9 +1261,9 @@ class PSDParEst(ParameterEstimation):
                 s1.set_xscale("log")
                 s1.set_yscale("log")
 
-                s1.set_xlim([min(self.ps.freq), max(self.ps.freq)])
-                s1.set_ylim([min(self.ps.freq)/10.0,
-                             max(self.ps.power)*10.0])
+                s1.set_xlim([np.min(self.ps.freq), np.max(self.ps.freq)])
+                s1.set_ylim([np.min(self.ps.freq)/10.0,
+                             np.max(self.ps.power)*10.0])
 
                 if self.ps.norm == "leahy":
                     s1.set_ylabel('Leahy-Normalized Power', fontsize=18)
@@ -1297,8 +1297,8 @@ class PSDParEst(ParameterEstimation):
                 s2.plot(logx, pldif, color='black', linestyle='steps-mid')
                 s2.plot(logx, np.ones(self.ps.freq.shape[0]),
                         color='blue', lw=2)
-                s2.set_xlim([min(logx), max(logx)])
-                s2.set_ylim([min(pldif), max(pldif)])
+                s2.set_xlim([np.min(logx), np.max(logx)])
+                s2.set_ylim([np.min(pldif), np.max(pldif)])
 
             else:
                 s2.plot(self.ps.freq, pldif, color='black',
@@ -1308,8 +1308,8 @@ class PSDParEst(ParameterEstimation):
 
                 s2.set_xscale("log")
                 s2.set_yscale("log")
-                s2.set_xlim([min(self.ps.freq), max(self.ps.freq)])
-                s2.set_ylim([min(pldif), max(pldif)])
+                s2.set_xlim([np.min(self.ps.freq), np.max(self.ps.freq)])
+                s2.set_ylim([np.min(pldif), np.max(pldif)])
 
             if res2 is not None:
                 bpldif = self.ps.power/res2.mfit
@@ -1321,7 +1321,7 @@ class PSDParEst(ParameterEstimation):
                     s3.plot(logx, bpldif, color='black', linestyle='steps-mid')
                     s3.plot(logx, np.ones(len(self.ps.freq)),
                             color='red', lw=2)
-                    s3.axis([min(logx), max(logx), min(bpldif), max(bpldif)])
+                    s3.axis([np.min(logx), np.max(logx), np.min(bpldif), np.max(bpldif)])
                     s3.set_xlabel("log(Frequency) [Hz]", fontsize=18)
 
                 else:
@@ -1331,8 +1331,8 @@ class PSDParEst(ParameterEstimation):
                             color='red', lw=2)
                     s3.set_xscale("log")
                     s3.set_yscale("log")
-                    s3.set_xlim([min(self.ps.freq), max(self.ps.freq)])
-                    s3.set_ylim([min(bpldif), max(bpldif)])
+                    s3.set_xlim([np.min(self.ps.freq), np.max(self.ps.freq)])
+                    s3.set_ylim([np.min(bpldif), np.max(bpldif)])
                     s3.set_xlabel("Frequency [Hz]", fontsize=18)
 
                 s3.set_ylabel("Residuals, \n second model",

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -140,8 +140,8 @@ def phase_exposure(start_time, stop_time, period, nbin=16, gtis=None):
             goodbins = np.logical_and(phs[:, 0] <= l1, phs[:, 1] >= l0)
             idxs = np.arange(len(phs), dtype=int)[goodbins]
             for i in idxs:
-                start = max([phs[i, 0], l0])
-                stop = min([phs[i, 1], l1])
+                start = np.max([phs[i, 0], l0])
+                stop = np.min([phs[i, 1], l1])
                 w = stop - start
                 expo[i] += w
 

--- a/stingray/simulator/base.py
+++ b/stingray/simulator/base.py
@@ -53,14 +53,14 @@ def simulate_times(lc, use_spline=False, bin_time=None):
     while bin_start < n_bin:
 
         t0 = times[bin_start]
-        bin_stop = min([bin_start + max_bin, n_bin + 1])
+        bin_stop = np.min([bin_start + max_bin, n_bin + 1])
 
         lc_filt = counts[bin_start:bin_stop]
         t_filt = times[bin_start:bin_stop]
         length = t_filt[-1] - t_filt[0]
 
         n_bin_filt = len(lc_filt)
-        n_to_simulate = n_bin_filt * max(lc_filt)
+        n_to_simulate = n_bin_filt * np.max(lc_filt)
         safety_factor = 10
 
         if n_to_simulate > 10000:
@@ -73,7 +73,7 @@ def simulate_times(lc, use_spline=False, bin_time=None):
         random_ts = ra.uniform(t_filt[0] - bin_time / 2,
                                t_filt[-1] + bin_time / 2, n_to_simulate)
 
-        random_amps = ra.uniform(0, max(lc_filt), n_to_simulate)
+        random_amps = ra.uniform(0, np.max(lc_filt), n_to_simulate)
 
         if use_spline:
             lc_spl = sci.splrep(t_filt, lc_filt, s=np.longdouble(0), k=1)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -199,8 +199,8 @@ class TestCrossspectrum(object):
 
     def test_timelag(self):
         time_lag = self.cs.time_lag()
-        assert max(time_lag) <= np.pi
-        assert min(time_lag) >= -np.pi
+        assert np.max(time_lag) <= np.pi
+        assert np.min(time_lag) >= -np.pi
 
     def test_nonzero_err(self):
         assert np.all(self.cs.power_err > 0)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -203,7 +203,8 @@ class TestPowerspectrum(object):
         bin_ps = ps.rebin(df)
         assert np.isclose(bin_ps.freq[1] - bin_ps.freq[0], bin_ps.df,
                           atol=1e-4, rtol=1e-4)
-        assert np.isclose(bin_ps.freq[0], (ps.freq[0] - ps.df * 0.5 + bin_ps.df * 0.5),
+        assert np.isclose(bin_ps.freq[0],
+                          (ps.freq[0] - ps.df * 0.5 + bin_ps.df * 0.5),
                           atol=1e-4, rtol=1e-4)
 
     def test_classical_significances_runs(self):
@@ -437,7 +438,8 @@ class TestAveragedPowerspectrum(object):
         ps = AveragedPowerspectrum(lc_all, 1.0, norm="leahy")
 
         assert np.isclose(np.mean(ps.power), 2.0, atol=1e-2, rtol=1e-2)
-        assert np.isclose(np.std(ps.power), 2.0 / np.sqrt(n*10), atol=0.1, rtol=0.1)
+        assert np.isclose(np.std(ps.power), 2.0 / np.sqrt(n*10), atol=0.1,
+                          rtol=0.1)
 
 
 class TestClassicalSignificances(object):
@@ -574,8 +576,8 @@ class TestDynamicalPowerspectrum(object):
         dps = DynamicalPowerspectrum(self.lc, segment_size=3)
         max_pos = dps.trace_maximum()
 
-        assert max(dps.freq[max_pos]) <= 1 / self.lc.dt
-        assert min(dps.freq[max_pos]) >= 1 / dps.segment_size
+        assert np.max(dps.freq[max_pos]) <= 1 / self.lc.dt
+        assert np.min(dps.freq[max_pos]) >= 1 / dps.segment_size
 
     def test_trace_maximum_with_boundaries(self):
         dps = DynamicalPowerspectrum(self.lc, segment_size=3)
@@ -583,8 +585,8 @@ class TestDynamicalPowerspectrum(object):
         maxfreq = 24
         max_pos = dps.trace_maximum(min_freq=minfreq, max_freq=maxfreq)
 
-        assert max(dps.freq[max_pos]) <= maxfreq
-        assert min(dps.freq[max_pos]) >= minfreq
+        assert np.max(dps.freq[max_pos]) <= maxfreq
+        assert np.min(dps.freq[max_pos]) >= minfreq
 
     def test_size_of_trace_maximum(self):
         dps = DynamicalPowerspectrum(self.lc, segment_size=3)


### PR DESCRIPTION
While running a few large computations, I realized that the builtin `max()` was taking 90% of the time in certain operations. 
I substituted `np.max` in all operations that involve numpy arrays.