### PR TITLE
Fix rms error

### DIFF
--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -157,11 +157,7 @@ class TestRMSEnergySpectrum(object):
         assert np.allclose(self.rms.spectrum, 0.4, 0.05)
 
     def test_correct_rms_errorbars(self):
-
-        # Assert that the rms measured at all energies is the same
-        assert np.all(
-            np.abs(self.rms.spectrum - self.rms.spectrum[0]) < \
-                self.rms.spectrum_error)
+        assert np.allclose(self.rms.spectrum_error, 0.0014, atol=0.0001)
 
     def test_rms_invalid_evlist_warns(self):
         ev = EventList(time=[], energy=[], gti=self.rms.events1.gti)

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -201,7 +201,7 @@ class RmsEnergySpectrum(VarEnergySpectrum):
                 rms_spec[i] = np.sqrt(np.sum(xspect.power[good]*xspect.df))
 
                 # Root squared sum of errors of the spectrum
-                root_sq_err_sum = np.sqrt(np.sum(xspect.power[good]**2))*xspect.df
+                root_sq_err_sum = np.sqrt(np.sum(xspect.power_err[good]**2))*xspect.df
                 # But the rms is the squared root. So,
                 # Error propagation
                 rms_spec_err[i] = 1 / (2 * rms_spec[i]) * root_sq_err_sum

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -201,7 +201,7 @@ class RmsEnergySpectrum(VarEnergySpectrum):
                 rms_spec[i] = np.sqrt(np.sum(xspect.power[good]*xspect.df))
 
                 # Root squared sum of errors of the spectrum
-                root_sq_err_sum = np.sqrt(np.sum(xspect.power_err[good]**2))*xspect.df
+                root_sq_err_sum = np.sqrt(np.sum((xspect.power_err[good]*xspect.df)**2))
                 # But the rms is the squared root. So,
                 # Error propagation
                 rms_spec_err[i] = 1 / (2 * rms_spec[i]) * root_sq_err_sum


### PR DESCRIPTION
The error bar in the rms spectrum was evidently wrong, because it was assuming the _power_ instead of the _power error_ in the squared sum.
Now it should be correct.