### PR TITLE
Fix issues with numpy.float128 frequencies and fdots

### DIFF
--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -22,7 +22,8 @@ def _pulse_phase_fast(time, f, fdot, buffer_array):
 def _folding_search(stat_func, times, frequencies, segment_size=5000,
                     use_times=False, fdots=0, **kwargs):
 
-    fgrid, fdgrid = np.meshgrid(frequencies, fdots)
+    fgrid, fdgrid = np.meshgrid(np.asarray(frequencies).astype(np.float64),
+                                np.asarray(fdots).astype(np.float64))
     stats = np.zeros_like(fgrid)
     times = (times - times[0]).astype(np.float64)
     length = times[-1]

--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -24,7 +24,7 @@ class TestAll(object):
         cls.counts = \
             100 + 20 * np.cos(2 * np.pi * cls.times * cls.pulse_frequency)
         cls.gti = [[cls.tstart, cls.tend]]
-        lc = Lightcurve(cls.times, cls.counts, gti=cls.gti)
+        lc = Lightcurve(cls.times, cls.counts, gti=cls.gti, err_dist='gauss')
         events = EventList()
         events.simulate_times(lc)
         cls.event_times = events.time
@@ -149,6 +149,20 @@ class TestAll(object):
         maxfdot = fdot.flatten()[np.argmax(stat)]
         assert np.allclose(maxfdot, 0.0, atol=0.1/self.tseg)
 
+    def test_epoch_folding_search_fdot_float128(self):
+        """Test pulse phase calculation, frequency only."""
+        frequencies = np.arange(9.8, 9.99, 0.1/self.tseg, dtype=np.float128)
+        fdots = np.array([-0.1, 0, 0.1], dtype=np.float128)
+        freq, fdot, stat = \
+            epoch_folding_search(self.event_times.astype(np.float128),
+                                 frequencies, nbin=43, fdots=fdots)
+
+        minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))
+        maxstatbin = freq.flatten()[np.argmax(stat)]
+        assert np.allclose(maxstatbin, frequencies[minbin], atol=0.1/self.tseg)
+        maxfdot = fdot.flatten()[np.argmax(stat)]
+        assert np.allclose(maxfdot, 0.0, atol=0.1/self.tseg)
+
     def test_epoch_folding_search_expocorr_fails(self):
         """Test pulse phase calculation, frequency only."""
         frequencies = np.arange(9.8, 9.99, 0.1/self.tseg)
@@ -171,9 +185,10 @@ class TestAll(object):
         """Test pulse phase calculation, frequency only."""
         frequencies = np.arange(9.8, 9.99, 0.1/self.tseg)
         fdots = [-0.1, 0, 0.1]
-        freq, fdot, stat = epoch_folding_search(self.event_times, frequencies,
-                                                nbin=42, expocorr=True, gti=self.gti,
-                                                fdots=fdots)
+        freq, fdot, stat = \
+            epoch_folding_search(self.event_times, frequencies,
+                                 nbin=42, expocorr=True, gti=self.gti,
+                                 fdots=fdots)
 
         minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))
         maxstatbin = freq.flatten()[np.argmax(stat)]
@@ -221,6 +236,20 @@ class TestAll(object):
         frequencies = np.arange(9.8, 9.99, 0.1/self.tseg)
         fdots = [-0.1, 0, 0.1]
         freq, fdot, stat = z_n_search(self.event_times, frequencies, nbin=25,
+                                      nharm=2, fdots=fdots)
+
+        minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))
+        maxstatbin = freq.flatten()[np.argmax(stat)]
+        assert np.allclose(maxstatbin, frequencies[minbin], atol=0.1/self.tseg)
+        maxfdot = fdot.flatten()[np.argmax(stat)]
+        assert np.allclose(maxfdot, 0.0, atol=0.1/self.tseg)
+
+    def test_z_n_search_fdot_float128(self):
+        """Test pulse phase calculation, frequency only."""
+        frequencies = np.arange(9.8, 9.99, 0.1/self.tseg, dtype=np.float128)
+        fdots = np.array([-0.1, 0, 0.1], dtype=np.float128)
+        freq, fdot, stat = z_n_search(self.event_times.astype(np.float128),
+                                      frequencies, nbin=25,
                                       nharm=2, fdots=fdots)
 
         minbin = np.argmin(np.abs(frequencies - self.pulse_frequency))


### PR DESCRIPTION
@ricardovb reported on an error arising when frequencies and fdots are `numpy.float128`s. 
https://github.com/StingraySoftware/HENDRICS/issues/25
The error is actually due to Stingray, and this PR fixes it.
It should be pretty quick to review.