### PR TITLE
Add n_summed_spectra to Z2n stats

### DIFF
--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -100,6 +100,9 @@ def check_gtis(gti):
         If GTIs have overlapping or displaced values
     """
     gti = np.asarray(gti)
+    if len(gti) < 1:
+        raise ValueError("Empty GTIs")
+
     if len(gti) != gti.shape[0] or len(gti.shape) != 2 or \
             len(gti) != gti.shape[0]:
         raise TypeError("Please check formatting of GTIs. They need to be"
@@ -158,7 +161,6 @@ def create_gti_mask_jit(time, gtis, mask, gti_mask, min_length=0):  # pragma: no
             if length < min_length:
                 next_gti = True
                 continue
-
             next_gti = False
             gti_mask[gti_el] = True
 
@@ -229,9 +231,14 @@ def create_gti_mask(time, gtis, safe_interval=0, min_length=0,
                                         dt=dt, epsilon=epsilon)
 
     gtis = np.array(gtis, dtype=np.longdouble)
+
     check_gtis(gtis)
 
     dt = assign_value_if_none(dt, np.median(np.diff(time)))
+
+    lengths = gtis[:, 1] - gtis[:, 0]
+    good = lengths > max(min_length, dt)
+    gtis = gtis[good]
 
     mask = np.zeros(len(time), dtype=bool)
 

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -261,8 +261,6 @@ def fold_events(times, *frequency_derivatives, **opts):
     start_phase, stop_phase = pulse_phase(np.array([start_time, stop_time]),
                                           *frequency_derivatives,
                                           to_1=False)
-    print(phases)
-    print(pulse_phase(times, frequency_derivatives[0], frequency_derivatives[1], to_1=True))
     raw_profile, bins = np.histogram(phases,
                                      bins=np.linspace(0, 1, nbin + 1),
                                      weights=weights)

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -259,7 +259,8 @@ def fold_events(times, *frequency_derivatives, **opts):
     start_phase, stop_phase = pulse_phase(np.array([start_time, stop_time]),
                                           *frequency_derivatives,
                                           to_1=False)
-
+    print(phases)
+    print(pulse_phase(times, frequency_derivatives[0], frequency_derivatives[1], to_1=True))
     raw_profile, bins = np.histogram(phases,
                                      bins=np.linspace(0, 1, nbin + 1),
                                      weights=weights)
@@ -357,6 +358,7 @@ def fold_detection_level(nbin, epsilon=0.01, ntrial=1):
     from scipy import stats
 
     return stats.chi2.isf(epsilon/ntrial, nbin - 1)
+
 
 def z_n(phase, n=2, norm=1):
     '''Z^2_n statistics, a` la Buccheri+03, A&A, 128, 245, eq. 2.
@@ -670,16 +672,19 @@ def _plot_TOA_fit(profile, template, toa, mod=None, toaerr=None,
     import matplotlib.pyplot as plt
     from scipy.interpolate import interp1d
     import time
-    phases = np.arange(0, 1, 1 / len(profile))
+    phases = np.arange(0, 2, 1 / len(profile))
+    profile = np.concatenate((profile, profile))
+    template = np.concatenate((template, template))
     if mod is None:
         mod = interp1d(phases, template, fill_value='extrapolate')
 
     fig = plt.figure()
-    plt.plot(phases - np.floor(phases), profile, drawstyle='steps-mid')
+    plt.plot(phases, profile, drawstyle='steps-mid')
     fine_phases = np.linspace(0, 1, 1000)
     fine_phases_shifted = fine_phases - toa / period + additional_phase
-    plt.plot(fine_phases,
-             mod(fine_phases_shifted - np.floor(fine_phases_shifted)))
+    model = mod(fine_phases_shifted - np.floor(fine_phases_shifted))
+    model = np.concatenate((model, model))
+    plt.plot(np.linspace(0, 2, 2000), model)
     if toaerr is not None:
         plt.axvline((toa - toaerr) / period)
         plt.axvline((toa + toaerr) / period)

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -370,7 +370,7 @@ def z_n(phase, n=2, norm=1):
     phase : array of floats
         The phases of the events
     n : int, default 2
-        The ``n`` in $Z^2_n$.
+        Number of harmonics, including the fundamental
 
     Other Parameters
     ----------------
@@ -407,7 +407,7 @@ def z2_n_detection_level(n=2, epsilon=0.01, ntrial=1, n_summed_spectra=1):
     Parameters
     ----------
     n : int, default 2
-        The ``n`` in $Z^2_n$
+        The ``n`` in $Z^2_n$ (number of harmonics, including the fundamental)
     epsilon : float, default 0.01
         The fractional probability that the signal has been produced by noise
 
@@ -438,7 +438,7 @@ def z2_n_probability(z2, n=2, ntrial=1, n_summed_spectra=1):
     z2 : float
         A Z^2_n statistics value
     n : int, default 2
-        The ``n`` in $Z^2_n$
+        The ``n`` in $Z^2_n$ (number of harmonics, including the fundamental)
 
     Other Parameters
     ----------------

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -355,8 +355,8 @@ def fold_detection_level(nbin, epsilon=0.01, ntrial=1):
     if ntrial > 1:
         simon("fold: The treatment of ntrial is very rough. Use with caution")
     from scipy import stats
-    return stats.chi2.isf(epsilon/ntrial, nbin - 1)
 
+    return stats.chi2.isf(epsilon/ntrial, nbin - 1)
 
 def z_n(phase, n=2, norm=1):
     '''Z^2_n statistics, a` la Buccheri+03, A&A, 128, 245, eq. 2.
@@ -395,7 +395,7 @@ def z_n(phase, n=2, norm=1):
                 for k in range(1, n + 1)])
 
 
-def z2_n_detection_level(epsilon=0.01, n=2, n_summed_spectra=1, ntrial=1):
+def z2_n_detection_level(n=2, epsilon=0.01, ntrial=1, n_summed_spectra=1):
     """Return the detection level for the Z^2_n statistics.
 
     See Buccheri et al. (1983), Bendat and Piersol (1971).

--- a/stingray/tests/test_gti.py
+++ b/stingray/tests/test_gti.py
@@ -237,3 +237,9 @@ class TestGTI(object):
 
         with pytest.raises(ValueError):
             check_gtis([[1, 0]])
+
+    def test_check_gti_fails_empty(self):
+        with pytest.raises(ValueError) as excinfo:
+            check_gtis([])
+        assert 'Empty' in str(excinfo)
+

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -17,6 +17,7 @@ try:
     from numba import jit
 
     HAS_NUMBA = True
+    from numba import njit, prange
 except ImportError:
     warnings.warn("Numba not installed. Faking it")
 
@@ -29,6 +30,19 @@ except ImportError:
                 return func(*args, **kwargs)
 
             return wrapped_f
+
+    class njit(object):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self, func):
+            def wrapped_f(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapped_f
+
+    def prange(x):
+        return range(x)
 
 try:
     from statsmodels.robust import mad as mad  # pylint: disable=unused-import


### PR DESCRIPTION
A missing bit of information in the Z2 statistics. We have the number of summed spectra in the PDS detection level, why not adding it to Z2 :)