### PR TITLE
Fix deprecated numpy usage to avoid warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-language: python
-
-python:
-    - 2.7
-    - 3.7
+language: minimal
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -29,76 +25,58 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - ASTROPY_VERSION=stable
-        - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='emcee statsmodels corner'
-        # For this package-template, we include examples of Cython modules,
-        # so Cython is required for testing. If your package does not include
-        # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython numpy scipy h5py nose matplotlib'
-    matrix:
-        # Make sure that egg_info works without dependencies
-        - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
+        - NUMPY_VERSION=stable
         - SETUP_CMD='test --coverage'
+        - PIP_DEPENDENCIES='emcee statsmodels corner'
+        - CONDA_DEPENDENCIES='scipy h5py matplotlib'
+        - SETUP_XVFB=True
 
 matrix:
     fast_finish: true
     include:
-        - python: 3.4
-          env: SCIPY_VERSION=0.18.0 NUMPY_VERSION=1.11 ASTROPY_VERSION=1.3 PIP_DEPENDENCIES='pytest-catchlog' SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
-        - python: 3.5
-          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner' SETUP_CMD='test --remote-data --coverage'
+        - env: PYTHON_VERSION=3.7
 
-        - python: 3.5
-          env: CONDA_DEPENDENCIES='Cython numpy scipy nose matplotlib numba' SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.4 SCIPY_VERSION=0.18.0 NUMPY_VERSION=1.11 ASTROPY_VERSION=1.3
+               PIP_DEPENDENCIES='pytest-catchlog'
+
+        - env: PYTHON_VERSION=3.6
+               PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner'
+               SETUP_CMD='test --remote-data --coverage' NUMPY_VERSION=1.14
+
+        - env: PYTHON_VERSION=3.7  CONDA_DEPENDENCIES='scipy matplotlib numba'
 
         # Try without using corner
-        - python: 3.5
-          env: PIP_DEPENDENCIES='emcee statsmodels' SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='emcee statsmodels'
 
         # Try without using emcee
-        - python: 3.5
-          env: PIP_DEPENDENCIES='statsmodels' SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='statsmodels'
 
         # Try without using statsmodels
-        - python: 3.5
-          env: PIP_DEPENDENCIES='emcee' SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='emcee'
 
-        - python: 3.6
-          env: PIP_DEPENDENCIES='nbsphinx' SETUP_CMD='build_docs -w'
+        - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='nbsphinx' SETUP_CMD='build_docs -w'
 
         # Try older scipy versions
-        - python: 2.7
-          env: SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.11
+        - env: PYTHON_VERSION=2.7 SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.12 ASTROPY_VERSION=lts
 
         # Try older scipy versions
-        - python: 3.4
-          env: SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.11
+        - env: PYTHON_VERSION=3.4 SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
 
         # Try Astropy development version
-        - python: 3.5
-          env: ASTROPY_VERSION=development
+        - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=development
+
+        - env: PYTHON_VERSION=2.7
 
     allow_failures:
         # Try older scipy versions
-        - python: 3.4
-          env: SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.11
+        - env: PYTHON_VERSION=3.4 SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
 
         # Try Astropy development version
-        - python: 3.5
-          env: ASTROPY_VERSION=development
+        - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=development
 
-        - python: 2.7
-        - SETUP_CMD='test --coverage'
-
-
-before_install:
-
-    # If there are matplotlib tests, comment these out to
-    # Make sure that interactive matplotlib backends work
-    # - export DISPLAY=:99.0
-    # - sh -e /etc/init.d/xvfb start
+        - env: PYTHON_VERSION=2.7
 
 install:
 
@@ -124,11 +102,6 @@ install:
     # well as at the start of the install section or in the before_install
     # section if they are needed before setting up conda) to install any
     # other dependencies.
-
-before_script:
-   - "export DISPLAY=:99.0"
-   - "sh -e /etc/init.d/xvfb start"
-   - sleep 3
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ matrix:
         - env: PYTHON_VERSION=2.7
 
     allow_failures:
+        - env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
         # Try older scipy versions
         - env: PYTHON_VERSION=3.4 SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,10 +57,7 @@ matrix:
         - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='emcee'
 
         - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='nbsphinx' SETUP_CMD='build_docs -w'
-
-        # Try older scipy versions
-        - env: PYTHON_VERSION=2.7 SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.12 ASTROPY_VERSION=lts
-
+        
         # Try older scipy versions
         - env: PYTHON_VERSION=3.4 SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
     - 2.7
-    - 3.6
+    - 3.7
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -50,13 +50,6 @@ matrix:
         - python: 3.5
           env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner' SETUP_CMD='test --remote-data --coverage'
 
-        - python: 2.7
-          env: PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner' SETUP_CMD='test --remote-data'
-
-        #Try without importing h5py but importing numba
-        - python: 2.7
-          env: CONDA_DEPENDENCIES='Cython numpy scipy nose matplotlib numba'
-
         - python: 3.5
           env: CONDA_DEPENDENCIES='Cython numpy scipy nose matplotlib numba' SETUP_CMD='test --coverage'
 
@@ -89,16 +82,15 @@ matrix:
 
     allow_failures:
         # Try older scipy versions
-        - python: 2.7
-          env: SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.11
-
-        # Try older scipy versions
         - python: 3.4
           env: SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.11
 
         # Try Astropy development version
         - python: 3.5
           env: ASTROPY_VERSION=development
+
+        - python: 2.7
+        - SETUP_CMD='test --coverage'
 
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,18 +14,15 @@ environment:
         PIP_DEPENDENCIES: "emcee pytest-catchlog"
 
     matrix:
-        - PYTHON_VERSION: "3.4"
-          CONDA_PY: "34"
-          CONDA_DEPENDENCIES: "mkl=2017.0.3 scipy=0.18 numpy=1.11 nose h5py astropy matplotlib statsmodels"
-        - PYTHON_VERSION: "3.5"
-          CONDA_PY: "35"
-          NUMPY_VERSION: "1.11"
-        - PYTHON_VERSION: "2.7"
-          NUMPY_VERSION: "stable"
-          CONDA_PY: "27"
         - PYTHON_VERSION: "3.6"
           NUMPY_VERSION: "stable"
           CONDA_PY: "36"
+        - PYTHON_VERSION: "3.7"
+          NUMPY_VERSION: "stable"
+          CONDA_PY: "37"
+        - PYTHON_VERSION: "3.5"
+          CONDA_PY: "35"
+          NUMPY_VERSION: "1.11"
 
 matrix:
     fast_finish: true

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -455,8 +455,8 @@ def cross_two_gtis(gti0, gti1):
     final_gti = []
     for ie, e in enumerate(conc_end):
         # Is this ending in series 0 or 1?
-        this_series = conc_tag[ie]
-        other_series = not this_series
+        this_series = int(conc_tag[ie])
+        other_series = int(this_series == 0)
 
         # Check that this closes intervals in both series.
         # 1. Check that there is an opening in both series 0 and 1 lower than e

--- a/stingray/modeling/scripts.py
+++ b/stingray/modeling/scripts.py
@@ -283,7 +283,7 @@ def fit_lorentzians(ps, nlor, starting_pars, fit_whitenoise=True,
     ...         models.Lorentz1D(amplitude_2, x_0_2, fwhm_2) + \\
     ...         models.Const1D(whitenoise)
 
-    >>> freq = np.linspace(0.01, 10.0, 10.0/0.01)
+    >>> freq = np.linspace(0.01, 10.0, 1000)
     >>> p = model(freq)
     >>> noise = np.random.exponential(size=len(freq))
 

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -572,8 +572,8 @@ if can_sample:
                                                 len(res.p_opt), cls.lpost,
                                                 args=[False], threads=1)
 
-         with catch_warnings(RuntimeWarning):
-               _, _, _ = cls.sampler.run_mcmc(p0, cls.niter)
+            with catch_warnings(RuntimeWarning):
+                _, _, _ = cls.sampler.run_mcmc(p0, cls.niter)
 
 
         def test_can_sample_is_true(self):

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -3,9 +3,8 @@ import numpy as np
 import scipy.stats
 import os
 import logging
-import warnings
 
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, catch_warnings
 from astropy.modeling import models
 from astropy.modeling.fitting import _fitter_to_model_params
 
@@ -161,9 +160,7 @@ class TestParameterEstimation(object):
         pe = ParameterEstimation()
         if os.path.exists("test_corner.pdf"):
             os.unlink("test_corner.pdf")
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=RuntimeWarning)
-
+        with catch_warnings(RuntimeWarning):
             sample_res = pe.sample(self.lpost, [2.0], nwalkers=100, niter=10,
                                    burnin=50, print_results=True, plot=True)
 
@@ -575,9 +572,8 @@ if can_sample:
                                                 len(res.p_opt), cls.lpost,
                                                 args=[False], threads=1)
 
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', category=RuntimeWarning)
-                _, _, _ = cls.sampler.run_mcmc(p0, cls.niter)
+         with catch_warnings(RuntimeWarning):
+               _, _, _ = cls.sampler.run_mcmc(p0, cls.niter)
 
 
         def test_can_sample_is_true(self):
@@ -926,8 +922,7 @@ class TestPSDParEst(object):
 
         pe = PSDParEst(self.ps)
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=RuntimeWarning)
+        with catch_warnings(RuntimeWarning):
             sample_res = pe.sample(self.lpost, [2.0, 0.1, 100, 2.0], nwalkers=50,
                                    niter=10, burnin=15, print_results=True,
                                    plot=True)
@@ -1191,8 +1186,7 @@ class TestPSDParEst(object):
 
         pe = PSDParEst(ps)
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=RuntimeWarning)
+        with catch_warnings(RuntimeWarning):
             pval = pe.calibrate_lrt(lpost, [2.0], lpost2,
                                     [2.0, 1.0, 2.0], sample=None,
                                     max_post=True, nsim=10, nwalkers=100,
@@ -1387,8 +1381,7 @@ class TestPSDParEst(object):
 
         pe = PSDParEst(ps)
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=RuntimeWarning)
+        with catch_warnings(RuntimeWarning):
             pval = pe.calibrate_highest_outlier(lpost, [2.0], sample=None,
                                                 max_post=True, seed=seed,
                                                 nsim=nsim, niter=20, nwalkers=100,

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -3,13 +3,13 @@ import numpy as np
 import scipy.stats
 import os
 import logging
+import warnings
 
 from astropy.tests.helper import pytest
 from astropy.modeling import models
 from astropy.modeling.fitting import _fitter_to_model_params
 
 from stingray import Powerspectrum
-
 from stingray.modeling import ParameterEstimation, PSDParEst, \
     OptimizationResults, SamplingResults
 from stingray.modeling import PSDPosterior, set_logprior, PSDLogLikelihood, \
@@ -161,8 +161,11 @@ class TestParameterEstimation(object):
         pe = ParameterEstimation()
         if os.path.exists("test_corner.pdf"):
             os.unlink("test_corner.pdf")
-        sample_res = pe.sample(self.lpost, [2.0], nwalkers=100, niter=10,
-                               burnin=50, print_results=True, plot=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=RuntimeWarning)
+
+            sample_res = pe.sample(self.lpost, [2.0], nwalkers=100, niter=10,
+                                   burnin=50, print_results=True, plot=True)
 
         assert os.path.exists("test_corner.pdf")
         assert sample_res.acceptance > 0.25
@@ -572,7 +575,9 @@ if can_sample:
                                                 len(res.p_opt), cls.lpost,
                                                 args=[False], threads=1)
 
-            _, _, _ = cls.sampler.run_mcmc(p0, cls.niter)
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', category=RuntimeWarning)
+                _, _, _ = cls.sampler.run_mcmc(p0, cls.niter)
 
 
         def test_can_sample_is_true(self):
@@ -921,9 +926,11 @@ class TestPSDParEst(object):
 
         pe = PSDParEst(self.ps)
 
-        sample_res = pe.sample(self.lpost, [2.0, 0.1, 100, 2.0], nwalkers=50,
-                               niter=10, burnin=15, print_results=True,
-                               plot=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=RuntimeWarning)
+            sample_res = pe.sample(self.lpost, [2.0, 0.1, 100, 2.0], nwalkers=50,
+                                   niter=10, burnin=15, print_results=True,
+                                   plot=True)
         assert os.path.exists("test_corner.pdf")
         os.unlink("test_corner.pdf")
         assert sample_res.acceptance > 0.25
@@ -1184,11 +1191,13 @@ class TestPSDParEst(object):
 
         pe = PSDParEst(ps)
 
-        pval = pe.calibrate_lrt(lpost, [2.0], lpost2,
-                                [2.0, 1.0, 2.0], sample=None,
-                                max_post=True, nsim=10, nwalkers=100,
-                                burnin=100, niter=20,
-                                seed=100)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=RuntimeWarning)
+            pval = pe.calibrate_lrt(lpost, [2.0], lpost2,
+                                    [2.0, 1.0, 2.0], sample=None,
+                                    max_post=True, nsim=10, nwalkers=100,
+                                    burnin=100, niter=20,
+                                    seed=100)
 
         assert pval > 0.001
 
@@ -1378,9 +1387,11 @@ class TestPSDParEst(object):
 
         pe = PSDParEst(ps)
 
-        pval = pe.calibrate_highest_outlier(lpost, [2.0], sample=None,
-                                            max_post=True, seed=seed,
-                                            nsim=nsim, niter=20, nwalkers=100,
-                                            burnin=100)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=RuntimeWarning)
+            pval = pe.calibrate_highest_outlier(lpost, [2.0], sample=None,
+                                                max_post=True, seed=seed,
+                                                nsim=nsim, niter=20, nwalkers=100,
+                                                burnin=100)
 
         assert pval > 0.001

--- a/stingray/modeling/tests/test_scripts.py
+++ b/stingray/modeling/tests/test_scripts.py
@@ -42,7 +42,7 @@ class TestFitLorentzians(object):
             models.Lorentz1D(cls.amplitude_2, cls.x_0_2, cls.fwhm_2) + \
             models.Const1D(cls.whitenoise)
 
-        freq = np.linspace(0.01, 10.0, 10.0 / 0.01)
+        freq = np.linspace(0.01, 10.0, 1000)
         p = cls.model(freq)
         noise = np.random.exponential(size=len(freq))
 

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -531,7 +531,7 @@ def fftfit(prof, template=None, quick=False, sigma=None, use_bootstrap=False,
         min_chisq = 1e32
 
         binsize = 1 / nbin
-        for d in np.linspace(-0.5, 0.5, nbin / 2):
+        for d in np.linspace(-0.5, 0.5, int(nbin / 2)):
             p0 = [1, dph + d]
 
             res_trial = minimize(_fft_fun_wrap, p0, args=([prof, template],),

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -298,7 +298,7 @@ class Simulator(object):
         h_primary = np.append(np.zeros(int(t1/dt)), p1)
 
         # Create a rising exponential of user-provided slope
-        x = np.linspace(t1/dt, t2/dt, (t2-t1)/dt)
+        x = np.linspace(t1/dt, t2/dt, int((t2-t1)/dt))
         h_rise = np.exp(rise*x)
 
         # Evaluate a factor for scaling exponential
@@ -306,7 +306,7 @@ class Simulator(object):
         h_secondary = (h_rise/factor) + p1
 
         # Create a decaying exponential until the end time
-        x = np.linspace(t2/dt, t3/dt, (t3-t2)/dt)
+        x = np.linspace(t2/dt, t3/dt, int((t3-t2)/dt))
         h_decay = (np.exp((-decay)*(x-4/dt)))
 
         # Add the three responses

--- a/stingray/simulator/transfer.py
+++ b/stingray/simulator/transfer.py
@@ -4,7 +4,7 @@ import numpy as np
 from stingray.io import read, write
 
 """
-Implementation of time and energy averaged responses from 2-d 
+Implementation of time and energy averaged responses from 2-d
 transfer functions.
 """
 
@@ -68,8 +68,8 @@ class TransferFunction(object):
 
     def time_response(self, e0=None, e1=None):
         """
-        Form an energy-averaged/time-resolved response of 2-d transfer 
-        function. 
+        Form an energy-averaged/time-resolved response of 2-d transfer
+        function.
 
         Returns
         -------
@@ -82,13 +82,13 @@ class TransferFunction(object):
         e1: int
             end value of energy interval to be averaged
         """
-        
+
         # Set start and stop values
         if e0 is None:
             start = 0
         else:
             start = int(self.estart + e0/self.de)
-        
+
         if e1 is None:
             stop = len(self.data[:][0]) - 1
         else:
@@ -108,14 +108,14 @@ class TransferFunction(object):
 
     def energy_response(self):
         """
-        Form a time-averaged/energy-resolved response of 2-d transfer function. 
+        Form a time-averaged/energy-resolved response of 2-d transfer function.
 
         Returns
         -------
         time : numpy.ndarray
             time-averaged/energy-resolved response of 2-d transfer function
         """
-        
+
         self.energy = np.mean(self.data, axis=1)
 
     def plot(self, response='2d', save=False, filename=None, show=False):
@@ -145,7 +145,7 @@ class TransferFunction(object):
         fig = plt.figure()
 
         if response == 'time':
-            t = np.linspace(self.tstart, len(self.data[0])*self.dt, 
+            t = np.linspace(self.tstart, len(self.data[0])*self.dt,
                             len(self.data[0]))
             figure = plt.plot(t, self.time)
             plt.xlabel('Time')
@@ -153,13 +153,13 @@ class TransferFunction(object):
             plt.title('Time-resolved Response')
 
         elif response == 'energy':
-            e = np.linspace(self.estart, len(self.data[:])*self.de, 
+            e = np.linspace(self.estart, len(self.data[:])*self.de,
                             len(self.data[:]))
             figure = plt.plot(e, self.energy)
             plt.xlabel('Energy')
             plt.ylabel('Flux')
             plt.title('Energy-resolved Response')
-            
+
         elif response == '2d':
             figure = plt.imshow(self.data, interpolation='nearest',
                                 cmap='Oranges', origin='lower')
@@ -177,12 +177,12 @@ class TransferFunction(object):
                 plt.savefig('out.png')
             else:
                 plt.savefig(filename)
-        
+
         if show:
             plt.show()
         else:
             plt.close()
-        
+
     @staticmethod
     def read(filename, format_='pickle'):
         """
@@ -198,7 +198,7 @@ class TransferFunction(object):
         data : class instance
             `TransferFunction` object
         """
-        
+
         object = read(filename, format_)
 
         if format_ == 'pickle':
@@ -209,7 +209,7 @@ class TransferFunction(object):
 
     def write(self, filename, format_='pickle'):
         """
-        Writes a transfer function to 'pickle' file. 
+        Writes a transfer function to 'pickle' file.
 
         Parameters
         ----------
@@ -224,13 +224,13 @@ class TransferFunction(object):
             raise KeyError("Format not understood.")
 
 """
-Implementation of artificial methods to create energy-averaged 
+Implementation of artificial methods to create energy-averaged
 responses for quick testing.
 """
 
 def simple_ir(dt=0.125, start=0, width=1000, intensity=1):
     """
-    Construct a simple impulse response using start time, 
+    Construct a simple impulse response using start time,
     width and scaling intensity.
     To create a delta impulse response, set width to 1.
 
@@ -241,10 +241,10 @@ def simple_ir(dt=0.125, start=0, width=1000, intensity=1):
 
     start : int
         start time of impulse response
-    
+
     width : int
         width of impulse response
-    
+
     intensity : float
         scaling parameter to set the intensity of delayed emission
         corresponding to direct emission.
@@ -275,22 +275,22 @@ def relativistic_ir(dt=0.125, t1=3, t2=4, t3=10, p1=1, p2=1.4, rise=0.6, decay=0
 
     t1 : int
         primary peak time
-    
+
     t2 : int
         secondary peak time
-    
+
     t3 : int
         end time
-    
+
     p1 : float
         value of primary peak
-    
+
     p2 : float
         value of secondary peak
-    
+
     rise : float
         slope of rising exponential from primary peak to secondary peak
-    
+
     decay : float
         slope of decaying exponential from secondary peak to end time
 
@@ -308,16 +308,16 @@ def relativistic_ir(dt=0.125, t1=3, t2=4, t3=10, p1=1, p2=1.4, rise=0.6, decay=0
     h_primary = np.append(np.zeros(int(t1/dt)), p1)
 
     # Create a rising exponential of user-provided slope
-    x = np.linspace(t1/dt, t2/dt, (t2-t1)/dt)
+    x = np.linspace(t1/dt, t2/dt, int((t2-t1)/dt))
     h_rise = np.exp(rise*x)
-    
+
     # Evaluate a factor for scaling exponential
     factor = np.max(h_rise)/(p2-p1)
     h_secondary = (h_rise/factor) + p1
 
     # Create a decaying exponential until the end time
-    x = np.linspace(t2/dt, t3/dt, (t3-t2)/dt)
-    h_decay = (np.exp((-decay)*(x-4/dt))) 
+    x = np.linspace(t2/dt, t3/dt, int((t3-t2)/dt))
+    h_decay = (np.exp((-decay)*(x-4/dt)))
 
     # Add the three responses
     h = np.append(h_primary, h_secondary)

--- a/stingray/tests/test_spectroscopy.py
+++ b/stingray/tests/test_spectroscopy.py
@@ -269,7 +269,7 @@ def test_get_new_df():
         models.Lorentz1D(amplitude_2, x_0_2, fwhm_2) + \
         models.Const1D(whitenoise)
 
-    freq = np.linspace(0.01, 10.0, 10.0 / 0.01)
+    freq = np.linspace(0.01, 10.0, 1000)
     p = model(freq)
     noise = np.random.exponential(size=len(freq))
 
@@ -328,7 +328,7 @@ def test_compute_rms():
         models.Lorentz1D(amplitude_2, x_0_2, fwhm_2) + \
         models.Const1D(whitenoise)
 
-    freq = np.linspace(-10.0, 10.0, 10.0 / 0.01)
+    freq = np.linspace(-10.0, 10.0, 1000)
     p = model(freq)
     noise = np.random.exponential(size=len(freq))
 


### PR DESCRIPTION
I suppose this should get rid of most of the travis failures in the other PR (#377), but given that there are other deprecation warnings coming from upstream packages I think it makes sense to deal with them separately from the helpers update.

I highly recommend to enable `enable_deprecations_as_exceptions()` in conftest.py to pick up these deprecations as early as possible.