### PR TITLE
Should fix the problem when tseg is different in light curves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ env:
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='Cython numpy scipy h5py nose matplotlib'
+        - SETUP_XVFB=True
+        - MPLBACKEND="Agg"
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
         # Try all python versions with the latest numpy
         - SETUP_CMD='test --coverage'
-        - SETUP_XVFB=True
-        - MPLBACKEND="Agg"
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,9 +134,9 @@ install:
     # other dependencies.
 
 before_script:
-   - "export DISPLAY=:99.0"
-   - "sh -e /etc/init.d/xvfb start"
-   - sleep 3
+#   - "export DISPLAY=:99.0"
+#   - "sh -e /etc/init.d/xvfb start"
+#   - sleep 3
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ env:
         - SETUP_CMD='egg_info'
         # Try all python versions with the latest numpy
         - SETUP_CMD='test --coverage'
+        - SETUP_XVFB=True
+        - MPLBACKEND="Agg"
 
 matrix:
     fast_finish: true
@@ -134,9 +136,6 @@ install:
     # other dependencies.
 
 before_script:
-#   - "export DISPLAY=:99.0"
-#   - "sh -e /etc/init.d/xvfb start"
-#   - sleep 3
 
 script:
    - python setup.py $SETUP_CMD

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,10 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
+;filterwarnings =
+;    ignore:FutureWarning
+;    ignore:DeprecationWarning
+addopts = --disable-warnings
 
 [ah_bootstrap]
 auto_use = True

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -757,7 +757,9 @@ class AveragedCrossspectrum(Crossspectrum):
         assert isinstance(lc2, Lightcurve)
 
         if lc1.tseg != lc2.tseg:
-            raise ValueError("Lightcurves do not have same tseg.")
+            simon("Lightcurves do not have same tseg. This means that the data"
+                  "from the two channels are not completely in sync. This "
+                  "might or might not be an issue. Keep an eye on it.")
 
         # If dt differs slightly, its propagated error must not be more than
         # 1/100th of the bin
@@ -766,7 +768,6 @@ class AveragedCrossspectrum(Crossspectrum):
 
         # In case a small difference exists, ignore it
         lc1.dt = lc2.dt
-
         if self.gti is None:
             self.gti = cross_two_gtis(lc1.gti, lc2.gti)
             lc1.gti = lc2.gti = self.gti

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1307,3 +1307,4 @@ class Lightcurve(object):
         self.meanrate = np.mean(self.countrate)
         self.meancounts = np.mean(self.counts)
         self.n = self.counts.shape[0]
+        self.tseg = np.max(self.gti) - np.min(self.gti)

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -591,7 +591,7 @@ class Lightcurve(object):
             A :class:`Lightcurve` object with the binned light curve
         """
 
-        toa = np.asarray(toa)
+        toa = np.sort(np.asarray(toa))
         # tstart is an optional parameter to set a starting time for
         # the light curve in case this does not coincide with the first photon
         if tstart is None:

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -485,6 +485,7 @@ def phaseogram(times, f, nph=128, nt=32, ph0=0, mjdref=None, fdot=0, fddot=0,
     allphases = np.concatenate([phases, phases + 1]).astype('float64')
     allts = \
         np.concatenate([times, times]).astype('float64')
+
     if weights is not None and isinstance(weights, collections.Iterable):
         if len(weights) != len(times):
             raise ValueError('The length of weights must match the length of '

--- a/stingray/tests/test_covariancespectrum.py
+++ b/stingray/tests/test_covariancespectrum.py
@@ -69,7 +69,7 @@ class TestCovariancespectrumwithEvents(object):
         event_list = np.array([[2, 1], [2, 3], [1, 2], [5, 2], [4, 1]])
         with warnings.catch_warnings(record=True) as w:
             c = Covariancespectrum(event_list, dt=1)
-            assert np.any(["must be sorted" in wi.message for wi in w])
+            assert np.any(["must be sorted" in str(wi.message) for wi in w])
 
     def test_with_std_as_iterable(self):
         c = Covariancespectrum(self.event_list, dt=1, std=[1, 2])

--- a/stingray/tests/test_covariancespectrum.py
+++ b/stingray/tests/test_covariancespectrum.py
@@ -69,7 +69,7 @@ class TestCovariancespectrumwithEvents(object):
         event_list = np.array([[2, 1], [2, 3], [1, 2], [5, 2], [4, 1]])
         with warnings.catch_warnings(record=True) as w:
             c = Covariancespectrum(event_list, dt=1)
-            assert "must be sorted" in str(w[0].message)
+            assert np.any(["must be sorted" in wi.message for wi in w])
 
     def test_with_std_as_iterable(self):
         c = Covariancespectrum(self.event_list, dt=1, std=[1, 2])

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -165,14 +165,14 @@ class TestCrossCorrelation(object):
         with pytest.raises(TypeError):
             with warnings.catch_warnings(record=True) as w:
                 cr.plot(labels=123)
-                assert "must be either a list or tuple" in str(w[0].message)
+                assert np.any(["must be either a list or tuple" in wi.message for wi in w])
 
     @pytest.mark.skipif(not HAS_MPL, reason='Matplotlib is not installed')
     def test_plot_labels_index_error(self):
         cr = CrossCorrelation(self.lc1, self.lc2)
         with warnings.catch_warnings(record=True) as w:
             cr.plot(labels='x')
-            assert "must have two labels" in str(w[0].message)
+            assert np.any(["must have two labels" in wi.message for wi in w])
 
     @pytest.mark.skipif(not HAS_MPL, reason='Matplotlib is not installed')
     def test_plot_axis(self):

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -165,14 +165,14 @@ class TestCrossCorrelation(object):
         with pytest.raises(TypeError):
             with warnings.catch_warnings(record=True) as w:
                 cr.plot(labels=123)
-                assert np.any(["must be either a list or tuple" in wi.message for wi in w])
+                assert np.any(["must be either a list or tuple" in str(wi.message) for wi in w])
 
     @pytest.mark.skipif(not HAS_MPL, reason='Matplotlib is not installed')
     def test_plot_labels_index_error(self):
         cr = CrossCorrelation(self.lc1, self.lc2)
         with warnings.catch_warnings(record=True) as w:
             cr.plot(labels='x')
-            assert np.any(["must have two labels" in wi.message for wi in w])
+            assert np.any(["must have two labels" in str(wi.message) for wi in w])
 
     @pytest.mark.skipif(not HAS_MPL, reason='Matplotlib is not installed')
     def test_plot_axis(self):

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -99,12 +99,15 @@ class TestCrossspectrum(object):
         dt = 0.0001
 
         time = np.arange(tstart + 0.5*dt, tend + 0.5*dt, dt)
+        time2 = np.arange(tstart + 0.5*dt, tend + 1.5*dt, dt)
 
         counts1 = np.random.poisson(0.01, size=time.shape[0])
         counts2 = np.random.negative_binomial(1, 0.09, size=time.shape[0])
+        counts3 = np.random.poisson(0.01, size=time2.shape[0])
 
         self.lc1 = Lightcurve(time, counts1, gti=[[tstart, tend]], dt=dt)
         self.lc2 = Lightcurve(time, counts2, gti=[[tstart, tend]], dt=dt)
+        self.lc3 = Lightcurve(time2, counts3, gti=[[tstart, tend]], dt=dt)
 
         self.cs = Crossspectrum(self.lc1, self.lc2)
 
@@ -316,19 +319,21 @@ class TestAveragedCrossspectrum(object):
 
     def test_different_tseg(self):
         time2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        counts2_test = np.random.poisson(0.01, size=len(time2))
+        counts2_test = np.random.poisson(1000, size=len(time2))
         test_lc2 = Lightcurve(time2, counts2_test)
 
         time1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        counts1_test = np.random.negative_binomial(1, 0.09, size=len(time1))
+        counts1_test = np.random.np.random.poisson(1000, size=len(time1))
         test_lc1 = Lightcurve(time1, counts1_test)
 
         assert test_lc2.dt == test_lc1.dt
 
         assert test_lc2.tseg != test_lc1.tseg
 
-        with pytest.raises(ValueError):
-            assert AveragedCrossspectrum(test_lc1, test_lc2, segment_size=1)
+        with pytest.warns(UserWarning) as record:
+            AveragedCrossspectrum(test_lc1, test_lc2, segment_size=5)
+            assert np.any(["same tseg" in r.message.args[0]
+                           for r in record])
 
     def test_rebin_with_invalid_type_attribute(self):
         new_df = 2

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -71,7 +71,7 @@ class TestIO(object):
 
     def test_split_number(self):
         """Test split with high precision numbers."""
-        numbers = np.array([57401.0000003423423400453453, 
+        numbers = np.array([57401.0000003423423400453453,
             0.00000574010000003426646], dtype = np.longdouble)
         number_I, number_F = split_numbers(numbers)
         r_numbers = np.longdouble(number_I) + np.longdouble(number_F)
@@ -110,7 +110,7 @@ class TestFileFormats(object):
         assert (rec_object.array == test_object.array).all()
         assert rec_object.long_number == test_object.long_number
         assert (rec_object.long_array == test_object.long_array).all()
-        
+
         os.remove('test.pickle')
 
     def test_pickle_functions(self):
@@ -229,7 +229,7 @@ class TestFileFormats(object):
         plt.close("all")
         with warnings.catch_warnings(record=True) as w:
             savefig('test.png')
-            assert "plot the image first" in str(w[0].message)
+            assert np.any(["plot the image first" in wi.message for wi in w])
         os.unlink('test.png')
 
     def test_savefig(self):

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -229,7 +229,7 @@ class TestFileFormats(object):
         plt.close("all")
         with warnings.catch_warnings(record=True) as w:
             savefig('test.png')
-            assert np.any(["plot the image first" in wi.message for wi in w])
+            assert np.any(["plot the image first" in str(wi.message) for wi in w])
         os.unlink('test.png')
 
     def test_savefig(self):

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -84,7 +84,6 @@ class TestChunks(object):
 
 
 class TestLightcurve(object):
-
     @classmethod
     def setup_class(cls):
         cls.times = np.array([1, 2, 3, 4])
@@ -496,7 +495,7 @@ class TestLightcurve(object):
 
         with warnings.catch_warnings(record=True) as w:
             lc = lc1.join(lc2)
-            assert np.any(["overlapping time ranges" in wi.message
+            assert np.any(["overlapping time ranges" in str(wi.message)
                            for wi in w])
 
         assert len(lc.counts) == len(lc.time) == 6
@@ -639,13 +638,14 @@ class TestLightcurve(object):
             with warnings.catch_warnings(record=True) as w:
                 lc.plot(labels=123)
                 assert np.any(["must be either a list or tuple"
-                               in wi.message for wi in w])
+                               in str(wi.message) for wi in w])
 
     def test_plot_labels_index_error(self):
         lc = Lightcurve(self.times, self.counts)
         with warnings.catch_warnings(record=True) as w:
             lc.plot(labels=('x'))
-            assert np.any(["must have two labels" in wi.message for wi in w])
+
+            assert np.any(["must have two labels" in str(wi.message) for wi in w])
 
     def test_plot_default_filename(self):
         lc = Lightcurve(self.times, self.counts)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -111,7 +111,7 @@ class TestLightcurve(object):
 
         with warnings.catch_warnings(record=True) as w:
             lc = Lightcurve(times, counts, err_dist="poisson")
-            assert str(w[0].message) == warn_str
+            assert np.any([str(wi.message) == warn_str for wi in w])
 
     def test_unrecognize_err_dist_warning(self):
         """
@@ -125,7 +125,7 @@ class TestLightcurve(object):
 
         with warnings.catch_warnings(record=True) as w:
             lc = Lightcurve(times, counts, err_dist='gauss')
-            assert str(w[0].message) == warn_str
+            assert np.any([str(wi.message) == warn_str for wi in w])
 
     def test_dummy_err_dist_fail(self):
         """
@@ -325,7 +325,8 @@ class TestLightcurve(object):
                          err_dist="gauss")
         with warnings.catch_warnings(record=True) as w:
             lc = lc1 + lc2
-            assert "ightcurves have different statistics" in str(w[0].message)
+            assert np.any(["ightcurves have different statistics"
+                           in str(wi.message) for wi in w])
 
     def test_add_with_same_gtis(self):
         lc1 = Lightcurve(self.times, self.counts, gti=self.gti)
@@ -383,7 +384,8 @@ class TestLightcurve(object):
                          err_dist="gauss")
         with warnings.catch_warnings(record=True) as w:
             lc = lc1 - lc2
-            assert "ightcurves have different statistics" in str(w[0].message)
+            assert np.any(["ightcurves have different statistics"
+                           in str(wi.message) for wi in w])
 
     def test_sub_with_different_mjdref(self):
         lc1 = Lightcurve(self.times, self.counts, gti=self.gti, mjdref=57000)
@@ -463,7 +465,8 @@ class TestLightcurve(object):
 
         with warnings.catch_warnings(record=True) as w:
             lc1.join(lc2)
-            assert "different bin widths" in str(w[0].message)
+            assert np.any(["different bin widths"
+                           in str(wi.message) for wi in w])
 
     def test_join_with_different_mjdref(self):
         lc1 = Lightcurve(self.times, self.counts, gti=self.gti, mjdref=57000)
@@ -493,7 +496,8 @@ class TestLightcurve(object):
 
         with warnings.catch_warnings(record=True) as w:
             lc = lc1.join(lc2)
-            assert "overlapping time ranges" in str(w[0].message)
+            assert np.any(["overlapping time ranges" in wi.message
+                           for wi in w])
 
         assert len(lc.counts) == len(lc.time) == 6
         assert np.all(lc.counts == np.array([2, 2, 3, 3, 4, 4]))
@@ -634,13 +638,14 @@ class TestLightcurve(object):
         with pytest.raises(TypeError):
             with warnings.catch_warnings(record=True) as w:
                 lc.plot(labels=123)
-                assert "must be either a list or tuple" in str(w[0].message)
+                assert np.any(["must be either a list or tuple"
+                               in wi.message for wi in w])
 
     def test_plot_labels_index_error(self):
         lc = Lightcurve(self.times, self.counts)
         with warnings.catch_warnings(record=True) as w:
             lc.plot(labels=('x'))
-            assert "must have two labels" in str(w[0].message)
+            assert np.any(["must have two labels" in wi.message for wi in w])
 
     def test_plot_default_filename(self):
         lc = Lightcurve(self.times, self.counts)


### PR DESCRIPTION
The current behavior is very strict: if light curves have a different tseg, `AveragedCrossspectrum` and the such will fail. This is probably an overkill.
The case in StingraySoftware/HENDRICS#52 is clear: the data have different GTIs and tseg is different. However, this is accounted for more than sufficiently by the `cross_gti` operations a few lines below the tseg check. If the light curve has no compatible gtis, everything will fail anyway. If GTIs have common intervals, the averaged cross spectrum will be calculated.

So, here I propose to change the `ValueError` into a `simon` warning, and let the subsequent GTI checks do the rest.

Additionally, `Lightcurve()._apply_gtis()` now also updates `tseg`. This seemed appropriate to do.

And `make_lightcurve` sorts the input array before calculating `tseg` as `times[-1] - tstart` :)