### PR TITLE
Warn when extrapolating outside range in orbital correction

### DIFF
--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -771,9 +771,20 @@ def get_orbital_correction_from_ephemeris_file(mjdstart, mjdstop, parfile,
     toalist = _load_and_prepare_TOAs(mjds, ephem=ephem)
     m = get_model(parfile)
     delays = m.delay(toalist)
-    correction_mjd = \
+
+    correction_mjd_rough = \
         interp1d(mjds,
-                 (toalist.table['tdbld'] * units.d - delays).to(units.d).value)
+                 (toalist.table['tdbld'] * units.d - delays).to(units.d).value,
+                  fill_value="extrapolate")
+
+    def correction_mjd(mjds):
+        xvals = correction_mjd_rough.x
+        # Maybe this will be fixed if scipy/scipy#9602 is accepted
+        bad = (mjds < xvals[0]) | (np.any(mjds > xvals[-1]))
+        if np.any(bad):
+            warnings.warn("Some points are outside the interpolation range:"
+                          " {}".format(mjds[bad]))
+        return correction_mjd_rough(mjds)
 
     def correction_sec(times, mjdref):
         deorb_mjds = correction_mjd(times / 86400 + mjdref)

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -778,6 +778,17 @@ def get_orbital_correction_from_ephemeris_file(mjdstart, mjdstop, parfile,
                   fill_value="extrapolate")
 
     def correction_mjd(mjds):
+        """Get the orbital correction.
+        
+        Parameters
+        ----------
+        mjds : array-like
+            The input times in MJD
+        
+        Returns
+        -------
+        mjds: Corrected times in MJD
+        """
         xvals = correction_mjd_rough.x
         # Maybe this will be fixed if scipy/scipy#9602 is accepted
         bad = (mjds < xvals[0]) | (np.any(mjds > xvals[-1]))
@@ -787,7 +798,20 @@ def get_orbital_correction_from_ephemeris_file(mjdstart, mjdstop, parfile,
         return correction_mjd_rough(mjds)
 
     def correction_sec(times, mjdref):
-        deorb_mjds = correction_mjd(times / 86400 + mjdref)
+        """Get the orbital correction.
+        
+        Parameters
+        ----------
+        times : array-like
+            The input times in seconds of Mission Elapsed Time (MET)
+        mjdref : float
+            MJDREF, reference MJD for the mission
+       
+        Returns
+        -------
+        mets: array-like
+            Corrected times in MET seconds
+        """        deorb_mjds = correction_mjd(times / 86400 + mjdref)
         return np.array((deorb_mjds - mjdref) * 86400)
 
     retvals = [correction_sec, correction_mjd]

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -811,7 +811,8 @@ def get_orbital_correction_from_ephemeris_file(mjdstart, mjdstop, parfile,
         -------
         mets: array-like
             Corrected times in MET seconds
-        """        deorb_mjds = correction_mjd(times / 86400 + mjdref)
+        """
+        deorb_mjds = correction_mjd(times / 86400 + mjdref)
         return np.array((deorb_mjds - mjdref) * 86400)
 
     retvals = [correction_sec, correction_mjd]


### PR DESCRIPTION
This modification is needed when correcting event times by small amounts (e.g. in the NuSTAR temperature correction), because the orbital correction uses interp1d and even a microsecond out of boundaries can raise exceptions in the strict mode. 
So, here I use fill_value="extrapolate" from interp1d in the orbital correction, and if out of bounds, I let the user decide if it's appropriate with a detailed warning. If out by a few seconds, it might be a minor issue. 
