### PR TITLE
Fix docstrings that made build_docs fail

### DIFF
--- a/stingray/io.py
+++ b/stingray/io.py
@@ -532,10 +532,6 @@ def _retrieve_ascii_object(filename, **kwargs):
     -------
     data : astropy.Table object
         An astropy.Table object with the data from the file
-
-
-    Example
-    -------
     """
     if not isinstance(filename, six.string_types):
         raise TypeError("filename must be string!")


### PR DESCRIPTION
Note that this is also needed to make PR #266 build. The new `numpydoc`, as reported by @bsipocz, is more picky about mistakes in docstrings!