### PR TITLE
warning about unequal bin sizes now works correctly when GTIs are loaded

### DIFF
--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -148,6 +148,11 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
     epsilon : float
         fraction of dt that is tolerated at the borders of a GTI
     """
+    if len(time) == 0:
+        raise ValueError("Passing an empty time array to create_gti_mask")
+    if len(gtis) == 0:
+        raise ValueError("Passing an empty GTI array to create_gti_mask")
+
     try:
         from numba import jit
     except ImportError:

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -156,6 +156,7 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
                                         min_length=min_length,
                                         return_new_gtis=return_new_gtis,
                                         dt=dt, epsilon=epsilon)
+
     gtis = np.array(gtis, dtype=np.longdouble)
     check_gtis(gtis)
 
@@ -176,8 +177,8 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
     # in order to simplify the calculation of the mask, but they will _not_
     # be returned.
     gtis_to_mask = copy.deepcopy(gtis_new)
-    gtis_to_mask[:, 0] = gtis_new[:, 0] - epsilon*dt + dt / 2
-    gtis_to_mask[:, 1] = gtis_new[:, 1] + epsilon*dt - dt / 2
+    gtis_to_mask[:, 0] = gtis_new[:, 0] - epsilon * dt + dt / 2
+    gtis_to_mask[:, 1] = gtis_new[:, 1] + epsilon * dt - dt / 2
 
     mask, gtimask = \
         create_gti_mask_jit((time - time[0]).astype(np.float64),

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -180,6 +180,7 @@ class Lightcurve(object):
             np.asarray(assign_value_if_none(gti,
                                             [[self.tstart,
                                               self.tstart + self.tseg]]))
+
         check_gtis(self.gti)
         good = create_gti_mask(self.time, self.gti)
 
@@ -201,7 +202,13 @@ class Lightcurve(object):
 
         # Issue a warning if the input time iterable isn't regularly spaced,
         # i.e. the bin sizes aren't equal throughout.
-        dt_array = np.diff(self.time)
+        dt_array = []
+        for g in self.gti:
+            mask = create_gti_mask(self.time, [g])
+            t = self.time[mask]
+            dt_array.extend(np.diff(t))
+        dt_array = np.asarray(dt_array)
+
         if not (np.allclose(dt_array, np.repeat(self.dt, dt_array.shape[0]))):
             simon("Bin sizes in input time array aren't equal throughout! "
                   "This could cause problems with Fourier transforms. "

--- a/stingray/tests/test_gti.py
+++ b/stingray/tests/test_gti.py
@@ -59,6 +59,20 @@ class TestGTI(object):
         # bin at times 0, 2, 4 and 5 are not in.
         assert np.all(mask == np.array([0, 1, 0, 0, 0, 0, 0], dtype=bool))
 
+    def test_gti_mask_fails_empty_time(self):
+        arr = np.array([])
+        gti = np.array([[0, 2.1], [3.9, 5]])
+        with pytest.raises(ValueError) as excinfo:
+            create_gti_mask(arr, gti, return_new_gtis=True)
+        assert 'empty time array' in str(excinfo)
+
+    def test_gti_mask_fails_empty_gti(self):
+        arr = np.array([0, 1, 2, 3, 4, 5, 6])
+        gti = np.array([])
+        with pytest.raises(ValueError) as excinfo:
+            create_gti_mask(arr, gti, return_new_gtis=True)
+        assert 'empty GTI array' in str(excinfo)
+
     def test_gti_mask_complete(self):
         arr = np.array([0, 1, 2, 3, 4, 5, 6])
         gti = np.array([[0, 2.1], [3.9, 5]])

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -439,7 +439,7 @@ class TestLightcurve(object):
         assert np.all(lc[::2].gti == [[0.5, 1.5], [2.5, 3.5]])
         assert np.all(lc[:].gti == lc.gti)
         assert lc[:].mjdref == lc.mjdref
-
+        assert lc[::2].n == 2
 
     def test_slicing_index_error(self):
         lc = Lightcurve(self.times, self.counts)


### PR DESCRIPTION
Should fix issue #257, if I understood it correctly.