### PR TITLE
Adding back interactive plot testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
         - PIP_DEPENDENCIES='emcee statsmodels corner'
         - CONDA_DEPENDENCIES='scipy h5py matplotlib'
         - SETUP_XVFB=True
+        - MPLBACKEND=TkAgg
 
 matrix:
     fast_finish: true
@@ -57,7 +58,7 @@ matrix:
         - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='emcee'
 
         - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='nbsphinx' SETUP_CMD='build_docs -w'
-        
+
         # Try older scipy versions
         - env: PYTHON_VERSION=3.4 SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
 


### PR DESCRIPTION
Recent changes in MPL made us manually setting MPLBACKEND to a non interactive one as default (MPL was segfaulting with several packages).

However, I notice that stingray is trying to do some interactive plotting, so overriding the default here. 
(Please do edit the PR if you prefer to have a different one)