### PR TITLE
fix #315

### DIFF
--- a/stingray/io.py
+++ b/stingray/io.py
@@ -808,9 +808,10 @@ def _isattribute(data):
         True if the data is a single number, False if it is an iterable.
     """
 
-    if isinstance(data, np.ndarray) or isinstance(data, list):
+    try:
+        _ = (i for i in data)
         return False
-    else:
+    except TypeError:
         return True
 
 


### PR DESCRIPTION
I would like to resolve #315 by checking if the input `data` is iterable instead of checking its attribute. This could easily be achieved by catching `TypeError` when trying sth. like `(i for i in data)`.