### PR TITLE
Update astropy-helpers to v2.0.2 and fixes to the docstrings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,6 @@ matrix:
           env: SCIPY_VERSION=0.14.0
 
         # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
         - python: 3.5
           env: ASTROPY_VERSION=development
 
@@ -95,8 +93,6 @@ matrix:
           env: SCIPY_VERSION=0.14.0
 
         # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
         - python: 3.5
           env: ASTROPY_VERSION=development
 

--- a/stingray/bispectrum.py
+++ b/stingray/bispectrum.py
@@ -70,9 +70,9 @@ class Bispectrum(object):
                 
                 [3] Matlab version of bispectrum under following link. 
                 https://www.mathworks.com/matlabcentral/fileexchange/60-bisp3cum
-                
-                Example
-                -------
+
+                Examples
+                --------
                 >> from stingray.lightcurve import Lightcurve
                 >> from stingray.bispectrum import Bispectrum
                 >> lc = Lightcurve([1,2,3,4,5],[2,3,1,1,2])

--- a/stingray/bispectrum.py
+++ b/stingray/bispectrum.py
@@ -13,62 +13,63 @@ class Bispectrum(object):
     def __init__(self, lc, maxlag=None, window=None, scale='biased'):
         """
                 Makes a :class:`Bispectrum` object from a given :class:`Lightcurve`.
-                
+
                 Bispectrum is a higher order time series analysis method and is calculated by indirect method as
                 fourier transform of triple auto-correlation function also called as 3rd Order cumulant.
-                
+
                 Parameters
                 ----------
-                lc: lightcurve.Lightcurve object
+                lc : lightcurve.Lightcurve object
                     The light curve data for bispectrum calculation.
-                maxlag: int, optional, default None
-                    Maximum lag on both positive and negative sides of 
+                maxlag : int, optional, default None
+                    Maximum lag on both positive and negative sides of
                     3rd order cumulant (Similar to lags in correlation).
                     if None, max lag is set to one-half of length of lightcurve.
                 window : {'uniform', 'parzen', 'hamming', 'hanning', 'traingular', 'welch', 'blackmann', 'flat-top'}, optional, default 'uniform'
                     Type of Window to apply for Bispectrum.
-                scale: {'biased', 'unbiased'}, optional, default 'biased'
+                scale : {'biased', 'unbiased'}, optional, default 'biased'
                     Flag to decide biased or unbiased normalization for 3rd order cumulant function.
-                    
+
 
                 Attributes
                 ----------
-                lc: lightcurve.Lightcurve 
+                lc : lightcurve.Lightcurve
                     The light curve data for bispectrum.
-                fs: float
-                    Sampling freq of light curve.        
-                n: int
+                fs : float
+                    Sampling freq of light curve.
+                n : int
                     Total Number of samples of light curve observations.
-                maxlag: int
-                    Maximum lag on both positive and negative sides of 
+                maxlag : int
+                    Maximum lag on both positive and negative sides of
                     3rd order cumulant (Similar to lags in correlation)
-                signal: numpy.ndarray
+                signal : numpy.ndarray
                     Row vector of lightcurve counts for matrix operations
-                scale: {'biased', 'unbiased'}
-                    Flag to decide biased or unbiased normalization for 3rd order cumulant function. 
-                lags: numpy.ndarray
+                scale : {'biased', 'unbiased'}
+                    Flag to decide biased or unbiased normalization for 3rd order cumulant function.
+                lags : numpy.ndarray
                     An array of time lags for which 3rd order cumulant is calculated
-                freq: numpy.ndarray
+                freq : numpy.ndarray
                     An array of freq values for bispectrum.
-                cum3: numpy.ndarray
+                cum3 : numpy.ndarray
                     A maxlag*2+1 x maxlag*2+1 matrix containing 3rd order cumulant data for different lags.
-                bispec: numpy.ndarray
+                bispec : numpy.ndarray
                     A maxlag*2+1 x maxlag*2+1 matrix containing bispectrum data for different frequencies.
-                bispec_mag: numpy.ndarray
+                bispec_mag : numpy.ndarray
                     Magnitude of Bispectrum
-                bispec_phase: numpy.ndarray
+                bispec_phase : numpy.ndarray
                     Phase of Bispectrum
+
                 References
-                ----------     
+                ----------
                 [1] The biphase explained: understanding the asymmetries invcoupled Fourier components of astronomical timeseries
                 by Thomas J. Maccarone Department of Physics, Box 41051, Science Building, Texas Tech University, Lubbock TX 79409-1051
                 School of Physics and Astronomy, University of Southampton, SO16 4ES
-                    
+
                 [2] T. S. Rao, M. M. Gabr, An Introduction to Bispectral Analysis and Bilinear Time
                 Series Models, Lecture Notes in Statistics, Volume 24, D. Brillinger, S. Fienberg,
                 J. Gani, J. Hartigan, K. Krickeberg, Editors, Springer-Verlag, New York, NY, 1984.
-                
-                [3] Matlab version of bispectrum under following link. 
+
+                [3] Matlab version of bispectrum under following link.
                 https://www.mathworks.com/matlabcentral/fileexchange/60-bisp3cum
 
                 Examples
@@ -92,7 +93,7 @@ class Bispectrum(object):
                 >> bs.bispec_phase
                 array([[ -9.65946229e-01,   2.25347190e-14,   3.46944695e-14],
                     [  0.00000000e+00,   3.14159265e+00,   0.00000000e+00],
-                    [ -3.46944695e-14,  -2.25347190e-14,   9.65946229e-01]])                  
+                    [ -3.46944695e-14,  -2.25347190e-14,   9.65946229e-01]])
         """
 
         # Function call to create Bispectrum Object
@@ -100,7 +101,7 @@ class Bispectrum(object):
 
     def _make_bispetrum(self, lc, maxlag, window, scale):
         """
-            Makes a Bispectrum Object with given lighcurve, maxlag and scale. 
+            Makes a Bispectrum Object with given lighcurve, maxlag and scale.
         """
 
         if not isinstance(lc, lightcurve.Lightcurve):
@@ -190,8 +191,8 @@ class Bispectrum(object):
     def _cumulant3(self):
         """
             Calculates the 3rd Order cummulant of the lightcurve.
-            Assigns: 
-            self.cum3, 
+            Assigns:
+            self.cum3,
             self.lags
         """
         # Initialize square cumulant matrix if zeros
@@ -224,7 +225,7 @@ class Bispectrum(object):
     def _normalize_cumulant3(self):
         """
         Scales (biased or ubiased) the 3rd Order cumulant of the lightcurve .
-        Updates: 
+        Updates:
         self.cum3
         """
 
@@ -271,7 +272,7 @@ class Bispectrum(object):
     def _cal_bispec(self):
         """
             Calculates bispectrum as a fourier transform of 3rd Order Cumulant.
-            Assigns: 
+            Assigns:
             self.freq
             self.bispec
             self.bispec_mag

--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -76,8 +76,8 @@ class Covariancespectrum(object):
         max_energy : float
             Energy of the photon with the maximum energy.
 
-        Reference
-        ---------
+        References
+        ----------
         [1] Wilkinson, T. and Uttley, P. (2009), Accretion disc variability
             in the hard state of black hole X-ray binaries. Monthly Notices
             of the Royal Astronomical Society, 397: 666–676.
@@ -479,8 +479,8 @@ class AveragedCovariancespectrum(Covariancespectrum):
         """
         Calculate Covariance error on the averaged quantities.
 
-        Reference
-        ---------
+        References
+        ----------
         http://arxiv.org/pdf/1405.6575v2.pdf Equation 15
 
         """

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -532,10 +532,6 @@ def _retrieve_ascii_object(filename, **kwargs):
     -------
     data : astropy.Table object
         An astropy.Table object with the data from the file
-
-
-    Example
-    -------
     """
     if not isinstance(filename, six.string_types):
         raise TypeError("filename must be string!")

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -298,8 +298,8 @@ class Lightcurve(object):
 
         GTIs are crossed, so that only common intervals are saved.
 
-        Example
-        -------
+        Examples
+        --------
         >>> time = [5, 10, 15]
         >>> count1 = [300, 100, 400]
         >>> count2 = [600, 1200, 800]
@@ -324,8 +324,8 @@ class Lightcurve(object):
 
         GTIs are crossed, so that only common intervals are saved.
 
-        Example
-        -------
+        Examples
+        --------
         >>> time = [10, 20, 30]
         >>> count1 = [600, 1200, 800]
         >>> count2 = [300, 100, 400]
@@ -347,8 +347,8 @@ class Lightcurve(object):
         The negation operator ``-`` is supposed to invert the sign of the count
         values of a light curve object.
 
-        Example
-        -------
+        Examples
+        --------
         >>> time = [1, 2, 3]
         >>> count1 = [100, 200, 300]
         >>> count2 = [200, 300, 400]
@@ -371,8 +371,8 @@ class Lightcurve(object):
         This method implements overrides the len function over a Lightcurve
         object and returns the length of the time and count arrays.
 
-        Example
-        -------
+        Examples
+        --------
         >>> time = [1, 2, 3]
         >>> count = [100, 200, 300]
         >>> lc = Lightcurve(time, count)
@@ -399,8 +399,8 @@ class Lightcurve(object):
         index : int or slice instance
             Index value of the time array or a slice object.
 
-        Example
-        -------
+        Examples
+        --------
         >>> time = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         >>> count = [11, 22, 33, 44, 55, 66, 77, 88, 99]
         >>> lc = Lightcurve(time, count)
@@ -436,11 +436,11 @@ class Lightcurve(object):
     def __eq__(self,other_lc):
 	    """
 	        Compares two :class:`Lightcurve` objects.
-	        
+
 	        Light curves are equal only if their counts as well as times at which those counts occur equal.
-	        
-	        Example
-	        -------
+
+	        Examples
+	        --------
 	        >>> time = [1, 2, 3]
 	        >>> count1 = [100, 200, 300]
 	        >>> count2 = [100, 200, 300]
@@ -616,8 +616,8 @@ class Lightcurve(object):
         lc_new : Lightcurve object
             The resulting lightcurve object.
 
-        Example
-        -------
+        Examples
+        --------
         >>> time1 = [5, 10, 15]
         >>> count1 = [300, 100, 400]
         >>> time2 = [20, 25, 30]
@@ -733,8 +733,8 @@ class Lightcurve(object):
             the values are treated as indices of the counts array, or
             if set to "time", the values are treated as actual time values.
 
-        Example
-        -------
+        Examples
+        --------
         >>> time = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         >>> count = [10, 20, 30, 40, 50, 60, 70, 80, 90]
         >>> lc = Lightcurve(time, count)
@@ -811,8 +811,8 @@ class Lightcurve(object):
         reverse : boolean, default False
             If True then the object is sorted in reverse order.
 
-        Example
-        -------
+        Examples
+        --------
         >>> time = [1, 2, 3]
         >>> count = [200, 100, 300]
         >>> lc = Lightcurve(time, count)

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -220,7 +220,7 @@ class ParameterEstimation(object):
             Any of the strings allowed in scipy.optimize.minimize in
             the method keyword. Sets the fit method to be used.
 
-        max_post: bool, optional, default True
+        max_post : bool, optional, default True
             If True, then compute the Maximum-A-Posteriori estimate. If False,
             compute a Maximum Likelihood estimate.
         """
@@ -236,7 +236,7 @@ class ParameterEstimation(object):
 
         Parameters
         -----------
-        lpost: Posterior (or subclass) instance
+        lpost : Posterior (or subclass) instance
             and instance of class Posterior or one of its subclasses
             that defines the function to be minized (either in loglikelihood
             or logposterior)
@@ -255,7 +255,7 @@ class ParameterEstimation(object):
 
         Returns
         --------
-        fitparams: dict
+        fitparams : dict
             A dictionary with the fit results
             TODO: Add description of keywords in the class!
         """
@@ -858,18 +858,18 @@ class SamplingResults(object):
         Parameters
         ----------
 
-        nsamples: int, default 1000
+        nsamples : int, default 1000
             The maximum number of samples used for plotting.
 
-        fig: matplotlib.Figure instance, default None
+        fig : matplotlib.Figure instance, default None
             If created externally, you can pass a Figure instance to this method.
             If none is passed, the method will create one internally.
 
-        save_plot: bool, default False
+        save_plot : bool, default False
             If True, save the plot to file with a file name specified by the
             keyword `filename`. If False, just return the `Figure` object
 
-        filename: str
+        filename : str
             Name of the output file with the figure
 
         """

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -214,9 +214,9 @@ class ParameterEstimation(object):
         this is required, define (uniform) priors in the ParametricModel
         instances to be used below.
 
-        Parameters:
-        -----------
-        fitmethod: string, optional, default "L-BFGS-B"
+        Parameters
+        ----------
+        fitmethod : string, optional, default "L-BFGS-B"
             Any of the strings allowed in scipy.optimize.minimize in
             the method keyword. Sets the fit method to be used.
 
@@ -234,7 +234,7 @@ class ParameterEstimation(object):
         Do either a Maximum A Posteriori or Maximum Likelihood
         fit to the data.
 
-        Parameters:
+        Parameters
         -----------
         lpost: Posterior (or subclass) instance
             and instance of class Posterior or one of its subclasses
@@ -253,7 +253,7 @@ class ParameterEstimation(object):
             A dictionary with options for `scipy.optimize.minimize`,
             directly passed on as keyword arguments.
 
-        Returns:
+        Returns
         --------
         fitparams: dict
             A dictionary with the fit results
@@ -974,7 +974,7 @@ class PSDParEst(ParameterEstimation):
         """
         Generate a fake power spectrum from a model.
 
-        Parameters:
+        Parameters
         ----------
         lpost : instance of a Posterior or LogLikelihood subclass
             The object containing the relevant information about the

--- a/stingray/modeling/posterior.py
+++ b/stingray/modeling/posterior.py
@@ -65,8 +65,8 @@ def set_logprior(lpost, priors):
         logprior : function
             The function definition for the prior
 
-    Example
-    -------
+    Examples
+    --------
     Make a light curve and power spectrum
 
     >>> photon_arrivals = np.sort(np.random.uniform(0,1000, size=10000))
@@ -105,14 +105,14 @@ def set_logprior(lpost, priors):
         The logarithm of the prior distribution for the
         model defined in self.model.
 
-        Parameters:
-        ------------
-        t0: {list | numpy.ndarray}
+        Parameters
+        ----------
+        t0 : {list | numpy.ndarray}
             The list with parameters for the model
 
-        Returns:
-        --------
-        logp: float
+        Returns
+        -------
+        logp : float
             The logarithm of the prior distribution for the model and
             parameters given.
         """

--- a/stingray/modeling/posterior.py
+++ b/stingray/modeling/posterior.py
@@ -200,10 +200,10 @@ class GaussianLogLikelihood(LogLikelihood):
         y : iterable
             y-coordinte of the data
 
-        yerr: iterable
+        yerr : iterable
             the uncertainty on the data, as standard deviation
 
-        model: an Astropy Model instance
+        model : an Astropy Model instance
             The model to use in the likelihood.
 
         """
@@ -254,7 +254,7 @@ class PoissonLogLikelihood(LogLikelihood):
         y : iterable
             y-coordinte of the data
 
-        model: an Astropy Model instance
+        model : an Astropy Model instance
             The model to use in the likelihood.
 
         """
@@ -297,14 +297,14 @@ class PSDLogLikelihood(LogLikelihood):
 
         Parameters
         ----------
-        freq: iterable
+        freq : iterable
             Array with frequencies
 
-        power: iterable
+        power : iterable
             Array with (averaged/singular) powers corresponding to the
             frequencies in `freq`
 
-        model: an Astropy Model instance
+        model : an Astropy Model instance
             The model to use in the likelihood.
 
         m : int
@@ -436,7 +436,7 @@ class Posterior(object):
         y : iterable
             The ordinate or dependent variable of the data.
 
-        model: astropy.modeling.models class instance
+        model : astropy.modeling.models class instance
             The parametric model supposed to represent the data. For details
             see the astropy.modeling documentation
 
@@ -507,10 +507,10 @@ class PSDPosterior(Posterior):
 
         Parameters
         ----------
-        ps: {Powerspectrum | AveragedPowerspectrum} instance
+        ps : {Powerspectrum | AveragedPowerspectrum} instance
             the Powerspectrum object containing the data
 
-        model: instance of any subclass of parameterclass.ParametricModel
+        model : instance of any subclass of parameterclass.ParametricModel
             The model for the power spectrum. Note that in order to define
             the posterior properly, the ParametricModel subclass must be
             instantiated with the hyperpars parameter set, or there won't
@@ -528,23 +528,23 @@ class PSDPosterior(Posterior):
             this module. Note that it is impossible to call the posterior object
             itself or the `self.logposterior` method without defining a prior.
 
-        m: int, default 1
+        m : int, default 1
             The number of averaged periodograms or frequency bins in ps.
             Useful for binned/averaged periodograms, since the value of
             m will change the likelihood function!
 
         Attributes
         ----------
-        ps: {Powerspectrum | AveragedPowerspectrum} instance
+        ps : {Powerspectrum | AveragedPowerspectrum} instance
             the Powerspectrum object containing the data
 
-        x: numpy.ndarray
+        x : numpy.ndarray
             The independent variable (list of frequencies) stored in ps.freq
 
-        y: numpy.ndarray
+        y : numpy.ndarray
             The dependent variable (list of powers) stored in ps.power
 
-        model: instance of any subclass of parameterclass.ParametricModel
+        model : instance of any subclass of parameterclass.ParametricModel
                The model for the power spectrum. Note that in order to define
                the posterior properly, the ParametricModel subclass must be
                instantiated with the hyperpars parameter set, or there won't
@@ -579,7 +579,7 @@ class PoissonPosterior(Posterior):
         y : numpy.ndarray
             The dependent variable (e.g. counts per bin of a light curve)
 
-        model: instance of any subclass of parameterclass.ParametricModel
+        model : instance of any subclass of parameterclass.ParametricModel
             The model for the power spectrum. Note that in order to define
             the posterior properly, the ParametricModel subclass must be
             instantiated with the hyperpars parameter set, or there won't
@@ -599,13 +599,13 @@ class PoissonPosterior(Posterior):
 
         Attributes
         ----------
-        x: numpy.ndarray
+        x : numpy.ndarray
             The independent variable (list of frequencies) stored in ps.freq
 
-        y: numpy.ndarray
+        y : numpy.ndarray
             The dependent variable (list of powers) stored in ps.power
 
-        model: instance of any subclass of parameterclass.ParametricModel
+        model : instance of any subclass of parameterclass.ParametricModel
                The model for the power spectrum. Note that in order to define
                the posterior properly, the ParametricModel subclass must be
                instantiated with the hyperpars parameter set, or there won't
@@ -633,16 +633,16 @@ class GaussianPosterior(Posterior):
 
         Parameters
         ----------
-        x: numpy.ndarray
+        x : numpy.ndarray
             independent variable
 
-        y: numpy.ndarray
+        y : numpy.ndarray
             dependent variable
 
-        yerr: numpy.ndarray
+        yerr : numpy.ndarray
             measurement uncertainties for y
 
-        model: instance of any subclass of parameterclass.ParametricModel
+        model : instance of any subclass of parameterclass.ParametricModel
             The model for the power spectrum. Note that in order to define
             the posterior properly, the ParametricModel subclass must be
             instantiated with the hyperpars parameter set, or there won't
@@ -668,16 +668,16 @@ class LaplacePosterior(Posterior):
 
         Parameters
         ----------
-        x: numpy.ndarray
+        x : numpy.ndarray
             independent variable
 
-        y: numpy.ndarray
+        y : numpy.ndarray
             dependent variable
 
-        yerr: numpy.ndarray
+        yerr : numpy.ndarray
             measurement uncertainties for y, in standard deviation
 
-        model: instance of any subclass of parameterclass.ParametricModel
+        model : instance of any subclass of parameterclass.ParametricModel
             The model for the power spectrum. Note that in order to define
             the posterior properly, the ParametricModel subclass must be
             instantiated with the hyperpars parameter set, or there won't

--- a/stingray/modeling/scripts.py
+++ b/stingray/modeling/scripts.py
@@ -64,8 +64,8 @@ def fit_powerspectrum(ps, model, starting_pars, max_post=False, priors=None,
         The OptimizationResults object storing useful results and quantities
         relating to the fit
 
-    Example
-    -------
+    Examples
+    --------
 
     We start by making an example power spectrum with three Lorentzians
     >>> m = 1
@@ -181,8 +181,8 @@ def fit_lorentzians(ps, nlor, starting_pars, fit_whitenoise=True,
         The OptimizationResults object storing useful results and quantities
         relating to the fit
 
-    Example
-    -------
+    Examples
+    --------
 
     We start by making an example power spectrum with three Lorentzians
     >>> np.random.seed(400)

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -55,68 +55,62 @@ class Simulator(object):
 
         Examples
         --------
-        - x = simulate(beta)
-            For generating a light curve using power law spectrum.
+        * x = simulate(beta):
+           For generating a light curve using power law spectrum.
 
-            Parameters
-            ----------
-            beta : float
-                Defines the shape of spectrum
+              Parameters:
+                * beta : float
+                  Defines the shape of spectrum
 
-        - x = simulate(s)
-            For generating a light curve from user-provided spectrum.
+        * x = simulate(s):
+           For generating a light curve from user-provided spectrum.
 
-            Parameters
-            ----------
-            s : array-like
-                power spectrum
+              Parameters:
+                * s : array-like
+                  power spectrum
 
-        - x = simulate(model)
-            For generating a light curve from pre-defined model
+        * x = simulate(model):
+           For generating a light curve from pre-defined model
 
-            Parameters
-            ----------
-            model : astropy.modeling.Model
-                the pre-defined model
+              Parameters:
+                * model : astropy.modeling.Model
+                  the pre-defined model
 
-        - x = simulate('model', params)
-            For generating a light curve from pre-defined model
+        * x = simulate('model', params):
+           For generating a light curve from pre-defined model
 
-            Parameters
-            ----------
-            model : string
-                the pre-defined model
-            params : list iterable or dict
-                the parameters for the pre-defined model
+              Parameters:
+                * model : string
+                  the pre-defined model
+                * params : list iterable or dict
+                  the parameters for the pre-defined model
 
-        - x = simulate(s, h)
-            For generating a light curve using impulse response.
+        * x = simulate(s, h):
+           For generating a light curve using impulse response.
 
-            Parameters
-            ----------
-            s : array-like
-                Underlying variability signal
-            h : array-like
-                Impulse response
+              Parameters:
+                * s : array-like
+                  Underlying variability signal
+                * h : array-like
+                  Impulse response
 
-        - x = simulate(s, h, 'same')
-            For generating a light curve of same length as input
-            signal, using impulse response.
+        * x = simulate(s, h, 'same'):
+           For generating a light curve of same length as input signal,
+           using impulse response.
 
-            Parameters
-            ----------
-            s : array-like
-                Underlying variability signal
-            h : array-like
-                Impulse response
-            mode : str
-                mode can be 'same', 'filtered, or 'full'.
-                'same' indicates that the length of output light
-                curve is same as that of input signal.
-                'filtered' means that length of output light curve
-                is len(s) - lag_delay
-                'full' indicates that the length of output light
-                curve is len(s) + len(h) -1
+              Parameters:
+                * s : array-like
+                  Underlying variability signal
+                * h : array-like
+                  Impulse response
+                * mode : str
+                  mode can be 'same', 'filtered, or 'full'.
+                  'same' indicates that the length of output light
+                  curve is same as that of input signal.
+                  'filtered' means that length of output light curve
+                  is len(s) - lag_delay
+                  'full' indicates that the length of output light
+                  curve is len(s) + len(h) -1
 
         Parameters
         ----------

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -150,7 +150,6 @@ class Simulator(object):
         else:
             raise ValueError("Length of arguments must be 1, 2 or 3.")
 
-
     def simulate_channel(self, channel, *args):
         """
         Simulate a lightcurve and add it to corresponding energy


### PR DESCRIPTION
~~This is an automated update of the astropy-helpers submodule to v2.0.2. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed.~~

Some fixes were needed to make the new version of numpydoc happy.

I've also removed the travis job to test against astropy dev on python 2.7. We don't support that version any more, so that build will always fail.