### PR TITLE
Make TOA calculation more robust

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
-filterwarnings =
-    once
-    ignore::DeprecationWarning
 
 [ah_bootstrap]
 auto_use = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,9 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
+filterwarnings =
+    once
+    ignore::DeprecationWarning
 
 [ah_bootstrap]
 auto_use = True

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -75,7 +75,6 @@ def check_gtis(gti):
     gti_start = gti[:, 0]
     gti_end = gti[:, 1]
 
-    logging.debug('-- GTI: ' + repr(gti))
     # Check that GTIs are well-behaved
     if not np.all(gti_end >= gti_start):
         raise ValueError('This GTI end times must be larger than '
@@ -84,8 +83,6 @@ def check_gtis(gti):
     # Check that there are no overlaps in GTIs
     if not np.all(gti_start[1:] >= gti_end[:-1]):
         raise ValueError('This GTI has overlaps')
-
-    logging.debug('-- Correct')
 
     return
 

--- a/stingray/pulse/modeling.py
+++ b/stingray/pulse/modeling.py
@@ -93,8 +93,10 @@ def sinc_square_deriv(x, amplitude=1., mean=0., width=1.):
     """
     x_is_zero = x == mean
 
-    d_x = 2 * amplitude * sinc((x-mean)/width) * (x * np.cos((x-mean)/width) \
-        - np.sin((x-mean)/width)) / ((x-mean)/width)**2
+    d_x = 2 * amplitude * \
+        sinc((x-mean)/width) * (
+                  x * np.cos((x-mean)/width) -
+                  np.sin((x - mean) / width)) / ((x - mean) / width) ** 2
     d_x = np.asarray(d_x)
     d_amplitude = sinc((x-mean)/width)**2
     d_x[x_is_zero] = 0
@@ -107,6 +109,7 @@ def sinc_square_deriv(x, amplitude=1., mean=0., width=1.):
 
 _SincSquareModel = models.custom_model(sinc_square_model,
                                        fit_deriv=sinc_square_deriv)
+
 
 class SincSquareModel(_SincSquareModel):
     def __reduce__(cls):
@@ -153,14 +156,14 @@ def fit_sinc(x, y, amp=1.5, mean=0., width=1., tied={}, fixed={}, bounds={},
         width = 1 / (np.pi * obs_length)
         fixed["width"] = True
 
-    sinc_in = SincSquareModel(amplitude=amp, mean=mean,width=width, tied=tied,
+    sinc_in = SincSquareModel(amplitude=amp, mean=mean, width=width, tied=tied,
                               fixed=fixed, bounds=bounds)
     fit_s = fitting.LevMarLSQFitter()
     sincfit = fit_s(sinc_in, x, y)
     return sincfit
 
 
-def fit_gaussian(x, y, amplitude=1.5,mean=0.,stddev=2., tied={}, fixed={},
+def fit_gaussian(x, y, amplitude=1.5, mean=0., stddev=2., tied={}, fixed={},
                  bounds={}):
     """
     Fit a gaussian function to x,y values.
@@ -190,7 +193,7 @@ def fit_gaussian(x, y, amplitude=1.5,mean=0.,stddev=2., tied={}, fixed={},
         The best-fit function, accepting x as input
         and returning the best-fit model as output
     """
-    g_in = models.Gaussian1D(amplitude=amplitude,mean=mean,stddev=stddev,
+    g_in = models.Gaussian1D(amplitude=amplitude, mean=mean, stddev=stddev,
                              tied=tied, fixed=fixed, bounds=bounds)
     fit_g = fitting.LevMarLSQFitter()
     g = fit_g(g_in, x, y)

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -341,7 +341,7 @@ def z_n(phase, n=2, norm=1):
                 np.sum(np.sin(k * phase) * norm) ** 2
                 for k in range(1, n + 1)])
 
-    
+
 def z2_n_detection_level(n=2, epsilon=0.01, ntrial=1):
     """Return the detection level for the Z^2_n statistics.
 
@@ -566,12 +566,7 @@ def fftfit_error(template, sigma=None, **fftfit_kwargs):
     ph_fit = np.zeros(nstep)
     amp_fit = np.zeros(nstep)
     # use bootstrap method to calculate errors
-    shift = 0
-    phase = np.arange(0, 1, 1 / nbin)
-    maxphase = np.argmax(template) / nbin
-
     for i in range(nstep):
-        shift = i
         newprof = np.random.normal(0, sigma, len(template)) + template
         dph = np.random.normal(0, 0.5 / nbin)
         p0 = [1, dph]
@@ -672,7 +667,7 @@ def _load_and_prepare_TOAs(mjds, ephem="DE405"):
     for i, m in enumerate(mjds):
         toalist[i] = toa.TOA(m, obs='Barycenter', scale='tdb')
 
-    toalist = toa.TOAs(toalist = toalist)
+    toalist = toa.TOAs(toalist=toalist)
     if 'tdb' not in toalist.table.colnames:
         toalist.compute_TDBs()
     if 'ssb_obs_pos' not in toalist.table.colnames:
@@ -718,7 +713,8 @@ def get_orbital_correction_from_ephemeris_file(mjdstart, mjdstop, parfile,
     m = get_model(parfile)
     delays = m.delay(toalist.table)
     correction_mjd = \
-        interp1d(mjds, (toalist.table['tdbld'] * units.d - delays).to(units.d).value)
+        interp1d(mjds,
+                 (toalist.table['tdbld'] * units.d - delays).to(units.d).value)
 
     def correction_sec(times, mjdref):
         deorb_mjds = correction_mjd(times / 86400 + mjdref)

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -429,8 +429,7 @@ def fftfit_fun(profile, template, amplitude, phase):
 
 
 def _fft_fun_wrap(pars, data):
-    '''Wrap parameters and input data up in order to be used with minimization
-    algorithms.'''
+    '''Wrap parameters and input data up for minimization algorithms.'''
     amplitude, phase = pars
     profile, template = data
     return fftfit_fun(profile, template, amplitude, phase)
@@ -457,6 +456,7 @@ def _pulse_template(phase, prof):
 def fftfit(prof, template=None, quick=False, sigma=None, use_bootstrap=False,
            **fftfit_kwargs):
     """Align a template to a pulse profile.
+
     Parameters
     ----------
     phase : array
@@ -466,12 +466,14 @@ def fftfit(prof, template=None, quick=False, sigma=None, use_bootstrap=False,
     template : array, default None
         The template of the pulse used to perform the TOA calculation. If None,
         a simple sinusoid is used
+
     Returns
     -------
     mean_amp, std_amp : floats
         Mean and standard deviation of the amplitude
     mean_phase, std_phase : floats
         Mean and standard deviation of the phase
+
     Other Parameters
     ----------------
     fftfit_kwargs : arguments
@@ -535,6 +537,7 @@ def fftfit(prof, template=None, quick=False, sigma=None, use_bootstrap=False,
 
 def fftfit_error(template, sigma=None, **fftfit_kwargs):
     """Calculate the error on the fit parameters from FFTFIT.
+
     Parameters
     ----------
     phase : array
@@ -545,12 +548,14 @@ def fftfit_error(template, sigma=None, **fftfit_kwargs):
         The template of the pulse used to perform the TOA calculation
     p0 : list
         The initial parameters for the fit
+
     Returns
     -------
     mean_amp, std_amp : floats
         Mean and standard deviation of the amplitude
     mean_phase, std_phase : floats
         Mean and standard deviation of the phase
+
     Other parameters
     ----------------
     nstep : int, optional, default 100
@@ -598,6 +603,7 @@ def fftfit_error(template, sigma=None, **fftfit_kwargs):
 
 def plot_TOA_fit(profile, template, toa, mod=None, toaerr=None,
                  additional_phase=0., show=True, period=1):
+    """Plot diagnostic information on the TOA."""
     import matplotlib.pyplot as plt
     from scipy.interpolate import interp1d
     import time
@@ -626,6 +632,7 @@ def get_TOA(prof, period, tstart, template=None, additional_phase=0,
             quick=False, debug=False, use_bootstrap=False,
             **fftfit_kwargs):
     """Calculate the Time-Of-Arrival of a pulse.
+
     Parameters
     ----------
     prof : array
@@ -635,10 +642,12 @@ def get_TOA(prof, period, tstart, template=None, additional_phase=0,
         Otherwise use the default of fftfit
     tstart : float
         The time at the start of the pulse profile
+
     Returns
     -------
     toa, toastd : floats
         Mean and standard deviation of the TOA
+
     Other parameters
     ----------------
     nstep : int, optional, default 100

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -435,24 +435,6 @@ def _fft_fun_wrap(pars, data):
     return fftfit_fun(profile, template, amplitude, phase)
 
 
-def _triple_sinusoid_model(phase, a0, ph, a1, ph1, a2, ph2):
-    twopi = np.pi * 2
-    return a0 * np.cos(twopi * (phase - ph)) + \
-        a1 * np.cos(twopi * (2 * (phase - ph - ph1))) + \
-        a2 * np.cos(twopi * (3 * (phase - ph - ph2)))
-
-
-def _pulse_template(phase, prof):
-    pres, pcov = curve_fit(_triple_sinusoid_model, phase, prof)
-
-    template = _triple_sinusoid_model(phase, *pres)
-
-    fine_phase = np.arange(0, 1, 0.0001)
-    fine_template = _triple_sinusoid_model(fine_phase, *pres)
-    additional_phase = fine_phase[np.argmax(fine_template)]
-    return template, additional_phase
-
-
 def fftfit(prof, template=None, quick=False, sigma=None, use_bootstrap=False,
            **fftfit_kwargs):
     """Align a template to a pulse profile.
@@ -480,8 +462,6 @@ def fftfit(prof, template=None, quick=False, sigma=None, use_bootstrap=False,
         Additional arguments to be passed to error calculation
     """
     prof = prof - np.mean(prof)
-    if sigma is None:
-        sigma = np.sqrt(prof)
 
     nbin = len(prof)
 

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -441,13 +441,19 @@ def fftfit(prof, template=None, quick=False, sigma=None, use_bootstrap=False,
 
     Parameters
     ----------
-    phase : array
-        The phases corresponding to each bin of the profile
     prof : array
         The pulse profile
     template : array, default None
         The template of the pulse used to perform the TOA calculation. If None,
         a simple sinusoid is used
+
+    Other parameters
+    ----------------
+    sigma : array
+        error on profile bins (currently has no effect)
+    use_bootstrap : bool
+        Calculate errors using a bootstrap method, with `fftfit_error`
+    **fftfit_kwargs : additional arguments for `fftfit_error`
 
     Returns
     -------
@@ -555,6 +561,9 @@ def fftfit_error(template, sigma=None, **fftfit_kwargs):
     ----------------
     nstep : int, optional, default 100
         Number of steps for the bootstrap method
+    sigma : array, default None
+        error on profile bins. If None, the square root of the mean profile
+        is used.
     """
     nstep = _default_value_if_no_key(fftfit_kwargs, "nstep", 100)
 
@@ -593,8 +602,8 @@ def fftfit_error(template, sigma=None, **fftfit_kwargs):
     return np.mean(amp_fit), np.std(amp_fit), mean_save, std_save
 
 
-def plot_TOA_fit(profile, template, toa, mod=None, toaerr=None,
-                 additional_phase=0., show=True, period=1):
+def _plot_TOA_fit(profile, template, toa, mod=None, toaerr=None,
+                  additional_phase=0., show=True, period=1):
     """Plot diagnostic information on the TOA."""
     import matplotlib.pyplot as plt
     from scipy.interpolate import interp1d
@@ -656,9 +665,9 @@ def get_TOA(prof, period, tstart, template=None, additional_phase=0,
     toaerr = phase_res_err * period
 
     if debug:
-        plot_TOA_fit(prof, template, toa - tstart, toaerr=toaerr,
-                     additional_phase=additional_phase,
-                     period=period)
+        _plot_TOA_fit(prof, template, toa - tstart, toaerr=toaerr,
+                      additional_phase=additional_phase,
+                      period=period)
 
     return toa, toaerr
 

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -4,7 +4,7 @@ Basic pulsar-related functions and statistics.
 from __future__ import division, print_function, absolute_import
 import numpy as np
 import collections
-from ..utils import simon, jit
+from ..utils import simon, jit, mad
 from scipy.optimize import minimize, basinhopping, curve_fit
 try:
     import pint.toa as toa
@@ -454,9 +454,9 @@ def _pulse_template(phase, prof):
     return template, additional_phase
 
 
-def fftfit(prof, template=None, **fftfit_kwargs):
+def fftfit(prof, template=None, quick=False, sigma=None, use_bootstrap=False,
+           **fftfit_kwargs):
     """Align a template to a pulse profile.
-
     Parameters
     ----------
     phase : array
@@ -466,41 +466,75 @@ def fftfit(prof, template=None, **fftfit_kwargs):
     template : array, default None
         The template of the pulse used to perform the TOA calculation. If None,
         a simple sinusoid is used
-
     Returns
     -------
     mean_amp, std_amp : floats
         Mean and standard deviation of the amplitude
     mean_phase, std_phase : floats
         Mean and standard deviation of the phase
-
     Other Parameters
     ----------------
     fftfit_kwargs : arguments
         Additional arguments to be passed to error calculation
     """
     prof = prof - np.mean(prof)
+    if sigma is None:
+        sigma = np.sqrt(prof)
 
     nbin = len(prof)
 
-    ph = np.arange(0, 1, 1/nbin)
+    ph = np.arange(0, 1, 1 / nbin)
     if template is None:
         template = np.cos(2 * np.pi * ph)
     template = template - np.mean(template)
 
-    p0 = [np.max(prof), np.float(np.argmax(prof) / nbin)]
+    dph = np.float((np.argmax(prof) - np.argmax(template) - 0.2) / nbin)
+    while dph > 0.5:
+        dph -= 1.
+    while dph < -0.5:
+        dph += 1.
 
-    res = basinhopping(_fft_fun_wrap, p0,
-                       minimizer_kwargs={'args': ([prof, template],),
-                                         'bounds': [[0, None], [0, None]]},
-                       niter=10000, niter_success=200)
+    if quick:
+        min_chisq = 1e32
 
-    return fftfit_error(ph, prof, template, res.x, **fftfit_kwargs)
+        binsize = 1 / nbin
+        for d in np.linspace(-0.5, 0.5, nbin / 2):
+            p0 = [1, dph + d]
+
+            res_trial = minimize(_fft_fun_wrap, p0, args=([prof, template],),
+                                 method='L-BFGS-B',
+                                 bounds=[[0, None], [dph + d - binsize,
+                                                     dph + d + binsize]],
+                                 options={'maxiter': 10000})
+            chisq = _fft_fun_wrap(res_trial.x, [prof, template])
+
+            if chisq < min_chisq:
+                min_chisq = chisq
+                res = res_trial
+    else:
+        p0 = [np.max(prof), dph]
+
+        res = basinhopping(_fft_fun_wrap, p0,
+                           minimizer_kwargs={'args': ([prof, template],),
+                                             'bounds': [[0, None], [-1, 1]]},
+                           niter=1000,
+                           niter_success=200).lowest_optimization_result
+
+    while res.x[1] > 0.5:
+        res.x[1] -= 1.
+    while res.x[1] < -0.5:
+        res.x[1] += 1.
+
+    if not use_bootstrap:
+        return res.x[0], 0, res.x[1], 0.5 / nbin
+    else:
+        mean_amp, std_amp, mean_ph, std_ph = \
+            fftfit_error(template, sigma=mad(np.diff(prof)), **fftfit_kwargs)
+        return res.x[0] + mean_amp, std_amp, res.x[1] + mean_ph, std_ph
 
 
-def fftfit_error(phase, prof, template, p0, **fftfit_kwargs):
+def fftfit_error(template, sigma=None, **fftfit_kwargs):
     """Calculate the error on the fit parameters from FFTFIT.
-
     Parameters
     ----------
     phase : array
@@ -511,14 +545,12 @@ def fftfit_error(phase, prof, template, p0, **fftfit_kwargs):
         The template of the pulse used to perform the TOA calculation
     p0 : list
         The initial parameters for the fit
-
     Returns
     -------
     mean_amp, std_amp : floats
         Mean and standard deviation of the amplitude
     mean_phase, std_phase : floats
         Mean and standard deviation of the phase
-
     Other parameters
     ----------------
     nstep : int, optional, default 100
@@ -526,43 +558,79 @@ def fftfit_error(phase, prof, template, p0, **fftfit_kwargs):
     """
     nstep = _default_value_if_no_key(fftfit_kwargs, "nstep", 100)
 
-    approx, _ = _pulse_template(phase, prof)
-    sigma = np.std(prof - approx)
-    nbin = len(prof)
+    if sigma is None:
+        sigma = np.sqrt(np.mean(template))
+
+    nbin = len(template)
 
     ph_fit = np.zeros(nstep)
     amp_fit = np.zeros(nstep)
     # use bootstrap method to calculate errors
+    shift = 0
+    phase = np.arange(0, 1, 1 / nbin)
+    maxphase = np.argmax(template) / nbin
+
     for i in range(nstep):
-        newprof = approx + np.random.normal(0, sigma, nbin)
+        shift = i
+        newprof = np.random.normal(0, sigma, len(template)) + template
+        dph = np.random.normal(0, 0.5 / nbin)
+        p0 = [1, dph]
         res = minimize(_fft_fun_wrap, p0, args=([newprof, template],),
                        method='L-BFGS-B',
-                       bounds=[[0, None], [0, None]])
-        amp_fit[i] = res.x[0]
-        ph_fit[i] = res.x[1]
+                       bounds=[[0, None], [-1, 1]],
+                       options={'maxiter': 10000})
 
-    p0 -= np.floor(p0)
+        amp_fit[i] = res.x[0]
+        while res.x[1] > 0.5:
+            res.x[1] -= 1
+        while res.x[1] < -0.5:
+            res.x[1] += 1
+        ph_fit[i] = res.x[1]
 
     std_save = 1e32
     # avoid problems if phase around 0 or 1: shift, calculate std,
     # if less save new std
-    for shift in np.arange(0, 0.8, 0.1):
+    for shift in np.arange(0, 0.8, 0.2):
         phs = ph_fit + shift
         phs -= np.floor(phs)
-        std = np.std(phs)
-        if std <= std_save:
+        std = mad(phs)
+        if std < std_save:
             std_save = std
-            mean_save = np.mean(phs) - shift
+            mean_save = np.median(phs) - shift
 
-    # But still, never less than half a bin!
-    std_save = np.max([std_save, np.diff(phase)[0] / 2])
     return np.mean(amp_fit), np.std(amp_fit), mean_save, std_save
 
 
+def plot_TOA_fit(profile, template, toa, mod=None, toaerr=None,
+                 additional_phase=0., show=True, period=1):
+    import matplotlib.pyplot as plt
+    from scipy.interpolate import interp1d
+    import time
+    phases = np.arange(0, 1, 1 / len(profile))
+    if mod is None:
+        mod = interp1d(phases, template, fill_value='extrapolate')
+
+    fig = plt.figure()
+    plt.plot(phases - np.floor(phases), profile, drawstyle='steps-mid')
+    fine_phases = np.linspace(0, 1, 1000)
+    fine_phases_shifted = fine_phases - toa / period + additional_phase
+    plt.plot(fine_phases,
+             mod(fine_phases_shifted - np.floor(fine_phases_shifted)))
+    if toaerr is not None:
+        plt.axvline((toa - toaerr) / period)
+        plt.axvline((toa + toaerr) / period)
+    plt.axvline(toa / period - 0.5 / len(profile), ls='--')
+    plt.axvline(toa / period + 0.5 / len(profile), ls='--')
+    timestamp = int(time.time())
+    plt.savefig('{}.png'.format(timestamp))
+    if not show:
+        plt.close(fig)
+
+
 def get_TOA(prof, period, tstart, template=None, additional_phase=0,
+            quick=False, debug=False, use_bootstrap=False,
             **fftfit_kwargs):
     """Calculate the Time-Of-Arrival of a pulse.
-
     Parameters
     ----------
     prof : array
@@ -572,24 +640,30 @@ def get_TOA(prof, period, tstart, template=None, additional_phase=0,
         Otherwise use the default of fftfit
     tstart : float
         The time at the start of the pulse profile
-
     Returns
     -------
     toa, toastd : floats
         Mean and standard deviation of the TOA
-
     Other parameters
     ----------------
     nstep : int, optional, default 100
         Number of steps for the bootstrap method
     """
+
     mean_amp, std_amp, phase_res, phase_res_err = \
-        fftfit(prof, template=template, **fftfit_kwargs)
+        fftfit(prof, template=template, quick=quick,
+               use_bootstrap=use_bootstrap, **fftfit_kwargs)
     phase_res = phase_res + additional_phase
     phase_res = phase_res - np.floor(phase_res)
 
     toa = tstart + phase_res * period
     toaerr = phase_res_err * period
+
+    if debug:
+        plot_TOA_fit(prof, template, toa - tstart, toaerr=toaerr,
+                     additional_phase=additional_phase,
+                     period=period)
+
     return toa, toaerr
 
 

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -32,7 +32,7 @@ def _folding_search(stat_func, times, frequencies, segment_size=5000,
     start_times = np.arange(times[0], times[-1], segment_size)
     count = 0
     for s in start_times:
-        good = (times >=s) & (times < s + segment_size)
+        good = (times >= s) & (times < s + segment_size)
         ts = times[good]
         if len(ts) < 1 or ts[-1] - ts[0] < 0.2 * segment_size:
             continue
@@ -45,7 +45,7 @@ def _folding_search(stat_func, times, frequencies, segment_size=5000,
                     kwargs_copy = {}
                     for key in kwargs.keys():
                         if isinstance(kwargs[key], collections.Iterable) and \
-                            len(kwargs[key]) == len(times):
+                                len(kwargs[key]) == len(times):
 
                             kwargs_copy[key] = kwargs[key][good]
                         else:
@@ -180,6 +180,7 @@ def z_n_search(times, frequencies, nharm=4, nbin=128, segment_size=5000,
         if expocorr and gti is None:
             raise ValueError('To calculate exposure correction, you need to'
                              ' specify the GTIs')
+
         def stat_fun(t, f, fd=0, **kwargs):
             return z_n(phase, n=nharm,
                        norm=fold_events(t, f, fd, nbin=nbin, **kwargs)[1])
@@ -422,7 +423,7 @@ def phaseogram(times, f, nph=128, nt=32, ph0=0, mjdref=None, fdot=0, fddot=0,
     plot_unit = 's'
     if use_mjdref:
         pepoch = (pepoch - mjdref) * 86400
-        plot_unit='MJD'
+        plot_unit = 'MJD'
 
     phases = pulse_phase((times - pepoch), f, fdot, fddot, to_1=True, ph0=ph0)
 
@@ -439,11 +440,12 @@ def phaseogram(times, f, nph=128, nt=32, ph0=0, mjdref=None, fdot=0, fddot=0,
     if use_mjdref:
         allts = allts / 86400 + mjdref
 
-    phas, binx, biny = np.histogram2d(allphases, allts,
-               bins=(np.linspace(0, 2, nph * 2 + 1),
-                     np.linspace(np.min(allts),
-                                 np.max(allts), nt + 1)),
-               weights=weights)
+    phas, binx, biny = np.histogram2d(
+        allphases, allts,
+        bins=(np.linspace(0, 2, nph * 2 + 1),
+              np.linspace(np.min(allts),
+                          np.max(allts), nt + 1)),
+        weights=weights)
 
     if plot:
         phaseogram_ax = plot_phaseogram(phas, binx, biny, ax=phaseogram_ax,

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -115,6 +115,17 @@ def epoch_folding_search(times, frequencies, nbin=128, segment_size=5000,
     weights : array-like
         weight for each time. This might be, for example, the number of counts
         if the times array contains the time bins of a light curve
+
+    Returns
+    -------
+    (fgrid, stats) or (fgrid, fdgrid, stats), as follows:
+
+    fgrid : array-like
+        frequency grid of the epoch folding periodogram
+    fdgrid : array-like
+        frequency derivative grid. Only returned if fdots is an array.
+    stats : array-like
+        the epoch folding statistics corresponding to each frequency bin.
     """
     if expocorr or not HAS_NUMBA or isinstance(weights, collections.Iterable):
         if expocorr and gti is None:
@@ -174,6 +185,17 @@ def z_n_search(times, frequencies, nharm=4, nbin=128, segment_size=5000,
     weights : array-like
         weight for each time. This might be, for example, the number of counts
         if the times array contains the time bins of a light curve
+
+    Returns
+    -------
+    (fgrid, stats) or (fgrid, fdgrid, stats), as follows:
+
+    fgrid : array-like
+        frequency grid of the epoch folding periodogram
+    fdgrid : array-like
+        frequency derivative grid. Only returned if fdots is an array.
+    stats : array-like
+        the Z^2_n statistics corresponding to each frequency bin.
     """
     phase = np.arange(0, 1, 1 / nbin)
     if expocorr or not HAS_NUMBA or isinstance(weights, collections.Iterable):

--- a/stingray/pulse/tests/test_modeling.py
+++ b/stingray/pulse/tests/test_modeling.py
@@ -33,7 +33,7 @@ def test_sinc_obs():
     y = 2 * (np.sin(x / w) / (x / w))**2
     y += np.random.normal(0., 0.1, x.shape)
 
-    s = fit_sinc(x, y, obs_length=obs_length )
+    s = fit_sinc(x, y, obs_length=obs_length)
 
     assert np.abs(1 / (np.pi*obs_length) - s.width) < 0.1
     assert s.width.fixed
@@ -57,7 +57,7 @@ def test_gaussian_bounds():
     y += np.random.normal(0., 0.1, x.shape)
 
     gs = fit_gaussian(x, y,
-                      bounds={"mean": [1., 1.6], "amplitude":[1.7, 2.3]})
+                      bounds={"mean": [1., 1.6], "amplitude": [1.7, 2.3]})
 
 
 def test_gaussian_fixed():

--- a/stingray/pulse/tests/test_pulse.py
+++ b/stingray/pulse/tests/test_pulse.py
@@ -265,7 +265,7 @@ class TestAll(object):
         prof = np.random.poisson(template)
 
         toa, toaerr = \
-            get_TOA(prof, period, tstart,
+            get_TOA(prof, period, tstart, quick=True,
                     template=_template_fun(phases, 0, 1, 0), nstep=200,
                     use_bootstrap=True)
 

--- a/stingray/pulse/tests/test_pulse.py
+++ b/stingray/pulse/tests/test_pulse.py
@@ -17,7 +17,6 @@ except ImportError:
     HAS_MPL = False
 
 
-
 def _template_fun(phase, ph0, amplitude, baseline=0):
     return baseline + amplitude * np.cos((phase - ph0) * 2 * np.pi)
 
@@ -69,7 +68,7 @@ class TestAll(object):
         mjdref = 50000
         toa_sec = (mjds - mjdref) * 86400
         corr = correction_mjd(mjds)
-        corr_s = correction_sec (toa_sec, mjdref)
+        corr_s = correction_sec(toa_sec, mjdref)
         assert np.allclose(corr, corr_s / 86400 + mjdref)
 
     @pytest.mark.skipif('HAS_PINT')
@@ -98,8 +97,9 @@ class TestAll(object):
         """Test pulse phase calculation, frequency only."""
         np.testing.assert_almost_equal(fold_detection_level(16, 0.01),
                                        30.577914166892498)
-        np.testing.assert_almost_equal(fold_detection_level(16, 0.01, ntrial=2),
-                                       fold_detection_level(16, 0.01 / 2))
+        np.testing.assert_almost_equal(
+            fold_detection_level(16, 0.01, ntrial=2),
+            fold_detection_level(16, 0.01 / 2))
 
     def test_zn_detection_level(self):
         np.testing.assert_almost_equal(z2_n_detection_level(2),

--- a/stingray/pulse/tests/test_pulse.py
+++ b/stingray/pulse/tests/test_pulse.py
@@ -10,6 +10,13 @@ from ..pulsar import HAS_PINT
 from astropy.tests.helper import remote_data
 import pytest
 import os
+try:
+    import matplotlib.pyplot as plt
+    HAS_MPL = True
+except ImportError:
+    HAS_MPL = False
+
+
 
 def _template_fun(phase, ph0, amplitude, baseline=0):
     return baseline + amplitude * np.cos((phase - ph0) * 2 * np.pi)
@@ -244,6 +251,41 @@ class TestAll(object):
         toa, toaerr = \
             get_TOA(prof, period, tstart,
                     template=_template_fun(phases, 0, 1, 0), nstep=200)
+
+        real_toa = tstart + start_phase * period
+        assert (real_toa >= toa - toaerr * 3) & (real_toa <= toa + toaerr * 3)
+
+    def test_get_TOA3(self):
+        np.random.seed(1234)
+        period = 1.2
+        tstart = 122
+        start_phase = 0.2123
+        phases = np.arange(0, 1, 1 / 32)
+        template = _template_fun(phases, start_phase, 10, 20)
+        prof = np.random.poisson(template)
+
+        toa, toaerr = \
+            get_TOA(prof, period, tstart,
+                    template=_template_fun(phases, 0, 1, 0), nstep=200,
+                    use_bootstrap=True)
+
+        real_toa = tstart + start_phase * period
+        assert (real_toa >= toa - toaerr * 3) & (real_toa <= toa + toaerr * 3)
+
+    @pytest.mark.skipif('not HAS_MPL')
+    def test_get_TOA4(self):
+        np.random.seed(1234)
+        period = 1.2
+        tstart = 122
+        start_phase = 0.2123
+        phases = np.arange(0, 1, 1 / 32)
+        template = _template_fun(phases, start_phase, 10, 20)
+        prof = np.random.poisson(template)
+
+        toa, toaerr = \
+            get_TOA(prof, period, tstart,
+                    template=_template_fun(phases, 0, 1, 0), nstep=200,
+                    debug=True)
 
         real_toa = tstart + start_phase * period
         assert (real_toa >= toa - toaerr * 3) & (real_toa <= toa + toaerr * 3)

--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -37,7 +37,7 @@ class TestAll(object):
             phaseogram(self.event_times, self.pulse_frequency)
         assert np.all(times < 25.6)
         assert np.any(times > 25)
-        assert np.all((phases >= 0)&(phases <= 2))
+        assert np.all((phases >= 0) & (phases <= 2))
 
     def test_phaseogram_bad_weights(self):
         with pytest.raises(ValueError) as excinfo:
@@ -52,7 +52,7 @@ class TestAll(object):
                        nph=16)
         assert np.all(times < 25.6)
         assert np.any(times > 25)
-        assert np.all((phases >= 0)&(phases <= 2))
+        assert np.all((phases >= 0) & (phases <= 2))
         import matplotlib.pyplot as plt
         fig = plt.figure('Phaseogram direct weights')
         plot_phaseogram(phaseogr, phases, times)
@@ -64,7 +64,7 @@ class TestAll(object):
             phaseogram(self.event_times, self.pulse_frequency,
                        mjdref=57000, out_filename='phaseogram_mjdref.png')
         assert np.all(times >= 57000)
-        assert np.all((phases >= 0)&(phases <= 2))
+        assert np.all((phases >= 0) & (phases <= 2))
 
     def test_phaseogram_mjdref_pepoch(self):
         phaseogr, phases, times, additional_info = \
@@ -72,7 +72,7 @@ class TestAll(object):
                        mjdref=57000, out_filename='phaseogram_mjdref.png',
                        pepoch=57000)
         assert np.all(times >= 57000)
-        assert np.all((phases >= 0)&(phases <= 2))
+        assert np.all((phases >= 0) & (phases <= 2))
 
     def test_plot_phaseogram_fromfunc(self):
         import matplotlib.pyplot as plt

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -389,19 +389,19 @@ class TestAveragedCrossspectrum(object):
     def test_timelag(self):
         from ..simulator.simulator import Simulator
         dt = 0.1
-        simulator = Simulator(dt, 10000, rms=0.4, mean=200)
+        simulator = Simulator(dt, 10000, rms=0.8, mean=1000)
         test_lc1 = simulator.simulate(2)
         test_lc2 = Lightcurve(test_lc1.time,
                               np.array(np.roll(test_lc1.counts, 2)),
                               err_dist=test_lc1.err_dist,
                               dt=dt)
 
-        cs = AveragedCrossspectrum(test_lc1, test_lc2, segment_size=10,
+        cs = AveragedCrossspectrum(test_lc1, test_lc2, segment_size=5,
                                    norm="none")
 
         time_lag, time_lag_err = cs.time_lag()
 
-        assert np.all(np.abs(time_lag[:10] - 0.1) < 3 * time_lag_err[:10])
+        assert np.all(np.abs(time_lag[:6] - 0.1) < 3 * time_lag_err[:6])
 
     def test_errorbars(self):
         time = np.arange(10000) * 0.1


### PR DESCRIPTION
+ Solve a number of problems in the calculations of pulse arrival times

+ Give a choice over fitting methods (still no maximum likelihood)

+ Plot diagnostic information if needed

All the relevant changes are under `pulse/`. The rest is just a mixed-up PEP8 cleanup (sorry about that)

See https://github.com/StingraySoftware/notebooks/pull/30 to see the functions in action

Also, resolves #314, resolves #317