### PR TITLE
Speedup lc from events

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,32 +10,25 @@ environment:
         PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
-        CONDA_DEPENDENCIES: "scipy=0.19 numpy nose h5py astropy matplotlib statsmodels"
+        CONDA_DEPENDENCIES: "scipy numpy nose h5py astropy matplotlib statsmodels"
         PIP_DEPENDENCIES: "emcee pytest-catchlog"
 
     matrix:
+        - PYTHON_VERSION: "3.4"
+          CONDA_PY: "34"
+          CONDA_DEPENDENCIES: "mkl=2017.0.3 scipy=0.18 numpy=1.11 nose h5py astropy matplotlib statsmodels"
+        - PYTHON_VERSION: "3.5"
+          CONDA_PY: "35"
+          NUMPY_VERSION: "1.11"
         - PYTHON_VERSION: "2.7"
           NUMPY_VERSION: "stable"
           CONDA_PY: "27"
         - PYTHON_VERSION: "3.6"
           NUMPY_VERSION: "stable"
           CONDA_PY: "36"
-        - PYTHON_VERSION: "3.4"
-          CONDA_PY: "34"
-          CONDA_DEPENDENCIES: "scipy=0.18 numpy=1.11 nose h5py astropy matplotlib statsmodels"
-        - PYTHON_VERSION: "3.5"
-          CONDA_PY: "35"
-          CONDA_DEPENDENCIES: "scipy=0.18 numpy=1.11 nose h5py astropy matplotlib statsmodels"
 
 matrix:
     fast_finish: true
-    allow_failures:
-        - PYTHON_VERSION: "3.4"
-          NUMPY_VERSION: "1.11"
-          CONDA_PY: "34"
-        - PYTHON_VERSION: "3.5"
-          NUMPY_VERSION: "1.11"
-          CONDA_PY: "35"
 
 platform:
     -x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,24 +14,28 @@ environment:
         PIP_DEPENDENCIES: "emcee pytest-catchlog"
 
     matrix:
-
-        - PYTHON_VERSION: "3.4"
-          NUMPY_VERSION: "1.11"
-          CONDA_PY: "34"
-        - PYTHON_VERSION: "3.5"
-          NUMPY_VERSION: "1.11"
-          CONDA_PY: "35"
         - PYTHON_VERSION: "2.7"
           NUMPY_VERSION: "stable"
           CONDA_PY: "27"
         - PYTHON_VERSION: "3.6"
           NUMPY_VERSION: "stable"
           CONDA_PY: "36"
+        - PYTHON_VERSION: "3.4"
+          NUMPY_VERSION: "1.11"
+          CONDA_PY: "34"
+        - PYTHON_VERSION: "3.5"
+          NUMPY_VERSION: "1.11"
+          CONDA_PY: "35"
+
 matrix:
     fast_finish: true
     allow_failures:
-        - PYTHON_VERSION: "3.6"
-          NUMPY_VERSION: "stable"
+        - PYTHON_VERSION: "3.4"
+          NUMPY_VERSION: "1.11"
+          CONDA_PY: "34"
+        - PYTHON_VERSION: "3.5"
+          NUMPY_VERSION: "1.11"
+          CONDA_PY: "35"
 
 platform:
     -x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
         PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
-        CONDA_DEPENDENCIES: "scipy numpy nose h5py astropy matplotlib statsmodels"
+        CONDA_DEPENDENCIES: "scipy=0.19 numpy nose h5py astropy matplotlib statsmodels"
         PIP_DEPENDENCIES: "emcee pytest-catchlog"
 
     matrix:
@@ -21,11 +21,11 @@ environment:
           NUMPY_VERSION: "stable"
           CONDA_PY: "36"
         - PYTHON_VERSION: "3.4"
-          NUMPY_VERSION: "1.11"
           CONDA_PY: "34"
+          CONDA_DEPENDENCIES: "scipy=0.18 numpy=1.11 nose h5py astropy matplotlib statsmodels"
         - PYTHON_VERSION: "3.5"
-          NUMPY_VERSION: "1.11"
           CONDA_PY: "35"
+          CONDA_DEPENDENCIES: "scipy=0.18 numpy=1.11 nose h5py astropy matplotlib statsmodels"
 
 matrix:
     fast_finish: true

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -79,7 +79,7 @@ class EventList(object):
             PI channels
 
         """
-        
+
         self.energy = None if energy is None else np.array(energy)
         self.notes = notes
         self.dt = dt
@@ -195,16 +195,16 @@ class EventList(object):
             return
 
         if isinstance(spectrum, list) or isinstance(spectrum, np.ndarray):
-            
+
             energy = np.array(spectrum)[0]
             fluxes = np.array(spectrum)[1]
 
             if not isinstance(energy, np.ndarray):
                 raise IndexError("Spectrum must be a 2-d array or list")
-        
+
         else:
             raise TypeError("Spectrum must be a 2-d array or list")
-        
+
         # Create a set of probability values
         prob = fluxes / float(sum(fluxes))
 
@@ -262,7 +262,7 @@ class EventList(object):
 
         ev_new.time = np.concatenate([self.time, other.time])
         order = np.argsort(ev_new.time)
-        ev_new.time = ev_new.time[order] 
+        ev_new.time = ev_new.time[order]
 
         if (self.pi is None) and (other.pi is None):
             ev_new.pi = None
@@ -335,11 +335,11 @@ class EventList(object):
         if format_ == 'ascii':
             time = np.array(data.columns[0])
             return EventList(time=time)
-        
+
         elif format_ == 'hdf5' or format_ == 'fits':
             keys = data.keys()
             values = []
-            
+
             if format_ == 'fits':
                 attributes = [a.upper() for a in attributes]
 
@@ -349,7 +349,7 @@ class EventList(object):
 
                 else:
                     values.append(None)
-                    
+
             return EventList(time=values[0], energy=values[1],
                              ncounts=values[2], mjdref=values[3], dt=values[4],
                              notes=values[5], gti=values[6], pi=values[7])
@@ -383,8 +383,8 @@ class EventList(object):
             write(self, filename, format_)
 
         elif format_ == 'fits':
-            write(self, filename, format_, tnames=['EVENTS', 'GTI'], 
-                colsassign={'gti':'GTI'})
+            write(self, filename, format_, tnames=['EVENTS', 'GTI'],
+                  colsassign={'gti':'GTI'})
 
         else:
             raise KeyError("Format not understood.")

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -3,6 +3,8 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 import numpy as np
 import logging
+import collections
+import copy
 
 from astropy.io import fits
 from .io import assign_value_if_none
@@ -146,9 +148,6 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
     epsilon : float
         fraction of dt that is tolerated at the borders of a GTI
     """
-    import collections
-    import copy
-
     try:
         from numba import jit
     except ImportError:
@@ -206,7 +205,6 @@ def create_gti_mask_complete(time, gtis, safe_interval=0, min_length=0,
     epsilon : float
         fraction of dt that is tolerated at the borders of a GTI
     """
-    import collections
 
     check_gtis(gtis)
 
@@ -267,7 +265,6 @@ def create_gti_from_condition(time, condition,
     dt : float
         The width (in sec) of each bin of the time array. Can be irregular.
     """
-    import collections
 
     if len(time) != len(condition):
         raise StingrayError('The length of the condition and '

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -9,6 +9,7 @@ from .io import assign_value_if_none
 from .utils import contiguous_regions, jit
 from stingray.exceptions import StingrayError
 
+
 def load_gtis(fits_file, gtistring=None):
     """Load GTI from HDU EVENTS of file fits_file."""
 
@@ -24,6 +25,7 @@ def load_gtis(fits_file, gtistring=None):
                         dtype=np.longdouble)
     lchdulist.close()
     return gti_list
+
 
 def _get_gti_from_extension(lchdulist, accepted_gtistrings=['GTI']):
     hdunames = [h.name for h in lchdulist]
@@ -46,6 +48,7 @@ def _get_gti_from_extension(lchdulist, accepted_gtistrings=['GTI']):
                                          gtistop)],
                         dtype=np.longdouble)
     return gti_list
+
 
 def check_gtis(gti):
     """Check if GTIs are well-behaved.
@@ -85,8 +88,10 @@ def check_gtis(gti):
 
     return
 
+
 @jit(nopython=True)
 def create_gti_mask_jit(time, gtis, mask, gti_mask, min_length=0):
+    """Compiled and fast function to create gti mask."""
     gti_el = -1
     next_gti = False
     for i, t in enumerate(time):
@@ -144,6 +149,13 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
     import collections
     import copy
 
+    try:
+        from numba import jit
+    except ImportError:
+        return create_gti_mask_complete(time, gtis, safe_interval=0,
+                                        min_length=0, return_new_gtis=False,
+                                        dt=None, epsilon=0.001)
+
     check_gtis(gtis)
 
     dt = assign_value_if_none(dt, np.median(np.diff(time)) / 2)
@@ -157,15 +169,76 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
     gtis_new[:, 0] = gtis[:, 0] + safe_interval[0] + dt - epsilon*dt
     gtis_new[:, 1] = gtis[:, 1] - safe_interval[1] - dt + epsilon*dt
     
-    mask, gtimask = create_gti_mask_jit((time - time[0]).astype(np.float64),
-                                        (gtis_new - time[0]).astype(np.float64),
-                                        mask,
-                                        gti_mask=gti_mask,
-                                        min_length=min_length)
+    mask, gtimask = \
+        create_gti_mask_jit((time - time[0]).astype(np.float64),
+                            (gtis_new - time[0]).astype(np.float64),
+                            mask, gti_mask=gti_mask, min_length=min_length)
 
     if return_new_gtis:
         return mask, gtis[gtimask]
     return mask
+
+
+def create_gti_mask_complete(time, gtis, safe_interval=0, min_length=0,
+                             return_new_gtis=False, dt=None, epsilon=0.001):
+    """Create GTI mask, allowing for non-constant dt.
+
+    Assumes that no overlaps are present between GTIs
+
+    Parameters
+    ----------
+    time : float array
+    gtis : [[g0_0, g0_1], [g1_0, g1_1], ...], float array-like
+
+    Returns
+    -------
+    mask : boolean array
+    new_gtis : Nx2 array
+
+    Other parameters
+    ----------------
+    safe_interval : float or [float, float]
+        A safe interval to exclude at both ends (if single float) or the start
+        and the end (if pair of values) of GTIs.
+    min_length : float
+    return_new_gtis : bool
+    dt : float
+    epsilon : float
+        fraction of dt that is tolerated at the borders of a GTI
+    """
+    import collections
+
+    check_gtis(gtis)
+
+    dt = assign_value_if_none(dt,
+                              np.zeros_like(time) +
+                              np.median(np.diff(time)) / 2)
+
+    mask = np.zeros(len(time), dtype=bool)
+
+    if not isinstance(safe_interval, collections.Iterable):
+        safe_interval = [safe_interval, safe_interval]
+
+    newgtis = np.zeros_like(gtis)
+    # Whose GTIs, including safe intervals, are longer than min_length
+    newgtimask = np.zeros(len(newgtis), dtype=np.bool)
+
+    for ig, gti in enumerate(gtis):
+        limmin, limmax = gti
+        limmin += safe_interval[0]
+        limmax -= safe_interval[1]
+        if limmax - limmin >= min_length:
+            newgtis[ig][:] = [limmin, limmax]
+            cond1 = time - dt + epsilon*dt >= limmin
+            cond2 = time + dt - epsilon*dt <= limmax
+            good = np.logical_and(cond1, cond2)
+            mask[good] = True
+            newgtimask[ig] = True
+
+    res = mask
+    if return_new_gtis:
+        res = [res, newgtis[newgtimask]]
+    return res
 
 
 def create_gti_from_condition(time, condition,
@@ -380,6 +453,7 @@ def gti_len(gti):
     """Return the total good time from a list of GTIs."""
     return np.sum([g[1] - g[0] for g in gti])
 
+
 def check_separate(gti0, gti1):
     """Check if two GTIs do not overlap.
 
@@ -415,6 +489,7 @@ def check_separate(gti0, gti1):
         return True
     else:
         return False
+
 
 def append_gtis(gti0, gti1):
     """Union of two non-overlapping GTIs.

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -102,7 +102,6 @@ def create_gti_mask_jit(time, gtis, mask, gti_mask, min_length=0):
             limmin = gtis[gti_el, 0]
             limmax = gtis[gti_el, 1]
             length = limmax - limmin
-
             if length < min_length:
                 next_gti = True
                 continue
@@ -158,7 +157,7 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
                                         min_length=min_length,
                                         return_new_gtis=return_new_gtis,
                                         dt=dt, epsilon=epsilon)
-    gtis = np.asarray(gtis)
+    gtis = np.array(gtis, dtype=np.longdouble)
     check_gtis(gtis)
 
     dt = assign_value_if_none(dt, np.median(np.diff(time)))
@@ -171,12 +170,10 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
     gtis_new = copy.deepcopy(gtis)
     gtis_new[:, 0] = gtis[:, 0] + safe_interval[0] + dt / 2 - epsilon*dt
     gtis_new[:, 1] = gtis[:, 1] - safe_interval[1] - dt / 2 + epsilon*dt
-
     mask, gtimask = \
         create_gti_mask_jit((time - time[0]).astype(np.float64),
                             (gtis_new - time[0]).astype(np.float64),
                             mask, gti_mask=gti_mask, min_length=min_length)
-
     if return_new_gtis:
         return mask, gtis[gtimask]
     return mask
@@ -234,6 +231,7 @@ def create_gti_mask_complete(time, gtis, safe_interval=0, min_length=0,
             newgtis[ig][:] = [limmin, limmax]
             cond1 = time >= limmin + dt / 2 - epsilon*dt
             cond2 = time <= limmax - dt / 2 + epsilon*dt
+
             good = np.logical_and(cond1, cond2)
             mask[good] = True
             newgtimask[ig] = True

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -152,9 +152,11 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
     try:
         from numba import jit
     except ImportError:
-        return create_gti_mask_complete(time, gtis, safe_interval=0,
-                                        min_length=0, return_new_gtis=False,
-                                        dt=None, epsilon=0.001)
+        return create_gti_mask_complete(time, gtis,
+                                        safe_interval=safe_interval,
+                                        min_length=min_length,
+                                        return_new_gtis=return_new_gtis,
+                                        dt=dt, epsilon=epsilon)
 
     check_gtis(gtis)
 

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -11,9 +11,9 @@ import stingray.io as io
 import stingray.utils as utils
 from stingray.exceptions import StingrayError
 from stingray.utils import simon, assign_value_if_none, baseline_als
+from stingray.utils import poisson_symmetrical_errors
 from stingray.gti import cross_two_gtis, join_gtis, gti_border_bins
 from stingray.gti import check_gtis, create_gti_mask_complete, create_gti_mask, bin_intervals_from_gtis
-from astropy.stats import poisson_conf_interval
 
 __all__ = ["Lightcurve"]
 
@@ -154,13 +154,7 @@ class Lightcurve(object):
             if err_dist.lower() == 'poisson':
                 # Instead of the simple square root, we use confidence
                 # intervals (should be valid for low fluxes too)
-                err_low, err_high = poisson_conf_interval(np.asarray(counts),
-                    interval='frequentist-confidence', sigma=1)
-                # calculate approximately symmetric uncertainties
-                err_low -= np.asarray(counts)
-                err_high -= np.asarray(counts)
-                err = (np.absolute(err_low) + np.absolute(err_high))/2.0
-                # other estimators can be implemented for other statistics
+                err = poisson_symmetrical_errors(counts)
             else:
                 simon("Stingray only uses poisson err_dist at the moment, "
                       "We are setting your errors to zero. "

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -539,8 +539,8 @@ class Lightcurve(object):
                 np.bincount(binned_toas, minlength=timebin)
             time = tstart + np.arange(0.5, 0.5 + len(counts)) * dt
         else:
-            counts, histbins = np.histogram(toa[good],
-                                            bins=np.linspace(tstart, tend, 1 + timebin))
+            histbins = np.arange(tstart, tend + dt, dt)
+            counts, histbins = np.histogram(toa[good], bins=histbins)
             time = histbins[:-1] + 0.5 * dt
 
         return Lightcurve(time, counts, gti=gti, mjdref=mjdref, dt=dt)

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -187,7 +187,6 @@ class Lightcurve(object):
                                             [[self.tstart,
                                               self.tstart + self.tseg]]))
         check_gtis(self.gti)
-
         good = create_gti_mask(self.time, self.gti)
 
         self.time = self.time[good]
@@ -543,8 +542,8 @@ class Lightcurve(object):
         if not use_hist:
             binned_toas = ((toa[good] - tstart) // dt).astype(np.int64)
             counts = \
-                np.bincount(binned_toas, minlength=timebin)[:timebin]
-            time = tstart + np.arange(0.5, 0.5 + timebin) * dt
+                np.bincount(binned_toas, minlength=timebin)
+            time = tstart + np.arange(0.5, 0.5 + len(counts)) * dt
         else:
             counts, histbins = np.histogram(toa[good],
                                             bins=np.linspace(tstart, tend, 1 + timebin))

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -427,28 +427,28 @@ class Lightcurve(object):
                              "object !")
 
     def __eq__(self,other_lc):
-	    """
-	        Compares two :class:`Lightcurve` objects.
+        """
+        Compares two :class:`Lightcurve` objects.
 
-	        Light curves are equal only if their counts as well as times at which those counts occur equal.
+        Light curves are equal only if their counts as well as times at which those counts occur equal.
 
-	        Examples
-	        --------
-	        >>> time = [1, 2, 3]
-	        >>> count1 = [100, 200, 300]
-	        >>> count2 = [100, 200, 300]
-	        >>> lc1 = Lightcurve(time, count1)
-	        >>> lc2 = Lightcurve(time, count2)
-	        >>> lc1 == lc2
-	        True
-	    """
-	    if not isinstance(other_lc, Lightcurve):
-	        raise ValueError('Lightcurve can only be compared with a Lightcurve Object')
-	    if (np.allclose(self.time, other_lc.time) and np.allclose(self.counts, other_lc.counts)):
-	        return True
-	    return False
+        Example
+        -------
+        >>> time = [1, 2, 3]
+        >>> count1 = [100, 200, 300]
+        >>> count2 = [100, 200, 300]
+        >>> lc1 = Lightcurve(time, count1)
+        >>> lc2 = Lightcurve(time, count2)
+        >>> lc1 == lc2
+        True
+        """
+        if not isinstance(other_lc, Lightcurve):
+            raise ValueError('Lightcurve can only be compared with a Lightcurve Object')
+        if (np.allclose(self.time, other_lc.time) and np.allclose(self.counts, other_lc.counts)):
+            return True
+        return False
 
-    def baseline(self, lam, p, niter=10):
+    def baseline(self, lam, p, niter=10, offset_correction=False):
         """Calculate the baseline of the light curve, accounting for GTIs.
 
         Parameters
@@ -459,11 +459,22 @@ class Lightcurve(object):
         p : float
             "asymmetry" parameter. Smaller values make the baseline more
             "horizontal". Typically 0.001 < p < 0.1, but not necessary.
+
+        Other parameters
+        ----------------
+        offset_correction : bool, default False
+            by default, this method does not align to the running mean of the
+            light curve, but it goes below the light curve. Setting align to
+            True, an additional step is done to shift the baseline so that it
+            is shifted to the middle of the light curve noise distribution.
         """
         baseline = np.zeros_like(self.time)
         for g in self.gti:
             good = create_gti_mask(self.time, [g])
-            baseline[good] = baseline_als(self.counts[good], lam, p, niter)
+            _, baseline[good] = \
+                baseline_als(self.time[good], self.counts[good], lam, p,
+                             niter, offset_correction=offset_correction,
+                             return_baseline=True)
 
         return baseline
 

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -533,14 +533,9 @@ class Lightcurve(object):
         timebin = np.int(tseg/dt)
         logging.info("make_lightcurve: timebin:  " + str(timebin))
 
-        tend = tstart + timebin*dt
-
-        counts, histbins = np.histogram(toa, bins=timebin,
-                                        range=[tstart, tend])
-
-        dt = histbins[1] - histbins[0]
-
-        time = histbins[:-1] + 0.5*dt
+        counts = np.bincount(((toa - tstart) // dt).astype(np.int64),
+                             minlength=timebin)
+        time = tstart + np.arange(0.5, 0.5 + len(counts)) * dt
 
         counts = np.asarray(counts)
 

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -22,7 +22,8 @@ def _pulse_phase_fast(time, f, fdot, buffer_array):
 def _folding_search(stat_func, times, frequencies, segment_size=5000,
                     use_times=False, fdots=0, **kwargs):
 
-    fgrid, fdgrid = np.meshgrid(frequencies, fdots)
+    fgrid, fdgrid = np.meshgrid(np.asarray(frequencies).astype(np.float64),
+                                np.asarray(fdots).astype(np.float64))
     stats = np.zeros_like(fgrid)
     times = (times - times[0]).astype(np.float64)
     length = times[-1]

--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -24,7 +24,7 @@ class TestAll(object):
         cls.counts = \
             100 + 20 * np.cos(2 * np.pi * cls.times * cls.pulse_frequency)
         cls.gti = [[cls.tstart, cls.tend]]
-        lc = Lightcurve(cls.times, cls.counts, gti=cls.gti)
+        lc = Lightcurve(cls.times, cls.counts, gti=cls.gti, err_dist='gauss')
         events = EventList()
         events.simulate_times(lc)
         cls.event_times = events.time

--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -149,12 +149,12 @@ class TestAll(object):
         maxfdot = fdot.flatten()[np.argmax(stat)]
         assert np.allclose(maxfdot, 0.0, atol=0.1/self.tseg)
 
-    def test_epoch_folding_search_fdot_float128(self):
+    def test_epoch_folding_search_fdot_longdouble(self):
         """Test pulse phase calculation, frequency only."""
-        frequencies = np.arange(9.8, 9.99, 0.1/self.tseg, dtype=np.float128)
-        fdots = np.array([-0.1, 0, 0.1], dtype=np.float128)
+        frequencies = np.arange(9.8, 9.99, 0.1/self.tseg, dtype=np.longdouble)
+        fdots = np.array([-0.1, 0, 0.1], dtype=np.longdouble)
         freq, fdot, stat = \
-            epoch_folding_search(self.event_times.astype(np.float128),
+            epoch_folding_search(self.event_times.astype(np.longdouble),
                                  frequencies, nbin=43, fdots=fdots)
 
         minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))
@@ -244,11 +244,11 @@ class TestAll(object):
         maxfdot = fdot.flatten()[np.argmax(stat)]
         assert np.allclose(maxfdot, 0.0, atol=0.1/self.tseg)
 
-    def test_z_n_search_fdot_float128(self):
+    def test_z_n_search_fdot_longdouble(self):
         """Test pulse phase calculation, frequency only."""
-        frequencies = np.arange(9.8, 9.99, 0.1/self.tseg, dtype=np.float128)
-        fdots = np.array([-0.1, 0, 0.1], dtype=np.float128)
-        freq, fdot, stat = z_n_search(self.event_times.astype(np.float128),
+        frequencies = np.arange(9.8, 9.99, 0.1/self.tseg, dtype=np.longdouble)
+        fdots = np.array([-0.1, 0, 0.1], dtype=np.longdouble)
+        freq, fdot, stat = z_n_search(self.event_times.astype(np.longdouble),
                                       frequencies, nbin=25,
                                       nharm=2, fdots=fdots)
 

--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -149,6 +149,20 @@ class TestAll(object):
         maxfdot = fdot.flatten()[np.argmax(stat)]
         assert np.allclose(maxfdot, 0.0, atol=0.1/self.tseg)
 
+    def test_epoch_folding_search_fdot_float128(self):
+        """Test pulse phase calculation, frequency only."""
+        frequencies = np.arange(9.8, 9.99, 0.1/self.tseg, dtype=np.float128)
+        fdots = np.array([-0.1, 0, 0.1], dtype=np.float128)
+        freq, fdot, stat = \
+            epoch_folding_search(self.event_times.astype(np.float128),
+                                 frequencies, nbin=43, fdots=fdots)
+
+        minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))
+        maxstatbin = freq.flatten()[np.argmax(stat)]
+        assert np.allclose(maxstatbin, frequencies[minbin], atol=0.1/self.tseg)
+        maxfdot = fdot.flatten()[np.argmax(stat)]
+        assert np.allclose(maxfdot, 0.0, atol=0.1/self.tseg)
+
     def test_epoch_folding_search_expocorr_fails(self):
         """Test pulse phase calculation, frequency only."""
         frequencies = np.arange(9.8, 9.99, 0.1/self.tseg)
@@ -171,9 +185,10 @@ class TestAll(object):
         """Test pulse phase calculation, frequency only."""
         frequencies = np.arange(9.8, 9.99, 0.1/self.tseg)
         fdots = [-0.1, 0, 0.1]
-        freq, fdot, stat = epoch_folding_search(self.event_times, frequencies,
-                                                nbin=42, expocorr=True, gti=self.gti,
-                                                fdots=fdots)
+        freq, fdot, stat = \
+            epoch_folding_search(self.event_times, frequencies,
+                                 nbin=42, expocorr=True, gti=self.gti,
+                                 fdots=fdots)
 
         minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))
         maxstatbin = freq.flatten()[np.argmax(stat)]
@@ -221,6 +236,20 @@ class TestAll(object):
         frequencies = np.arange(9.8, 9.99, 0.1/self.tseg)
         fdots = [-0.1, 0, 0.1]
         freq, fdot, stat = z_n_search(self.event_times, frequencies, nbin=25,
+                                      nharm=2, fdots=fdots)
+
+        minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))
+        maxstatbin = freq.flatten()[np.argmax(stat)]
+        assert np.allclose(maxstatbin, frequencies[minbin], atol=0.1/self.tseg)
+        maxfdot = fdot.flatten()[np.argmax(stat)]
+        assert np.allclose(maxfdot, 0.0, atol=0.1/self.tseg)
+
+    def test_z_n_search_fdot_float128(self):
+        """Test pulse phase calculation, frequency only."""
+        frequencies = np.arange(9.8, 9.99, 0.1/self.tseg, dtype=np.float128)
+        fdots = np.array([-0.1, 0, 0.1], dtype=np.float128)
+        freq, fdot, stat = z_n_search(self.event_times.astype(np.float128),
+                                      frequencies, nbin=25,
                                       nharm=2, fdots=fdots)
 
         minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))

--- a/stingray/tests/test_events.py
+++ b/stingray/tests/test_events.py
@@ -18,7 +18,7 @@ except ImportError:
 
 
 class TestEvents(object):
-    
+
     @classmethod
     def setup_class(self):
         self.time = [0.5, 1.5, 2.5, 3.5]
@@ -39,8 +39,7 @@ class TestEvents(object):
         """Create a light curve from event list."""
         ev = EventList(self.time, gti=self.gti)
         lc = ev.to_lc(1)
-        print(lc.time)
-        assert (lc.time == [0.5, 1.5, 2.5, 3.5]).all()
+        assert np.all((lc.time == [0.5, 1.5, 2.5, 3.5]))
         assert (lc.gti == self.gti).all()
 
     def test_from_lc(self):
@@ -51,7 +50,7 @@ class TestEvents(object):
         assert (ev.time == np.array([0.5, 0.5, 1.5, 2.5, 2.5])).all()
 
     def test_simulate_times(self):
-        """Simulate photon arrival times for an event list 
+        """Simulate photon arrival times for an event list
         from light curve.
         """
         lc = Lightcurve(self.time, self.counts_flat, gti=self.gti)
@@ -78,7 +77,7 @@ class TestEvents(object):
 
     def test_simulate_energies_with_1d_spectrum(self):
         """Test that simulate_energies() method raises index
-        error exception is spectrum is 1-d. 
+        error exception is spectrum is 1-d.
         """
         ev = EventList(ncounts=100)
         with pytest.raises(IndexError):
@@ -199,9 +198,9 @@ class TestEvents(object):
     def test_non_overlapping_join(self):
         """Join two overlapping event lists.
         """
-        ev = EventList(time=[1, 1, 2, 3, 4], 
+        ev = EventList(time=[1, 1, 2, 3, 4],
                         energy=[3, 4, 7, 4, 3], gti=[[1, 2],[3, 4]])
-        ev_other = EventList(time=[5, 6, 6, 7, 10], 
+        ev_other = EventList(time=[5, 6, 6, 7, 10],
                             energy=[4, 3, 8, 1, 2], gti=[[6, 7]])
         ev_new = ev.join(ev_other)
 
@@ -209,15 +208,15 @@ class TestEvents(object):
                 np.array([1, 1, 2, 3, 4, 5, 6, 6, 7, 10])).all()
         assert (ev_new.energy ==
                 np.array([3, 4, 7, 4, 3, 4, 3, 8, 1, 2])).all()
-        assert (ev_new.gti == 
+        assert (ev_new.gti ==
                 np.array([[1, 2],[3, 4],[6, 7]])).all()
 
     def test_overlapping_join(self):
         """Join two non-overlapping event lists.
         """
-        ev = EventList(time=[1, 1, 10, 6, 5], 
+        ev = EventList(time=[1, 1, 10, 6, 5],
                         energy=[10, 6, 3, 11, 2], gti=[[1, 3],[5, 6]])
-        ev_other = EventList(time=[5, 7, 6, 6, 10], 
+        ev_other = EventList(time=[5, 7, 6, 6, 10],
                             energy=[2, 3, 8, 1, 2], gti=[[5, 7],[8, 10]])
         ev_new = ev.join(ev_other)
 
@@ -280,4 +279,4 @@ class TestEvents(object):
 
         with pytest.raises(KeyError):
             ev.read('ev.pickle', format_="unsupported")
-            
+

--- a/stingray/tests/test_gti.py
+++ b/stingray/tests/test_gti.py
@@ -5,11 +5,11 @@ import numpy as np
 import pytest
 import os
 
-from ..utils import contiguous_regions
 from ..gti import cross_gtis, append_gtis, load_gtis, get_btis, join_gtis
 from ..gti import check_separate, create_gti_mask, check_gtis
 from ..gti import create_gti_from_condition, gti_len, gti_border_bins
 from ..gti import time_intervals_from_gtis, bin_intervals_from_gtis
+from ..gti import create_gti_mask_complete
 
 curdir = os.path.abspath(os.path.dirname(__file__))
 datadir = os.path.join(curdir, 'data')
@@ -35,13 +35,14 @@ class TestGTI(object):
         assert np.all(newgti == [[4.0, 5.0], [7.0, 9.0], [12.2, 13.2]]), \
             'GTIs do not coincide!'
 
-    def test_crossgti2(self):
+    def test_crossgti3(self):
         """A more complicated example of intersection of GTIs."""
         gti1 = np.array([[1, 2], [4, 5], [7, 10]])
         newgti = cross_gtis([gti1])
 
         assert np.all(newgti == gti1), \
             'GTIs do not coincide!'
+
     def test_bti(self):
         """Test the inversion of GTIs."""
         gti = np.array([[1, 2], [4, 5], [7, 10], [11, 11.2], [12.2, 13.2]])
@@ -54,6 +55,15 @@ class TestGTI(object):
         arr = np.array([0, 1, 2, 3, 4, 5, 6])
         gti = np.array([[0, 2.1], [3.9, 5]])
         mask, new_gtis = create_gti_mask(arr, gti, return_new_gtis=True)
+        # NOTE: the time bin has to be fully inside the GTI. That is why the
+        # bin at times 0, 2, 4 and 5 are not in.
+        assert np.all(mask == np.array([0, 1, 0, 0, 0, 0, 0], dtype=bool))
+
+    def test_gti_mask_complete(self):
+        arr = np.array([0, 1, 2, 3, 4, 5, 6])
+        gti = np.array([[0, 2.1], [3.9, 5]])
+        mask, new_gtis = create_gti_mask_complete(arr, gti,
+                                                  return_new_gtis=True)
         # NOTE: the time bin has to be fully inside the GTI. That is why the
         # bin at times 0, 2, 4 and 5 are not in.
         assert np.all(mask == np.array([0, 1, 0, 0, 0, 0, 0], dtype=bool))

--- a/stingray/tests/test_gti.py
+++ b/stingray/tests/test_gti.py
@@ -68,6 +68,14 @@ class TestGTI(object):
         # bin at times 0, 2, 4 and 5 are not in.
         assert np.all(mask == np.array([0, 1, 0, 0, 0, 0, 0], dtype=bool))
 
+    def test_gti_mask_compare(self):
+        arr = np.array([ 0.5, 1.5, 2.5, 3.5])
+        gti = np.array([[0, 4]])
+        mask_c, new_gtis_c = \
+            create_gti_mask_complete(arr, gti, return_new_gtis=True)
+        mask, new_gtis = create_gti_mask(arr, gti, return_new_gtis=True)
+        assert np.all(mask == mask_c)
+
     def test_gti_from_condition1(self):
         t = np.array([0, 1, 2, 3, 4, 5, 6])
         condition = np.array([1, 1, 0, 0, 1, 0, 0], dtype=bool)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -758,6 +758,18 @@ class TestLightcurveRebin(object):
         baseline = lc.baseline(10000, 0.01)
         assert np.all(lc.counts - baseline < 1)
 
+    def test_lc_baseline_offset(self):
+        times = np.arange(0, 100, 0.01)
+        input_stdev = 0.1
+        counts = np.random.normal(100, input_stdev, len(times)) + \
+            0.001 * times
+        gti = [[-0.005, 50.005], [59.005, 100.005]]
+        good = create_gti_mask(times, gti)
+        counts[np.logical_not(good)] = 0
+        lc = Lightcurve(times, counts, gti=gti)
+        baseline = lc.baseline(10000, 0.01, offset_correction=True)
+        assert np.isclose(np.std(lc.counts - baseline), input_stdev, rtol=0.1)
+
     def test_change_mjdref(self):
         lc_new = self.lc.change_mjdref(57000)
         assert lc_new.mjdref == 57000

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -68,7 +68,7 @@ class TestChunks(object):
         nevar, nevar_err = res
         assert np.allclose(nevar, fvar**2, rtol=0.01)
 
-    def test_analyze_lc_chunks_nvar_fracstep(self):
+    def test_analyze_lc_chunks_nvar_fracstep_mean(self):
         start, stop, mean = self.lc.analyze_lc_chunks(20, np.mean,
                                                       fraction_step=0.5)
         start, stop, res = self.lc.analyze_lc_chunks(20, evar_fun,
@@ -170,7 +170,12 @@ class TestLightcurve(object):
         assert np.allclose(lc.bin_hi, bin_hi)
 
     def test_lightcurve_from_toa(self):
-        lc = Lightcurve.make_lightcurve(self.times, self.dt)
+        lc = Lightcurve.make_lightcurve(self.times, self.dt, use_hist=True,
+                                        tstart=0.5)
+        lc2 = Lightcurve.make_lightcurve(self.times, self.dt, use_hist=False,
+                                        tstart=0.5)
+        assert np.allclose(lc.time, lc2.time)
+        assert np.all(lc.counts == lc2.counts)
 
     def test_tstart(self):
         tstart = 0.0
@@ -748,7 +753,6 @@ class TestLightcurveRebin(object):
         assert np.all(lc.time == np.array([0, 1, 2, 13, 14]))
         lc.gti = [[-0.5, 10.5]]
         lc._apply_gtis()
-        assert lc.n == 3
         assert np.all(lc.time == np.array([0, 1, 2]))
 
     def test_eq_operator(self):

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -177,6 +177,25 @@ class TestLightcurve(object):
         assert np.allclose(lc.time, lc2.time)
         assert np.all(lc.counts == lc2.counts)
 
+    def test_lightcurve_from_toa_halfbin(self):
+        lc = Lightcurve.make_lightcurve(self.times + 0.5, self.dt,
+                                        use_hist=True,
+                                        tstart=0.5)
+        lc2 = Lightcurve.make_lightcurve(self.times + 0.5, self.dt,
+                                         use_hist=False,
+                                         tstart=0.5)
+        assert np.allclose(lc.time, lc2.time)
+        assert np.all(lc.counts == lc2.counts)
+
+    def test_lightcurve_from_toa_random_nums(self):
+        times = np.random.uniform(0, 10, 1000)
+        lc = Lightcurve.make_lightcurve(times, self.dt, use_hist=True,
+                                        tstart=0.5)
+        lc2 = Lightcurve.make_lightcurve(times, self.dt, use_hist=False,
+                                        tstart=0.5)
+        assert np.allclose(lc.time, lc2.time)
+        assert np.all(lc.counts == lc2.counts)
+
     def test_tstart(self):
         tstart = 0.0
         lc = Lightcurve.make_lightcurve(self.times, self.dt, tstart=0.0)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -548,7 +548,7 @@ class TestDynamicalPowerspectrum(object):
         vari = 25 * np.sin(2 * np.pi * freq * timestamps)
         signal = vari + 50
         # create a lightcurve
-        lc = Lightcurve(timestamps, signal)
+        lc = Lightcurve(timestamps, signal, err_dist='gauss')
         cls.lc = lc
 
         # Simple lc to demonstrate rebinning of dyn ps

--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -102,7 +102,7 @@ class TestVarEnergySpectrum(object):
             vespec._construct_lightcurves([0, 0.5],
                                           tstart=0, tstop=0.65)
         np.testing.assert_allclose(base_lc.counts, [1, 0, 2, 1, 0, 0])
-        np.testing.assert_allclose(ref_lc.counts, [0, 0, 0, 1, 0, 1])
+        np.testing.assert_allclose(ref_lc.counts, [0, 0, 0, 0, 1, 1])
 
     def test_construct_lightcurves_no_exclude(self):
         events = EventList([0.09, 0.21, 0.23, 0.32, 0.4, 0.54],
@@ -129,7 +129,7 @@ class TestVarEnergySpectrum(object):
             vespec._construct_lightcurves([0, 0.5],
                                           tstart=0, tstop=0.65)
         np.testing.assert_allclose(base_lc.counts, [1, 0, 2, 1, 0, 0])
-        np.testing.assert_allclose(ref_lc.counts, [0, 0, 0, 1, 0, 1])
+        np.testing.assert_allclose(ref_lc.counts, [0, 0, 0, 0, 1, 1])
 
 
 class TestRMSEnergySpectrum(object):

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -550,7 +550,8 @@ def poisson_symmetrical_errors(counts):
     >>> assert np.all(err_thisfun == err)
     """
     from astropy.stats import poisson_conf_interval
-    count_values = np.unique(np.asarray(counts, dtype=np.int64))
+    counts_int = np.asarray(counts, dtype=np.int64)
+    count_values = np.unique(counts_int)
     err_low, err_high = \
         poisson_conf_interval(count_values,
                               interval='frequentist-confidence', sigma=1)
@@ -559,5 +560,5 @@ def poisson_symmetrical_errors(counts):
     err_high -= np.asarray(count_values)
     err = (np.absolute(err_low) + np.absolute(err_high))/2.0
 
-    idxs = np.searchsorted(count_values, counts)
+    idxs = np.searchsorted(count_values, counts_int)
     return err[idxs]

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -465,6 +465,14 @@ def baseline_als(x, y, lam=None, p=None, niter=10, return_baseline=False,
         The initial time series, subtracted from the trend
     baseline : array-like, same size as y
         Fitted baseline. Only returned if return_baseline is True
+
+    Examples
+    --------
+    >>> x = np.arange(0, 10, 0.01)
+    >>> y = np.zeros_like(x) + 10
+    >>> ysub = baseline_als(x, y)
+    >>> np.all(ysub < 0.001)
+    True
     """
 
     if lam is None:

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -32,6 +32,19 @@ except ImportError:
             return wrapped_f
 
 
+try:
+    from statsmodels.robust import mad as mad  # pylint: disable=unused-import
+except ImportError:
+    def mad(data, c=0.6745, axis=None):
+        """Straight from statsmodels's source code, adapted"""
+        data = np.asarray(data)
+        if axis is not None:
+            center = np.apply_over_axes(np.median, data, axis)
+        else:
+            center = np.median(data)
+        return np.median((np.fabs(data - center)) / c, axis=axis)
+
+
 __all__ = ['simon', 'rebin_data', 'rebin_data_log', 'look_for_array_in_array',
            'is_string', 'is_iterable', 'order_list_of_arrays',
            'optimal_bin_time', 'contiguous_regions', 'is_int',
@@ -346,35 +359,134 @@ def get_random_state(random_state=None):
     return random_state
 
 
-def baseline_als(y, lam, p, niter=10):
-    """Baseline Correction with Asymmetric Least Squares Smoothing.
+def _offset(x, off):
+    """An offset."""
+    return off
 
-    Modifications to the routine from Eilers & Boelens 2005
-    https://www.researchgate.net/publication/228961729_Technical_Report_Baseline_Correction_with_Asymmetric_Least_Squares_Smoothing
-    The Python translation is partly from
-    http://stackoverflow.com/questions/29156532/python-baseline-correction-library
+
+def offset_fit(x, y, offset_start=0):
+    """Fit a constant offset to the data.
 
     Parameters
     ----------
-    y : array of floats
-        the "light curve". It assumes equal spacing.
+    x : array-like
+    y : array-like
+    offset_start : float
+        Constant offset, initial value
+
+    Returns
+    -------
+    offset : float
+        Fitted offset
+    """
+    from scipy.optimize import curve_fit
+    par, _ = curve_fit(_offset, x, y, [offset_start],
+                       maxfev=6000)
+    return par[0]
+
+
+def _als(y, lam, p, niter=10):
+    """Baseline Correction with Asymmetric Least Squares Smoothing.
+
+    Modifications to the routine from Eilers & Boelens 2005
+    https://www.researchgate.net/publication/
+        228961729_Technical_Report_Baseline_Correction_with_
+        Asymmetric_Least_Squares_Smoothing
+    The Python translation is partly from
+    http://stackoverflow.com/questions/29156532/
+        python-baseline-correction-library
+
+    Parameters
+    ----------
+    y : array-like
+        the data series corresponding to x
     lam : float
-        "smoothness" parameter. Larger values make the baseline stiffer
-        Typically 1e2 < lam < 1e9
+        the lambda parameter of the ALS method. This control how much the
+        baseline can adapt to local changes. A higher value corresponds to a
+        stiffer baseline
     p : float
-        "asymmetry" parameter. Smaller values make the baseline more
-        "horizontal". Typically 0.001 < p < 0.1, but not necessary.
+        the asymmetry parameter of the ALS method. This controls the overall
+        slope tollerated for the baseline. A higher value correspond to a
+        higher possible slope
+
+    Other parameters
+    ----------------
+    niter : int
+        The number of iterations to perform
+
+    Returns
+    -------
+    z : array-like, same size as y
+        Fitted baseline.
     """
     from scipy import sparse
     L = len(y)
     D = sparse.csc_matrix(np.diff(np.eye(L), 2))
     w = np.ones(L)
-    for i in range(niter):
+    for _ in range(niter):
         W = sparse.spdiags(w, 0, L, L)
         Z = W + lam * D.dot(D.transpose())
         z = sparse.linalg.spsolve(Z, w * y)
         w = p * (y > z) + (1 - p) * (y < z)
     return z
+
+
+def baseline_als(x, y, lam=None, p=None, niter=10, return_baseline=False,
+                 offset_correction=False):
+    """Baseline Correction with Asymmetric Least Squares Smoothing.
+
+    Parameters
+    ----------
+    x : array-like
+        the sample time/number/position
+    y : array-like
+        the data series corresponding to x
+    lam : float
+        the lambda parameter of the ALS method. This control how much the
+        baseline can adapt to local changes. A higher value corresponds to a
+        stiffer baseline
+    p : float
+        the asymmetry parameter of the ALS method. This controls the overall
+        slope tollerated for the baseline. A higher value correspond to a
+        higher possible slope
+
+    Other Parameters
+    ----------------
+    niter : int
+        The number of iterations to perform
+    return_baseline : bool
+        return the baseline?
+    offset_correction : bool
+        also correct for an offset to align with the running mean of the scan
+
+    Returns
+    -------
+    y_subtracted : array-like, same size as y
+        The initial time series, subtracted from the trend
+    baseline : array-like, same size as y
+        Fitted baseline. Only returned if return_baseline is True
+    """
+
+    if lam is None:
+        lam = 1e11
+    if p is None:
+        p = 0.001
+
+    z = _als(y, lam, p, niter=niter)
+
+    ysub = y - z
+    offset = 0
+    if offset_correction:
+        std = mad(ysub)
+
+        good = np.abs(ysub) < 10 * std
+
+        offset = offset_fit(x[good], ysub[good], 0)
+
+    if return_baseline:
+        return ysub - offset, z + offset
+    else:
+        return ysub - offset
 
 
 def excess_variance(lc, normalization='fvar'):

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -36,7 +36,7 @@ __all__ = ['simon', 'rebin_data', 'rebin_data_log', 'look_for_array_in_array',
            'is_string', 'is_iterable', 'order_list_of_arrays',
            'optimal_bin_time', 'contiguous_regions', 'is_int',
            'get_random_state', 'baseline_als', 'excess_variance',
-           'create_window']
+           'create_window', 'poisson_symmetrical_errors']
 
 def _root_squared_mean(array):
     return np.sqrt(np.sum(array ** 2)) / len(array)
@@ -527,3 +527,37 @@ def create_window(N, window_type='uniform'):
                  a4 * np.cos((8 * np.pi * n) / N_minus_1)
 
     return window
+
+
+def poisson_symmetrical_errors(counts):
+    """Optimized version of frequentist symmetrical errors.
+
+    Uses a lookup table in order to limit the calls to poisson_conf_interval
+
+    Example
+    -------
+    >>> from astropy.stats import poisson_conf_interval
+    >>> counts = np.random.randint(0, 1000, 100)
+    >>> # ---- Do it without the lookup table ----
+    >>> err_low, err_high = poisson_conf_interval(np.asarray(counts),
+    ...                 interval='frequentist-confidence', sigma=1)
+    >>> err_low -= np.asarray(counts)
+    >>> err_high -= np.asarray(counts)
+    >>> err = (np.absolute(err_low) + np.absolute(err_high))/2.0
+    >>> # Do it with this function
+    >>> err_thisfun = poisson_symmetrical_errors(counts)
+    >>> # Test that results are always the same
+    >>> assert np.all(err_thisfun == err)
+    """
+    from astropy.stats import poisson_conf_interval
+    count_values = np.unique(np.asarray(counts, dtype=np.int64))
+    err_low, err_high = \
+        poisson_conf_interval(count_values,
+                              interval='frequentist-confidence', sigma=1)
+    # calculate approximately symmetric uncertainties
+    err_low -= np.asarray(count_values)
+    err_high -= np.asarray(count_values)
+    err = (np.absolute(err_low) + np.absolute(err_high))/2.0
+
+    idxs = np.searchsorted(count_values, counts)
+    return err[idxs]

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -158,7 +158,8 @@ class VarEnergySpectrum(object):
             ref_intervals = self.ref_band
 
         ref_lc = Lightcurve(base_lc.time, np.zeros_like(base_lc.counts),
-                            gti=base_lc.gti, mjdref=base_lc.mjdref)
+                            gti=base_lc.gti, mjdref=base_lc.mjdref,
+                            err_dist='gauss')
 
         for i in ref_intervals:
             good = (energies2 >= i[0]) & (energies2 < i[1])
@@ -170,6 +171,7 @@ class VarEnergySpectrum(object):
                                                 mjdref=self.events2.mjdref)
             ref_lc = ref_lc + new_lc
 
+        ref_lc.err_dist = base_lc.err_dist
         return base_lc, ref_lc
 
     @abstractmethod


### PR DESCRIPTION
This speeds up considerably the light curve creation from events when datasets are large, in three ways:

1. Using `np.bincount` instead of `np.histogram`. Resolves #252

2. Using a jit-compiled function to create GTI masks with a single loop over the time series, instead of the existing, purely pythonic one that used multiple filters on the full dataset for each GTI. Falls back to the old implementation if numba is not installed.

3. Using a lookup table in the calculation of `poisson_conf_interval`. The speedup is HUGE. Two orders of magnitude at least, on large datasets. 

EDIT: Note that `np.bincount` is slower when datasets are small. However, it seems like a good tradeoff. If you think that a use case might be creating a million small light curves, we could think of letting the user choose which function to use. 

I tried creating and loading a 6.5d-long _NuSTAR_ light curve with bin time 0.1 s from an event list. 
Before these changes: ~500 s, dominated by `create_gti_mask` and `poisson_conf_interval`
![screenshot_20171027_153243](https://user-images.githubusercontent.com/7190189/32106573-5726c884-bb2c-11e7-8230-0596549ec57c.png)

After these modifications: ~4.5 seconds, dominated by I/O outside `stingray` (`save_as_netcdf` from `HENDRICS`)
![screenshot_20171027_152927](https://user-images.githubusercontent.com/7190189/32106589-6098b878-bb2c-11e7-8970-db117661dc94.png)
