### PR TITLE
New feature! Added lightcurve splitting

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -965,8 +965,12 @@ class Lightcurve(object):
         # calculate new GTIs
         gti_start = np.hstack([self.time[0]-epsilon, self.time[gap_idx+1]-epsilon])
         gti_stop = np.hstack([self.time[gap_idx]+epsilon, self.time[-1]+epsilon])
-        self.gti = np.vstack([gti_start, gti_stop]).T
-
+        
+        gti = np.vstack([gti_start, gti_stop]).T
+        if hasattr(self, 'gti') and self.gti is not None:
+            gti = cross_two_gtis(self.gti, gti)
+        self.gti = gti
+        
         lc_split = self.split_by_gti(min_points=min_points)
         return lc_split
 

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -962,7 +962,10 @@ class Lightcurve(object):
 
         lc_all = []
         for i in range(len(gap_idx) - 1):
-            lc_new = self.truncate(start=gap_idx[i] + 1, stop=gap_idx[i + 1] + 1)
+            if gap_idx[i+1] - gap_idx[i] <= 1:
+                continue
+            else:
+                lc_new = self.truncate(start=gap_idx[i] + 1, stop=gap_idx[i + 1] + 1)
 
             if len(lc_new) > min_points:
                 lc_all.append(lc_new)

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -921,6 +921,54 @@ class Lightcurve(object):
 
         return self._truncate_by_index(start, stop)
 
+    def split(self, min_gap, min_points=1):
+        """
+        For data with gaps, it can sometimes be useful to be able to split
+        the light curve into separate, evenly sampled objects along those
+        data gaps. This method allows to do this: it finds data gaps of a
+        specified minimum size, and produces a list of new `Lightcurve`
+        objects for each contiguous segment.
+
+        Parameters
+        ----------
+        min_gap : float
+            The length of a data gap, in the same units as the `time` attribute
+            of the `Lightcurve` object. Any smaller gaps will be ignored, any
+            larger gaps will be identified and used to split the light curve.
+
+        min_points : int, default 1
+            The minimum number of data points in each light curve. Light
+            curves with fewer data points will be ignored.
+
+        Returns
+        -------
+        lc_all : iterable of `Lightcurve` objects
+            The list of all contiguous light curves
+
+        Example
+        -------
+        >>> time = np.array([1, 2, 3, 6, 7, 8, 11, 12, 13])
+        >>> counts = np.random.rand(time.shape[0])
+        >>> lc = Lightcurve(time, counts)
+        >>> split_lc = lc.split(lc, 1.5)
+
+        """
+
+        gap_idx = np.where(np.diff(self.time) >= min_gap)[0]
+        print(gap_idx)
+
+        gap_idx = np.hstack([[-1], gap_idx, [self.n - 1]])
+        print(gap_idx)
+
+        lc_all = []
+        for i in range(len(gap_idx) - 1):
+            lc_new = self.truncate(start=gap_idx[i] + 1, stop=gap_idx[i + 1] + 1)
+
+            if len(lc_new) > min_points:
+                lc_all.append(lc_new)
+
+        return lc_all
+
     def sort(self, reverse=False):
         """
         Sort a Lightcurve object by time.

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -606,6 +606,18 @@ class TestLightcurve(object):
         assert np.all((slc[1].counts == test_counts[3:6]))
         assert np.all((slc[2].counts == test_counts[6:]))
 
+    def test_split_with_gtis(self):
+        test_time = np.array([1, 2, 3, 6, 7, 8, 10, 11, 12])
+        test_counts = np.random.rand(len(test_time))
+        gti = [[0,4], [9, 13]]
+        lc_test = Lightcurve(test_time, test_counts, gti=gti)
+        slc = lc_test.split(1.5)
+
+        assert np.all((slc[0].time == [1, 2, 3]))
+        assert np.all((slc[1].time == [10, 11 ,12]))
+        assert np.all((slc[0].counts == test_counts[:3]))
+        assert np.all((slc[1].counts == test_counts[6:]))
+
     def test_consecutive_gaps(self):
         test_time = np.array([1, 2, 3, 6, 9, 10, 11])
         test_counts = np.random.rand(len(test_time))

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -769,6 +769,21 @@ class TestLightcurve(object):
         assert np.all(lc0.gti == [[0.5, 4.5]])
         assert np.all(lc1.gti == [[5.5, 7.5]])
 
+    def test_split_lc_by_gtis_minpoints(self):
+        times = [1, 2, 3, 4, 5, 6, 7, 8]
+        counts = [1, 1, 1, 1, 2, 3, 3, 2]
+        gti = [[0.5, 3.5], [3.5, 5.5], [5.5, 8.5]]
+        min_points = 3
+
+        lc = Lightcurve(times, counts, gti=gti)
+        list_of_lcs = lc.split_by_gti(min_points=min_points)
+        lc0 = list_of_lcs[0]
+        lc1 = list_of_lcs[1]
+        assert np.all(lc0.time == [1, 2, 3])
+        assert np.all(lc1.time == [6, 7, 8])
+        assert np.all(lc0.counts == [1, 1, 1])
+        assert np.all(lc1.counts == [3, 3, 2])
+
     def test_shift(self):
         times = [1, 2, 3, 4, 5, 6, 7, 8]
         counts = [1, 1, 1, 1, 2, 3, 3, 2]

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -606,6 +606,17 @@ class TestLightcurve(object):
         assert np.all((slc[1].counts == test_counts[3:6]))
         assert np.all((slc[2].counts == test_counts[6:]))
 
+    def test_consecutive_gaps(self):
+        test_time = np.array([1, 2, 3, 6, 9, 10, 11])
+        test_counts = np.random.rand(len(test_time))
+        lc_test = Lightcurve(test_time, test_counts)
+        slc = lc_test.split(1.5)
+
+        assert np.all((slc[0].time == [1, 2, 3]))
+        assert np.all((slc[1].time == [9, 10, 11]))
+        assert np.all((slc[0].counts == test_counts[:3]))
+        assert np.all((slc[1].counts == test_counts[4:]))
+
     def test_sort(self):
         _times = [2, 1, 3, 4]
         _counts = [40, 10, 20, 5]

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -566,6 +566,46 @@ class TestLightcurve(object):
         np.testing.assert_almost_equal(lc2.gti[-1][-1], 2.5)
         assert lc2.mjdref == lc.mjdref
 
+    def test_split_with_two_segments(self):
+        test_time = np.array([1, 2, 3, 6, 7, 8])
+        test_counts = np.random.rand(len(test_time))
+        lc_test = Lightcurve(test_time, test_counts)
+        slc = lc_test.split(1.5)
+
+        assert len(slc) == 2
+
+    def test_split_has_correct_data_points(self):
+        test_time = np.array([1, 2, 3, 6, 7, 8])
+        test_counts = np.random.rand(len(test_time))
+        lc_test = Lightcurve(test_time, test_counts)
+        slc = lc_test.split(1.5)
+
+        assert np.all((slc[0].time == [1, 2, 3]))
+        assert np.all((slc[1].time == [6, 7 ,8]))
+        assert np.all((slc[0].counts == test_counts[:3]))
+        assert np.all((slc[1].counts == test_counts[3:]))
+
+    def test_split_with_three_segments(self):
+        test_time = np.array([1, 2, 3, 6, 7, 8, 10, 11, 12])
+        test_counts = np.random.rand(len(test_time))
+        lc_test = Lightcurve(test_time, test_counts)
+        slc = lc_test.split(1.5)
+
+        assert len(slc) == 3
+
+    def test_threeway_split_has_correct_data_points(self):
+        test_time = np.array([1, 2, 3, 6, 7, 8, 10, 11, 12])
+        test_counts = np.random.rand(len(test_time))
+        lc_test = Lightcurve(test_time, test_counts)
+        slc = lc_test.split(1.5)
+
+        assert np.all((slc[0].time == [1, 2, 3]))
+        assert np.all((slc[1].time == [6, 7 ,8]))
+        assert np.all((slc[2].time == [10, 11 ,12]))
+        assert np.all((slc[0].counts == test_counts[:3]))
+        assert np.all((slc[1].counts == test_counts[3:6]))
+        assert np.all((slc[2].counts == test_counts[6:]))
+
     def test_sort(self):
         _times = [2, 1, 3, 4]
         _counts = [40, 10, 20, 5]


### PR DESCRIPTION
I keep running into the situation where I need to split light curves along data gaps, i.e. make a light curve of a contiguous light segment before a gap and a contiguous segment after a gap. I'm probably not the only one, so I wrote a method for `Lightcurve` that can do this.

Comments welcome! :) 