### PR TITLE
Fixing egg build and removing remaining python 2.7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
 matrix:
     fast_finish: true
     include:
-        - env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+        - env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info' SETUP_XVFB=False
 
         - env: PYTHON_VERSION=3.7
 
@@ -64,17 +64,12 @@ matrix:
         # Try Astropy development version
         - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=development
 
-        - env: PYTHON_VERSION=2.7
-
     allow_failures:
-        - env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
         # Try older scipy versions
         - env: PYTHON_VERSION=3.4 SCIPY_VERSION=0.16.0 NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
 
         # Try Astropy development version
         - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=development
-
-        - env: PYTHON_VERSION=2.7
 
 install:
 


### PR DESCRIPTION
@matteobachetti - I expect this to fix the egg build.

Keeping the language minimal has the advantage of having faster installs and it shouldn't matter as we use conda and pip to install the dependencies anyway. I expect that even the latex and dvipng install can be removed, but I haven't touched those.