### PR TITLE
Updating the usage of ci-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,8 +121,8 @@ install:
     # in how to install a package, in which case you can have additional
     # commands in the install: section below.
 
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda.sh
 
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ platform:
     -x64
 
 install:
-    - "git clone git://github.com/astropy/ci-helpers.git"
+    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"


### PR DESCRIPTION
We'll do some automated PRs for these sometimes soonish, but I did them here now while I was already around.

With this, you can use the custom tags in commit messages implemented in ci-helpers, such as ``[docs only]`` and ``[skip travis]``. I suppose it will be quite useful as full build currently runs for over 4 hours...