### PR TITLE
Added new parameter in cross spectrum class

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -143,14 +143,7 @@ class Crossspectrum(object):
     nphots2: float
         The total number of photons in light curve 2
     """
-
-    def __init__(
-            self,
-            lc1=None,
-            lc2=None,
-            norm='none',
-            gti=None,
-            amplitude=False):
+    def __init__(self, lc1=None, lc2=None, norm='none', gti=None, amplitude=False):
 
         if isinstance(norm, str) is False:
             raise TypeError("norm must be a string")
@@ -161,8 +154,7 @@ class Crossspectrum(object):
         self.norm = norm.lower()
 
         # check if input data is a Lightcurve object, if not make one or
-        # make an empty Crossspectrum object if lc1 == ``None`` or lc2 ==
-        # ``None``
+        # make an empty Crossspectrum object if lc1 == ``None`` or lc2 == ``None``
         if lc1 is None or lc2 is None:
             if lc1 is not None or lc2 is not None:
                 raise TypeError("You can't do a cross spectrum with just one "
@@ -400,8 +392,7 @@ class Crossspectrum(object):
             if self.type == 'powerspectrum':
                 pass
             else:
-                raise AttributeError(
-                    'Spectrum has no attribute named nphots2.')
+                raise AttributeError('Spectrum has no attribute named nphots2.')
 
         bin_cs.m = np.rint(step_size * self.m)
 
@@ -597,29 +588,9 @@ class Crossspectrum(object):
             raise ImportError("Matplotlib required for plot()")
 
         fig = plt.figure('crossspectrum')
-        fig = plt.plot(
-            self.freq,
-            np.abs(
-                self.power),
-            marker,
-            color='b',
-            label='Amplitude')
-        fig = plt.plot(
-            self.freq,
-            np.abs(
-                self.power.real),
-            marker,
-            color='r',
-            alpha=0.5,
-            label='Real Part')
-        fig = plt.plot(
-            self.freq,
-            np.abs(
-                self.power.imag),
-            marker,
-            color='g',
-            alpha=0.5,
-            label='Imaginary Part')
+        fig = plt.plot(self.freq, np.abs(self.power), marker, color='b', label='Amplitude')
+        fig = plt.plot(self.freq, np.abs(self.power.real), marker, color='r', alpha=0.5, label='Real Part')
+        fig = plt.plot(self.freq, np.abs(self.power.imag), marker, color='g', alpha=0.5, label='Imaginary Part')
 
         if labels is not None:
             try:
@@ -719,7 +690,6 @@ class AveragedCrossspectrum(Crossspectrum):
         two light curves
 
     """
-
     def __init__(self, lc1=None, lc2=None, segment_size=None,
                  norm='none', gti=None):
 
@@ -816,9 +786,9 @@ class AveragedCrossspectrum(Crossspectrum):
             counts_2 = lc2.counts[start_ind:end_ind]
             counts_2_err = lc2.counts_err[start_ind:end_ind]
             gti1 = np.array([[time_1[0] - lc1.dt / 2,
-                              time_1[-1] + lc1.dt / 2]])
+                             time_1[-1] + lc1.dt / 2]])
             gti2 = np.array([[time_2[0] - lc2.dt / 2,
-                              time_2[-1] + lc2.dt / 2]])
+                             time_2[-1] + lc2.dt / 2]])
             lc1_seg = Lightcurve(time_1, counts_1, err=counts_1_err,
                                  err_dist=lc1.err_dist,
                                  gti=gti1,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -143,7 +143,14 @@ class Crossspectrum(object):
     nphots2: float
         The total number of photons in light curve 2
     """
-    def __init__(self, lc1=None, lc2=None, norm='none', gti=None, amplitude=False):
+
+    def __init__(
+            self,
+            lc1=None,
+            lc2=None,
+            norm='none',
+            gti=None,
+            amplitude=False):
 
         if isinstance(norm, str) is False:
             raise TypeError("norm must be a string")
@@ -154,7 +161,8 @@ class Crossspectrum(object):
         self.norm = norm.lower()
 
         # check if input data is a Lightcurve object, if not make one or
-        # make an empty Crossspectrum object if lc1 == ``None`` or lc2 == ``None``
+        # make an empty Crossspectrum object if lc1 == ``None`` or lc2 ==
+        # ``None``
         if lc1 is None or lc2 is None:
             if lc1 is not None or lc2 is not None:
                 raise TypeError("You can't do a cross spectrum with just one "
@@ -392,7 +400,8 @@ class Crossspectrum(object):
             if self.type == 'powerspectrum':
                 pass
             else:
-                raise AttributeError('Spectrum has no attribute named nphots2.')
+                raise AttributeError(
+                    'Spectrum has no attribute named nphots2.')
 
         bin_cs.m = np.rint(step_size * self.m)
 
@@ -588,9 +597,29 @@ class Crossspectrum(object):
             raise ImportError("Matplotlib required for plot()")
 
         fig = plt.figure('crossspectrum')
-        fig = plt.plot(self.freq, np.abs(self.power), marker, color='b', label='Amplitude')
-        fig = plt.plot(self.freq, np.abs(self.power.real), marker, color='r', alpha=0.5, label='Real Part')
-        fig = plt.plot(self.freq, np.abs(self.power.imag), marker, color='g', alpha=0.5, label='Imaginary Part')
+        fig = plt.plot(
+            self.freq,
+            np.abs(
+                self.power),
+            marker,
+            color='b',
+            label='Amplitude')
+        fig = plt.plot(
+            self.freq,
+            np.abs(
+                self.power.real),
+            marker,
+            color='r',
+            alpha=0.5,
+            label='Real Part')
+        fig = plt.plot(
+            self.freq,
+            np.abs(
+                self.power.imag),
+            marker,
+            color='g',
+            alpha=0.5,
+            label='Imaginary Part')
 
         if labels is not None:
             try:
@@ -690,6 +719,7 @@ class AveragedCrossspectrum(Crossspectrum):
         two light curves
 
     """
+
     def __init__(self, lc1=None, lc2=None, segment_size=None,
                  norm='none', gti=None):
 
@@ -786,9 +816,9 @@ class AveragedCrossspectrum(Crossspectrum):
             counts_2 = lc2.counts[start_ind:end_ind]
             counts_2_err = lc2.counts_err[start_ind:end_ind]
             gti1 = np.array([[time_1[0] - lc1.dt / 2,
-                             time_1[-1] + lc1.dt / 2]])
+                              time_1[-1] + lc1.dt / 2]])
             gti2 = np.array([[time_2[0] - lc2.dt / 2,
-                             time_2[-1] + lc2.dt / 2]])
+                              time_2[-1] + lc2.dt / 2]])
             lc1_seg = Lightcurve(time_1, counts_1, err=counts_1_err,
                                  err_dist=lc1.err_dist,
                                  gti=gti1,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -398,7 +398,7 @@ class Crossspectrum(object):
 
         return bin_cs
 
-    def _normalize_crossspectrum(self, unnorm_power, tseg, amp=False):
+    def _normalize_crossspectrum(self, unnorm_power, tseg):
         """
         Normalize the real part of the cross spectrum to Leahy, absolute rms^2,
         fractional rms^2 normalization, or not at all.

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -102,6 +102,9 @@ class Crossspectrum(object):
     norm: {``frac``, ``abs``, ``leahy``, ``none``}, default ``none``
         The normalization of the (real part of the) cross spectrum.
 
+    amplitude: bool, optional, default ``False``
+        Parameter to choose between real component and amplitude of the cross spectrum.
+
     Other Parameters
     ----------------
     gti: 2-d float array
@@ -140,7 +143,7 @@ class Crossspectrum(object):
     nphots2: float
         The total number of photons in light curve 2
     """
-    def __init__(self, lc1=None, lc2=None, norm='none', gti=None):
+    def __init__(self, lc1=None, lc2=None, norm='none', gti=None, amplitude=False):
 
         if isinstance(norm, str) is False:
             raise TypeError("norm must be a string")
@@ -169,6 +172,7 @@ class Crossspectrum(object):
         self.gti = gti
         self.lc1 = lc1
         self.lc2 = lc2
+        self.amplitude = amplitude
 
         self._make_crossspectrum(lc1, lc2)
 
@@ -199,6 +203,7 @@ class Crossspectrum(object):
         ----------
         lc1, lc2 : :class:`stingray.Lightcurve` objects
             Two light curves used for computing the cross spectrum.
+
         """
         # make sure the inputs work!
         if not isinstance(lc1, Lightcurve):
@@ -393,7 +398,7 @@ class Crossspectrum(object):
 
         return bin_cs
 
-    def _normalize_crossspectrum(self, unnorm_power, tseg):
+    def _normalize_crossspectrum(self, unnorm_power, tseg, amp=False):
         """
         Normalize the real part of the cross spectrum to Leahy, absolute rms^2,
         fractional rms^2 normalization, or not at all.
@@ -405,6 +410,9 @@ class Crossspectrum(object):
 
         tseg: int
             The length of the Fourier segment, in seconds.
+
+        amp: bool, optional, default ``False``
+            Parameter to choose between real component and amplitude of the cross spectrum
 
         Returns
         -------
@@ -425,16 +433,21 @@ class Crossspectrum(object):
         assert actual_mean > 0.0, \
             "Mean count rate is <= 0. Something went wrong."
 
+        if self.amplitude:
+            c_num = np.abs(unnorm_power)
+        else:
+            c_num = unnorm_power.real
+
         if self.norm.lower() == 'leahy':
-            c = unnorm_power.real
+            c = c_num
             power = c * 2. / actual_nphots
 
         elif self.norm.lower() == 'frac':
-            c = unnorm_power.real / np.float(self.n ** 2.)
+            c = c_num / np.float(self.n ** 2.)
             power = c * 2. * tseg / (actual_mean ** 2.0)
 
         elif self.norm.lower() == 'abs':
-            c = unnorm_power.real / np.float(self.n ** 2.)
+            c = c_num / np.float(self.n ** 2.)
             power = c * (2. * tseg)
 
         elif self.norm.lower() == 'none':


### PR DESCRIPTION
This PR introduces new parameter `amplitude` in `Crosspectrum` class. A user can now choose if the person wants just the real component or the amplitude of the cross spectrum.

Instead of passing it from one function to another function, I added `self.amplitude` to store user's choice.

**Usage:**
![screen shot 2018-05-24 at 23 15 29](https://user-images.githubusercontent.com/14021461/40502387-6d1de426-5fa8-11e8-8831-37fb3ef0bef7.png)
