### PR TITLE
Changed np.where to np.searchsorted in truncate method

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -828,10 +828,10 @@ class Lightcurve(object):
                 raise ValueError("start time must be less than stop time!")
 
         if not start == 0:
-            start = np.where(self.time == start)[0][0]
+            start = self.time.searchsorted(start)
 
         if stop is not None:
-            stop = np.where(self.time == stop)[0][0]
+            stop = self.time.searchsorted(stop)
 
         return self._truncate_by_index(start, stop)
 


### PR DESCRIPTION
Tiny bug fix in `Lightcurve.truncate`: `truncate_by_time()` will fail if the time chosen to truncate at does *not* exactly match one of the time stamps of the light curve. I think that shouldn't be a necessary requirement: we should be able to truncate at whatever time we want, and it'll just find the nearest index.

Because our time arrays should be strictly sorted, `np.searchsorted()` is the better alternative here, since unlike `where()`, it doesn't require an exact match of the time indices. Hence the change in this PR.