### PR TITLE
Fixed bug where GTIs were not taken into account correctly in rebinning light curves

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -604,25 +604,30 @@ class Lightcurve(object):
 
         else:
             bin_time, bin_counts, bin_err = [], [], []
+            gti_new = []
             for g  in self.gti:
-                # find start and end of GTI segment in data
-                start_ind = self.time.searchsorted(g[0])
-                end_ind = self.time.searchsorted(g[1])
+                if g[1] - g[0] < dt_new:
+                    continue
+                else:
+                    # find start and end of GTI segment in data
+                    start_ind = self.time.searchsorted(g[0])
+                    end_ind = self.time.searchsorted(g[1])
 
-                t_temp = self.time[start_ind:end_ind]
-                c_temp = self.counts[start_ind:end_ind]
-                e_temp = self.counts_err[start_ind:end_ind]
+                    t_temp = self.time[start_ind:end_ind]
+                    c_temp = self.counts[start_ind:end_ind]
+                    e_temp = self.counts_err[start_ind:end_ind]
 
-                bin_t, bin_c, bin_e, _ = \
-                    utils.rebin_data(t_temp, c_temp, dt_new,
-                                     yerr=e_temp, method=method)
+                    bin_t, bin_c, bin_e, _ = \
+                        utils.rebin_data(t_temp, c_temp, dt_new,
+                                         yerr=e_temp, method=method)
 
-                bin_time.extend(bin_t)
-                bin_counts.extend(bin_c)
-                bin_err.extend(bin_e)
+                    bin_time.extend(bin_t)
+                    bin_counts.extend(bin_c)
+                    bin_err.extend(bin_e)
+                    gti_new.append(g)
 
         lc_new = Lightcurve(bin_time, bin_counts, err=bin_err,
-                            mjdref=self.mjdref, dt=dt_new, gti=self.gti)
+                            mjdref=self.mjdref, dt=dt_new, gti=gti_new)
         return lc_new
 
     def join(self, other):

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -747,6 +747,21 @@ class TestLightcurveRebin(object):
         for dt in dt_all:
             self.rebin_several(dt)
 
+    def test_rebin_with_gtis(self):
+        times = np.arange(0, 100, 0.1)
+
+        counts = np.random.normal(100, 0.1, size=times.shape[0])
+        gti = [[0, 40], [60, 100]]
+
+        good = create_gti_mask(times, gti)
+
+        counts[np.logical_not(good)] = 0
+        lc = Lightcurve(times, counts, gti=gti)
+
+        lc_rebin = lc.rebin(1.0)
+
+        assert (lc_rebin.time[39] - lc_rebin.time[38]) > 1.0
+
     def test_lc_baseline(self):
         times = np.arange(0, 100, 0.01)
         counts = np.random.normal(100, 0.1, len(times)) + \


### PR DESCRIPTION
This fix should solve #280, I hope. If GTIs are present, it will rebin each segment separately, and then combine the outputs into one new rebinned light curve. 