### PR TITLE
Abs rms norm fix

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -453,7 +453,7 @@ class Crossspectrum(object):
 
         elif self.norm.lower() == 'abs':
             c = c_num / np.float(self.n ** 2.)
-            power = c * (2. * tseg)
+            power = c * 2. / np.float(tseg)
 
         elif self.norm.lower() == 'none':
             power = unnorm_power


### PR DESCRIPTION
Fixed significant bug in absolute rms^2 normalization. Previous formula was for light curves in units of counts/s, but Stingray uses counts/bin (i.e., counts). New formula is for counts/bin.