### PR TITLE
Fixed rebinning issues for complex numbers

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -469,7 +469,6 @@ class Crossspectrum(object):
 
     def _phase_lag(self):
         """Return the fourier phase lag of the cross spectrum."""
-
         return np.angle(self.unnorm_power)
 
     def time_lag(self):
@@ -758,9 +757,18 @@ class AveragedCrossspectrum(Crossspectrum):
         """Calculate time lag and uncertainty.
 
         Formula from Bendat & Piersol 1986
+
+        Returns
+        -------
+        lag : np.ndarray
+            The time lag
+
+        lag_err : np.ndarray
+            The uncertainty in the time lag
+
         """
         lag = super(AveragedCrossspectrum, self).time_lag()
         coh, uncert = self.coherence()
         dum = (1. - coh) / (2. * coh)
         lag_err = np.sqrt(dum / self.m) / (2 * np.pi * self.freq)
-        return (lag, lag_err)
+        return lag, lag_err

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -381,6 +381,11 @@ class TestAveragedCrossspectrum(object):
         new_cs = self.cs.rebin_log(f=0.1)
         assert isinstance(new_cs.power[0], np.complex)
 
+    def test_rebin_log_returns_complex_errors(self):
+        # For now, just verify that it doesn't crash
+        new_cs = self.cs.rebin_log(f=0.1)
+        assert isinstance(new_cs.power_err[0], np.complex)
+
     def test_timelag(self):
         from ..simulator.simulator import Simulator
         dt = 0.1

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -376,6 +376,11 @@ class TestAveragedCrossspectrum(object):
         assert type(new_cs) == type(self.cs)
         new_cs.time_lag()
 
+    def test_rebin_log_returns_complex_values(self):
+        # For now, just verify that it doesn't crash
+        new_cs = self.cs.rebin_log(f=0.1)
+        assert isinstance(new_cs.power[0], np.complex)
+
     def test_timelag(self):
         from ..simulator.simulator import Simulator
         dt = 0.1


### PR DESCRIPTION
This should fix the issue whereby the `rebin_data_log` in `utils.py` casts complex numbers to real ones, which means we loose the imaginary parts of the cross spectrum when rebinning. 

It now computes the real and imaginary parts of the rebinned cross spectrum separately and combines them back in the end into a set of complex values. 