### PR TITLE
Can now run classical_significances on log-binned periodograms

### DIFF
--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -314,10 +314,15 @@ class Powerspectrum(Crossspectrum):
             raise ValueError("This method only works on "
                              "Leahy-normalized power spectra!")
 
-        # calculate p-values for all powers
-        # leave out zeroth power since it just encodes the number of photons!
-        pv = np.array([classical_pvalue(power, self.m)
-                       for power in self.power])
+        if np.size(self.m) == 1:
+            # calculate p-values for all powers
+            # leave out zeroth power since it just encodes the number of photons!
+            pv = np.array([classical_pvalue(power, self.m)
+                           for power in self.power])
+        else:
+            pv = np.array([classical_pvalue(power, m)
+                           for power, m in zip(self.power, self.m)])
+
 
         # if trial correction is used, then correct the threshold for
         # the number of powers in the power spectrum

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -109,8 +109,6 @@ class TestPowerspectrum(object):
         ps = Powerspectrum(lc=self.lc, norm="frac")
         ps_int = np.sum(ps.power[:-1] * ps.df) + ps.power[-1] * ps.df / 2
         std_lc = np.var(self.lc.counts) / np.mean(self.lc.counts) ** 2
-        print(ps_int)
-        print(std_lc)
         assert np.isclose(ps_int, std_lc, atol=0.01, rtol=0.01)
 
     def test_fractional_rms_in_frac_norm_is_consistent(self):
@@ -286,6 +284,14 @@ class TestPowerspectrum(object):
         pval = ps.classical_significances(threshold=threshold,
                                           trial_correction=True)
         assert np.size(pval) == 0
+
+
+    def test_classical_significances_with_logbinned_psd(self):
+        ps = Powerspectrum(lc=self.lc, norm="leahy")
+        ps_log = ps.rebin_log()
+        pval = ps_log.classical_significances(threshold=1.1, trial_correction=False)
+
+        assert len(pval[0]) == len(ps_log.power)
 
     def test_pvals_is_numpy_array(self):
         ps = Powerspectrum(lc=self.lc, norm="leahy")

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -224,19 +224,27 @@ def rebin_data_log(x, y, f, y_err=None, dx=None):
     """
 
     dx_init = assign_value_if_none(dx, np.median(np.diff(x)))
+    x = np.asarray(x)
     y = np.asarray(y)
     y_err = np.asarray(assign_value_if_none(y_err, np.zeros_like(y)))
 
-    minx = x[1] * 0.5  # frequency to start from
+    if x.shape[0] != y.shape[0]:
+        raise ValueError("x and y must be of the same length!")
+    if y.shape[0] != y_err.shape[0]:
+        raise ValueError("y and y_err must be of the same length!")
+
+    minx = x[0] * 0.5  # frequency to start from
     maxx = x[-1]  # maximum frequency to end
     binx = [minx, minx + dx_init]  # first
-    dx = x[1]  # the frequency resolution of the first bin
+    dx = dx_init  # the frequency resolution of the first bin
 
     # until we reach the maximum frequency, increase the width of each
     # frequency bin by f
     while binx[-1] <= maxx:
         binx.append(binx[-1] + dx * (1.0 + f))
         dx = binx[-1] - binx[-2]
+
+    binx = np.asarray(binx)
 
     real = y.real
     real_err = y_err.real

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -222,6 +222,7 @@ def rebin_data_log(x, y, f, y_err=None, dx=None):
     step_size: float
         The size of the binning step
     """
+
     dx_init = assign_value_if_none(dx, np.median(np.diff(x)))
     y = np.asarray(y)
     y_err = np.asarray(assign_value_if_none(y_err, np.zeros_like(y)))
@@ -267,7 +268,7 @@ def rebin_data_log(x, y, f, y_err=None, dx=None):
 
     # compute the number of powers in each frequency bin
     nsamples = np.array([len(binno[np.where(binno == i)[0]])
-                         for i in range(np.max(binno))])
+                         for i in range(1, np.max(binno)+1, 1)])
 
     return binx, biny, biny_err, nsamples
 


### PR DESCRIPTION
I realized it wasn't possible to run the method `classical_significances` on log-binned periodograms, because it expected `self.m` to be a single integer, rather than a `numpy.ndarray`. 

In the process of enabling that functionality, I discovered a bug in the way `self.m` was calculated for the log-binned periodogram and fixed that, too.