### PR TITLE
refactor `_empty` into `EvtData`

### DIFF
--- a/stingray/io.py
+++ b/stingray/io.py
@@ -189,7 +189,7 @@ def load_events_and_gtis(fits_file, additional_columns=None,
 
     additional_data = order_list_of_arrays(additional_data, order)
 
-    returns = _empty()
+    returns = EvtData()
     returns.ev_list = ev_list
     returns.gti_list = gti_list
     returns.additional_data = additional_data
@@ -199,7 +199,7 @@ def load_events_and_gtis(fits_file, additional_columns=None,
     return returns
 
 
-class _empty():
+class EvtData():
     def __init__(self):
         pass
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -481,7 +481,7 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
         check_gtis(self.gti)
 
         start_inds, end_inds = \
-            bin_intervals_from_gtis(self.gti, segment_size, lc.time)
+            bin_intervals_from_gtis(self.gti, segment_size, lc.time, dt=lc.dt)
 
         power_all = []
         nphots_all = []

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -582,8 +582,17 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         self.dyn_ps = np.array([ps.power for ps in ps_all]).T
 
         self.freq = ps_all[0].freq
-        self.time = np.arange(lc.time[0] + 0.5 * self.segment_size,
-                              lc.time[-1], self.segment_size)
+
+        start_inds, end_inds = \
+            bin_intervals_from_gtis(self.gti, self.segment_size, lc.time, dt=lc.dt)
+
+
+        tstart = lc.time[start_inds]
+        tend = lc.time[end_inds]
+
+        self.time = tstart + 0.5*(tend - tstart)
+        #self.time = np.arange(lc.time[0] + 0.5 * self.segment_size,
+        #                      lc.time[-1], self.segment_size)
 
         # Assign lenght of lightcurve as time resolution if only one value
         if len(self.time) > 1:
@@ -597,8 +606,9 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         else:
             self.df = 1 / lc.n
 
-        if len(self.time) > self.dyn_ps.shape[1]:
-            self.time = self.time[:-1]
+
+        #if len(self.time) > self.dyn_ps.shape[1]:
+        #    self.time = self.time[:-1]
 
     def rebin_frequency(self, df_new, method="sum"):
         """

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -597,7 +597,7 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         else:
             self.df = 1 / lc.n
 
-        if len(self.time) > self.dyn_ps.shape[0]:
+        if len(self.time) > self.dyn_ps.shape[1]:
             self.time = self.time[:-1]
 
     def rebin_frequency(self, df_new, method="sum"):

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -582,8 +582,8 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         self.dyn_ps = np.array([ps.power for ps in ps_all]).T
 
         self.freq = ps_all[0].freq
-        self.time = np.arange(lc.time[0] - 0.5 * lc.dt + 0.5 * self.segment_size,
-                              lc.time[-1] + 0.5 * lc.dt, self.segment_size)
+        self.time = np.arange(lc.time[0] + 0.5 * self.segment_size,
+                              lc.time[-1], self.segment_size)
 
         # Assign lenght of lightcurve as time resolution if only one value
         if len(self.time) > 1:

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -591,10 +591,8 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         tend = lc.time[end_inds]
 
         self.time = tstart + 0.5*(tend - tstart)
-        #self.time = np.arange(lc.time[0] + 0.5 * self.segment_size,
-        #                      lc.time[-1], self.segment_size)
 
-        # Assign lenght of lightcurve as time resolution if only one value
+        # Assign length of lightcurve as time resolution if only one value
         if len(self.time) > 1:
             self.dt = self.time[1] - self.time[0]
         else:
@@ -605,10 +603,6 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
             self.df = self.freq[1] - self.freq[0]
         else:
             self.df = 1 / lc.n
-
-
-        #if len(self.time) > self.dyn_ps.shape[1]:
-        #    self.time = self.time[:-1]
 
     def rebin_frequency(self, df_new, method="sum"):
         """

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -659,8 +659,8 @@ class TestDynamicalPowerspectrum(object):
     def test_rebin_time_default_method(self):
         segment_size = 3
         dt_new = 4.0
-        rebin_time = np.array([1.5, 5.5, 9.5, 13.5])
-        rebin_dps = np.array([[0.7962963, 1.16402116, 0.28571429, 0.65625]])
+        rebin_time = np.array([ 2.,  6., 10.])
+        rebin_dps = np.array([[0.7962963 , 1.16402116, 0.28571429]])
         dps = DynamicalPowerspectrum(self.lc_test, segment_size=segment_size)
         dps.rebin_time(dt_new=dt_new)
         assert np.allclose(dps.time, rebin_time)
@@ -686,8 +686,8 @@ class TestDynamicalPowerspectrum(object):
     def test_rebin_time_mean_method(self):
         segment_size = 3
         dt_new = 4.0
-        rebin_time = np.array([1.5, 5.5, 9.5, 13.5])
-        rebin_dps = np.array([[0.59722222, 0.87301587, 0.21428571, 0.4921875]])
+        rebin_time = np.array([ 2.,  6., 10.])
+        rebin_dps = np.array([[0.59722222, 0.87301587, 0.21428571]])
         dps = DynamicalPowerspectrum(self.lc_test, segment_size=segment_size)
         dps.rebin_time(dt_new=dt_new, method='mean')
         assert np.allclose(dps.time, rebin_time)
@@ -713,8 +713,8 @@ class TestDynamicalPowerspectrum(object):
     def test_rebin_time_average_method(self):
         segment_size = 3
         dt_new = 4.0
-        rebin_time = np.array([1.5, 5.5, 9.5, 13.5])
-        rebin_dps = np.array([[0.59722222, 0.87301587, 0.21428571, 0.4921875]])
+        rebin_time = np.array([ 2.,  6., 10.])
+        rebin_dps = np.array([[0.59722222, 0.87301587, 0.21428571]])
         dps = DynamicalPowerspectrum(self.lc_test, segment_size=segment_size)
         dps.rebin_time(dt_new=dt_new, method='average')
         assert np.allclose(dps.time, rebin_time)


### PR DESCRIPTION
I just loaded some data using `load_events_and_gtis` and was *really* confused when I did `print()` on the output and it told me that I had an object of type `stingray.io._empty`, because it made me think that the function had failed to actually extract some data.

I understand where the name `_empty` comes from, but it's a really confusing one for a user-facing function, so I've given it a slightly more descriptive name.