### PR TITLE
Abs normalization fix

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -434,7 +434,7 @@ class Crossspectrum(object):
             power = c * 2. * tseg / (actual_mean ** 2.0)
 
         elif self.norm.lower() == 'abs':
-            c = unnorm_power.real / np.float(self.n ** 2.)
+            c = unnorm_power.real
             power = c * (2. * tseg)
 
         elif self.norm.lower() == 'none':

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -435,7 +435,7 @@ class Crossspectrum(object):
 
         elif self.norm.lower() == 'abs':
             c = unnorm_power.real
-            power = c * (2. * tseg)
+            power = c * 2. / np.float(tseg)
 
         elif self.norm.lower() == 'none':
             power = unnorm_power


### PR DESCRIPTION
Found error in equation for absolute rms^2 normalization and fixed it. I think the old equation was for light curves in counts per second units, and Stingray uses counts per bin.