### PR TITLE
Fix rms error

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -738,7 +738,7 @@ class AveragedCrossspectrum(Crossspectrum):
                   "expected statistical distributions.")
 
         # Calculate average coherence
-        unnorm_power_avg = self.unnorm_power / self.m
+        unnorm_power_avg = self.unnorm_power
 
         num = np.absolute(unnorm_power_avg) ** 2
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -695,6 +695,7 @@ class AveragedCrossspectrum(Crossspectrum):
 
         power_avg /= np.float(m)
         power_err_avg = np.sqrt(power_err_avg) / m
+        unnorm_power_avg /= np.float(m)
 
         self.freq = self.cs_all[0].freq
         self.power = power_avg

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -182,7 +182,7 @@ class Powerspectrum(Crossspectrum):
 
         return bin_ps
 
-    def compute_rms(self, min_freq, max_freq):
+    def compute_rms(self, min_freq, max_freq, white_noise_offset=2.):
         """
         Compute the fractional rms amplitude in the periodgram
         between two frequencies.
@@ -194,6 +194,14 @@ class Powerspectrum(Crossspectrum):
 
         max_freq: float
             The upper frequency bound for the calculation
+
+        Other parameters
+        ----------------
+        white_noise_offset : float, default 2
+            This is the white noise level, in Leahy normalization. In the ideal
+            case, this is 2. Dead time and other instrumental effects can alter
+            it. The user can fit the white noise level outside this function
+            and it will get subtracted from powers here.
 
         Returns
         -------
@@ -207,14 +215,14 @@ class Powerspectrum(Crossspectrum):
         powers = self.power[minind:maxind]
 
         if self.norm.lower() == 'leahy':
-            rms = np.sqrt(np.sum(powers) / self.nphots)
-
+            powers_leahy = powers
         elif self.norm.lower() == "frac":
-            rms = np.sqrt(np.sum(powers * self.df))
+            powers_leahy = self.unnorm_power[minind:maxind] * 2 / self.nphots
         else:
             raise TypeError("Normalization not recognized!")
 
-        rms_err = self._rms_error(powers)
+        rms = np.sqrt(np.sum(powers_leahy - white_noise_offset) / self.nphots)
+        rms_err = self._rms_error(powers_leahy)
 
         return rms, rms_err
 


### PR DESCRIPTION
Resolves #285
Now it is possible to subtract white noise when calculating the rms.
Fixes (I think) an inconsistency in the normalization factors used when calculating error bars on the rms.
Need to check that the values coming out of this make sense in different conditions