### PR TITLE
Accept Event Lists for periodograms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ addons:
         packages:
             - graphviz
 
+# Only build master and tags, besides pull requests.
+branches:
+  only:
+    - master
+    - /v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
+
 
 stages:
    # Do the style check and a single test job, don't proceed if it fails
@@ -156,7 +162,7 @@ matrix:
           name: Python 3.8 with developer version of astropy
           stage: Comprehensive tests
           env: TOXENV=py38-test-devdeps
-          
+
         # Add a job that runs from cron only and tests against astropy dev and
         # numpy dev to give a change for early discovery of issues and feedback
         # for both developer teams.

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
         - os: linux
           python: 3.8
           name: Documentation build
-          stage: Comprehensive tests
+          stage: Initial tests
           env: TOXENV=build_docs
 
         # Now all dependencies with the latest Python

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -365,8 +365,16 @@ class Crossspectrum(object):
     nphots2: float
         The total number of photons in light curve 2
     """
-    def __init__(self, lc1=None, lc2=None, norm='none', gti=None,
-                 power_type="real", dt=None):
+
+    def __init__(self, data1=None, data2=None, norm='none', gti=None,
+                 lc1=None, lc2=None, power_type="real", dt=None):
+
+        # for backwards compatibility
+        if data1 is None and lc1 is not None:
+            data1 = lc1
+        if data2 is None and lc2 is not None:
+            data2 = lc2
+
         if isinstance(norm, str) is False:
             raise TypeError("norm must be a string")
 
@@ -378,8 +386,8 @@ class Crossspectrum(object):
         # check if input data is a Lightcurve object, if not make one or
         # make an empty Crossspectrum object if lc1 == ``None`` or lc2 == ``None``
 
-        if lc1 is None or lc2 is None:
-            if lc1 is not None or lc2 is not None:
+        if data1 is None or data2 is None:
+            if data1 is not None or data2 is not None:
                 raise TypeError("You can't do a cross spectrum with just one "
                                 "light curve!")
             else:
@@ -392,15 +400,16 @@ class Crossspectrum(object):
                 self.m = 1
                 self.n = None
                 return
-        if (isinstance(lc1, EventList) or isinstance(lc2, EventList)) and \
+
+        if (isinstance(data1, EventList) or isinstance(data2, EventList)) and \
                 dt is None:
             raise ValueError("If using event lists, please specify the bin "
                              "time to generate lightcurves.")
 
-        if isinstance(lc1, EventList):
-            lc1 = lc1.to_lc(dt)
-        if isinstance(lc2, EventList):
-            lc2 = lc2.to_lc(dt)
+        if isinstance(data1, EventList):
+            lc1 = data1.to_lc(dt)
+        if isinstance(data2, EventList):
+            lc2 = data2.to_lc(dt)
 
         self.gti = gti
         self.lc1 = lc1
@@ -985,8 +994,15 @@ class AveragedCrossspectrum(Crossspectrum):
 
     """
 
-    def __init__(self, lc1=None, lc2=None, segment_size=None, norm='none',
-                 gti=None, power_type="real", silent=False, dt=None):
+    def __init__(self, data1=None, data2=None, segment_size=None, norm='none',
+                 gti=None, power_type="real", silent=False, lc1=None, lc2=None,
+                 dt=None):
+
+        # for backwards compatibility
+        if data1 is None and lc1 is not None:
+            data1 = lc1
+        if data2 is None and lc2 is not None:
+            data2 = lc2
 
         self.type = "crossspectrum"
 
@@ -1001,11 +1017,11 @@ class AveragedCrossspectrum(Crossspectrum):
         self.show_progress = not silent
         self.dt = dt
 
-        for lc in [lc1, lc2]:
-            if isinstance(lc, EventList):
-                lengths = lc.gti[:, 1] - lc.gti[:, 0]
+        for data in [data1, data2]:
+            if isinstance(data, EventList):
+                lengths = data.gti[:, 1] - data.gti[:, 0]
                 good = lengths >= segment_size
-                lc.gti = lc.gti[good]
+                data.gti = data.gti[good]
 
         Crossspectrum.__init__(self, lc1, lc2, norm, gti=gti,
                                power_type=power_type, dt=dt)

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -6,6 +6,7 @@ import scipy
 import scipy.stats
 import scipy.fftpack
 import scipy.optimize
+import copy
 
 # location of factorial moved between scipy versions
 try:
@@ -26,7 +27,8 @@ from stingray.utils import rebin_data, simon, rebin_data_log
 from stingray.exceptions import StingrayError
 from stingray.gti import cross_two_gtis, bin_intervals_from_gtis, check_gtis
 from .events import EventList
-import copy
+from .utils import show_progress
+
 
 try:
     from tqdm import tqdm as show_progress
@@ -1014,8 +1016,10 @@ class AveragedCrossspectrum(Crossspectrum):
             Two light curves used for computing the cross spectrum.
         """
         # A way to say that this is actually not a power spectrum
-        if lc1 is not lc2 and (isinstance(lc1, EventList) or
-                               isinstance(lc1, Lightcurve)):
+        if self.type != "powerspectrum" and \
+                lc1 is not lc2 and (isinstance(lc1, EventList) or
+                                    isinstance(lc1, Lightcurve)):
+            print("Auxil")
             self.pds1 = AveragedCrossspectrum(lc1, lc1,
                                               segment_size=self.segment_size,
                                               norm='none', gti=lc1.gti,
@@ -1168,7 +1172,7 @@ class AveragedCrossspectrum(Crossspectrum):
 
         else:
             self.cs_all, nphots1_all, nphots2_all = [], [], []
-            for lc1_seg, lc2_seg in zip(lc1, lc2):
+            for lc1_seg, lc2_seg in show_progress(zip(lc1, lc2)):
                 if self.type == "crossspectrum":
                     cs_sep, nphots1_sep, nphots2_sep = \
                         self._make_segment_spectrum(lc1_seg, lc2_seg,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1071,19 +1071,16 @@ class AveragedCrossspectrum(Crossspectrum):
         # In case a small difference exists, ignore it
         lc1.dt = lc2.dt
 
-        gti = cross_two_gtis(lc1.gti, lc2.gti)
+        current_gtis = cross_two_gtis(lc1.gti, lc2.gti)
+        lc1.gti = lc2.gti = current_gtis
         lc1.apply_gtis()
         lc2.apply_gtis()
 
-        current_gtis = cross_two_gtis(lc1.gti, lc2.gti)
         if self.gti is None:
             self.gti = current_gtis
         else:
-            current_gtis = cross_two_gtis(current_gtis, self.gti)
-
-        lc1.gti = lc2.gti = current_gtis
-        lc1._apply_gtis()
-        lc2._apply_gtis()
+            if not np.all(self.gti == current_gtis):
+                self.gti = np.vstack([self.gti, current_gtis])
 
         check_gtis(current_gtis)
 
@@ -1102,7 +1099,8 @@ class AveragedCrossspectrum(Crossspectrum):
         if not self.show_progress:
             local_show_progress = lambda a: a
 
-        for start_ind, end_ind in zip(start_inds, end_inds):
+        for start_ind, end_ind in \
+                local_show_progress(zip(start_inds, end_inds)):
             time_1 = copy.deepcopy(lc1.time[start_ind:end_ind])
             counts_1 = copy.deepcopy(lc1.counts[start_ind:end_ind])
             counts_1_err = copy.deepcopy(lc1.counts_err[start_ind:end_ind])

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -906,11 +906,11 @@ class AveragedCrossspectrum(Crossspectrum):
 
     Parameters
     ----------
-    lc1: :class:`stingray.Lightcurve` object OR iterable of :class:`stingray.Lightcurve` objects
+    lc1: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects OR :class:`stingray.EventList` object
         A light curve from which to compute the cross spectrum. In some cases, this would
         be the light curve of the wavelength/energy/frequency band of interest.
 
-    lc2: :class:`stingray.Lightcurve` object OR iterable of :class:`stingray.Lightcurve` objects
+    lc2: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects OR :class:`stingray.EventList` object
         A second light curve to use in the cross spectrum. In some cases, this would be
         the wavelength/energy/frequency reference band to compare the band of interest with.
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -398,7 +398,6 @@ class Crossspectrum(object):
         self.lc1 = lc1
         self.lc2 = lc2
         self.power_type = power_type
-
         self._make_crossspectrum(lc1, lc2)
 
         # These are needed to calculate coherence
@@ -994,6 +993,12 @@ class AveragedCrossspectrum(Crossspectrum):
         self.show_progress = not silent
         self.dt = dt
 
+        for lc in [lc1, lc2]:
+            if isinstance(lc, EventList):
+                lengths = lc.gti[:, 1] - lc.gti[:, 0]
+                good = lengths >= segment_size
+                lc.gti = lc.gti[good]
+
         Crossspectrum.__init__(self, lc1, lc2, norm, gti=gti,
                                power_type=power_type, dt=dt)
 
@@ -1009,7 +1014,8 @@ class AveragedCrossspectrum(Crossspectrum):
             Two light curves used for computing the cross spectrum.
         """
         # A way to say that this is actually not a power spectrum
-        if lc1 is not lc2:
+        if lc1 is not lc2 and (isinstance(lc1, EventList) or
+                               isinstance(lc1, Lightcurve)):
             self.pds1 = AveragedCrossspectrum(lc1, lc1,
                                               segment_size=self.segment_size,
                                               norm='none', gti=lc1.gti,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -334,6 +334,20 @@ class Crossspectrum(object):
         This choice overrides the GTIs in the single light curves. Use with
         care!
 
+    lc1: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects
+        For backwards compatibility only. Like ``data1``, but no
+        :class:`stingray.events.EventList` objects allowed
+
+    lc2: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects
+        For backwards compatibility only. Like ``data2``, but no
+        :class:`stingray.events.EventList` objects allowed
+
+    dt: float
+        The time resolution of the light curve. Only needed when constructing
+        light curves in the case where ``data1``, ``data2`` are
+        :class:`EventList` objects
+
+
     Attributes
     ----------
     freq: numpy.ndarray
@@ -952,8 +966,10 @@ class AveragedCrossspectrum(Crossspectrum):
         ``[[gti0_0, gti0_1], [gti1_0, gti1_1], ...]`` -- Good Time intervals.
         This choice overrides the GTIs in the single light curves. Use with
         care!
+
     dt : float
-        Only needed if feeding :class:`EventList` objects
+        The time resolution of the light curve. Only needed when constructing
+        light curves in the case where data1 or data2 are of :class:EventList
 
     power_type: string, optional, default ``real``
          Parameter to choose among complete, real part and magnitude of
@@ -962,6 +978,14 @@ class AveragedCrossspectrum(Crossspectrum):
     silent : bool, default False
          Do not show a progress bar when generating an averaged cross spectrum.
          Useful for the batch execution of many spectra
+
+    lc1: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects
+        For backwards compatibility only. Like ``data1``, but no
+        :class:`stingray.events.EventList` objects allowed
+
+    lc2: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects
+        For backwards compatibility only. Like ``data2``, but no
+        :class:`stingray.events.EventList` objects allowed
 
     Attributes
     ----------

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -236,6 +236,7 @@ def cospectra_pvalue(power, nspec):
 
     return pval
 
+
 def coherence(lc1, lc2):
     """
     Estimate coherence function of two light curves.
@@ -391,10 +392,15 @@ class Crossspectrum(object):
                 self.m = 1
                 self.n = None
                 return
+        if (isinstance(lc1, EventList) or isinstance(lc2, EventList)) and \
+                dt is None:
+            raise ValueError("If using event lists, please specify the bin "
+                             "time to generate lightcurves.")
 
-        # gti = cross_two_gtis(lc1.gti, lc2.gti)
-        # lc1.gti = gti
-        # lc2.gti = gti
+        if isinstance(lc1, EventList):
+            lc1 = lc1.to_lc(dt)
+        if isinstance(lc2, EventList):
+            lc2 = lc2.to_lc(dt)
 
         self.gti = gti
         self.lc1 = lc1

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -394,6 +394,9 @@ class Crossspectrum(object):
         # check if input data is a Lightcurve object, if not make one or
         # make an empty Crossspectrum object if lc1 == ``None`` or lc2 == ``None``
 
+        if lc1 is not None or lc2 is not None:
+            warnings.warn("The lcN keywords are now deprecated. Use dataN "
+                          "instead", DeprecationWarning)
         # for backwards compatibility
         if data1 is None:
             data1 = lc1
@@ -1028,6 +1031,9 @@ class AveragedCrossspectrum(Crossspectrum):
                  gti=None, power_type="real", silent=False, lc1=None, lc2=None,
                  dt=None):
 
+        if lc1 is not None or lc2 is not None:
+            warnings.warn("The lcN keywords are now deprecated. Use dataN "
+                          "instead", DeprecationWarning)
         # for backwards compatibility
         if data1 is None:
             data1 = lc1

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -135,6 +135,19 @@ class EventList(object):
 
 
     def to_lc_list(self, dt):
+        """
+        Convert event list to a generator of :class:`stingray.Lightcurve`s.
+
+        Parameters
+        ----------
+        dt: float
+            Binning time of the light curves
+
+        Returns
+        -------
+        lc_gen: generator
+            Generates one :class:`stingray.Lightcurve` object for each GTI
+        """
         start_times = self.gti[:, 0]
         end_times = self.gti[:, 1]
         tsegs = end_times - start_times

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -135,8 +135,7 @@ class EventList(object):
 
 
     def to_lc_list(self, dt):
-        """
-        Convert event list to a generator of :class:`stingray.Lightcurve`s.
+        """Convert event list to a generator of Lightcurves.
 
         Parameters
         ----------

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -133,6 +133,23 @@ class EventList(object):
                                           gti=self.gti, tseg=tseg,
                                           mjdref=self.mjdref)
 
+
+    def to_lc_list(self, dt):
+        start_times = self.gti[:, 0]
+        end_times = self.gti[:, 1]
+        tsegs = end_times - start_times
+
+        for st, end, tseg in zip(start_times, end_times, tsegs):
+            idx_st = np.searchsorted(self.time, st, side='right')
+            idx_end = np.searchsorted(self.time, end, side='left')
+            lc = Lightcurve.make_lightcurve(self.time[idx_st:idx_end], dt,
+                                            tstart=st,
+                                            gti=np.array([[st, end]]),
+                                            tseg=tseg,
+                                            mjdref=self.mjdref)
+
+            yield lc
+
     @staticmethod
     def from_lc(lc):
         """

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -159,7 +159,6 @@ class EventList(object):
                                             gti=np.array([[st, end]]),
                                             tseg=tseg,
                                             mjdref=self.mjdref)
-
             yield lc
 
     @staticmethod

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -13,9 +13,6 @@ from stingray.stats import pds_probability
 
 from .events import EventList
 
-__all__ = ["Powerspectrum", "AveragedPowerspectrum", "DynamicalPowerspectrum"]
-
-
 from .gti import cross_two_gtis
 
 try:
@@ -353,6 +350,8 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
         if segment_size is not None and not np.isfinite(segment_size):
             raise ValueError("segment_size must be finite!")
 
+        self.dt = dt
+
         if isinstance(lc, EventList):
             lengths = lc.gti[:, 1] - lc.gti[:, 0]
             good = lengths >= segment_size
@@ -390,13 +389,13 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
 
         current_gtis = lc.gti
 
-        if self.gti is not None:
-            current_gtis = cross_two_gtis(current_gtis, self.gti)
+        if self.gti is None:
+            self.gti = lc.gti
+        else:
+            if not np.all(lc.gti == self.gti):
+                self.gti = np.vstack([self.gti, lc.gti])
 
-        lc.gti = current_gtis
-        lc._apply_gtis()
-
-        check_gtis(current_gtis)
+        check_gtis(self.gti)
 
         start_inds, end_inds = \
             bin_intervals_from_gtis(current_gtis, segment_size, lc.time, dt=lc.dt)

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -82,8 +82,12 @@ class Powerspectrum(Crossspectrum):
         The total number of photons in the light curve
 
     """
-    def __init__(self, lc=None, norm='frac', gti=None, dt=None):
-        Crossspectrum.__init__(self, lc1=lc, lc2=lc, norm=norm, gti=gti,
+    def __init__(self, data=None, norm="frac", gti=None,
+                 dt=None, lc=None):
+        if data is None:
+            data = lc
+
+        Crossspectrum.__init__(self, data1=data, data2=data, norm=norm, gti=gti,
                                dt=dt)
         self.nphots = self.nphots1
         self.dt = dt
@@ -340,26 +344,29 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
         The total number of photons in the light curve
 
     """
-    def __init__(self, lc=None, segment_size=None, norm="frac", gti=None,
-                 silent=False, dt=None):
+    def __init__(self, data=None, segment_size=None, norm="frac", gti=None,
+                 silent=False, dt=None, lc=None):
 
         self.type = "powerspectrum"
+        # Backwards compatibility: user might have supplied lc instead
+        if data is None:
+            data = lc
 
-        if segment_size is None and lc is not None:
+        if segment_size is None and data is not None:
             raise ValueError("segment_size must be specified")
         if segment_size is not None and not np.isfinite(segment_size):
             raise ValueError("segment_size must be finite!")
 
         self.dt = dt
 
-        if isinstance(lc, EventList):
-            lengths = lc.gti[:, 1] - lc.gti[:, 0]
+        if isinstance(data, EventList):
+            lengths = data.gti[:, 1] - data.gti[:, 0]
             good = lengths >= segment_size
-            lc.gti = lc.gti[good]
+            data.gti = data.gti[good]
 
         self.segment_size = segment_size
         self.show_progress = not silent
-        Powerspectrum.__init__(self, lc, norm, gti=gti, dt=dt)
+        Powerspectrum.__init__(self, data, norm, gti=gti, dt=dt)
 
         return
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -36,7 +36,7 @@ class Powerspectrum(Crossspectrum):
 
     Parameters
     ----------
-    lc: :class:`stingray.Lightcurve` object, optional, default ``None``
+    data: :class:`stingray.Lightcurve` object, optional, default ``None``
         The light curve data to be Fourier-transformed.
 
     norm: {``leahy`` | ``frac`` | ``abs`` | ``none`` }, optional, default ``frac``
@@ -288,7 +288,7 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
 
     Parameters
     ----------
-    lc: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects OR :class:`stingray.EventList` object
+    data: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects OR :class:`stingray.EventList` object
         The light curve data to be Fourier-transformed.
 
     segment_size: float

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -282,7 +282,7 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
 
     Parameters
     ----------
-    lc: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects
+    lc: :class:`stingray.Lightcurve`object OR iterable of :class:`stingray.Lightcurve` objects OR :class:`stingray.EventList` object
         The light curve data to be Fourier-transformed.
 
     segment_size: float

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -11,6 +11,11 @@ from stingray.gti import bin_intervals_from_gtis, check_gtis
 from stingray.crossspectrum import Crossspectrum, AveragedCrossspectrum
 from stingray.stats import pds_probability
 
+from .events import EventList
+
+__all__ = ["Powerspectrum", "AveragedPowerspectrum", "DynamicalPowerspectrum"]
+
+
 from .gti import cross_two_gtis
 
 try:
@@ -347,6 +352,11 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
             raise ValueError("segment_size must be specified")
         if segment_size is not None and not np.isfinite(segment_size):
             raise ValueError("segment_size must be finite!")
+
+        if isinstance(lc, EventList):
+            lengths = lc.gti[:, 1] - lc.gti[:, 0]
+            good = lengths >= segment_size
+            lc.gti = lc.gti[good]
 
         self.segment_size = segment_size
         self.show_progress = not silent

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -312,6 +312,11 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
          Do not show a progress bar when generating an averaged cross spectrum.
          Useful for the batch execution of many spectra
 
+    dt: float
+        The time resolution of the light curve. Only needed when constructing
+        light curves in the case where data is of :class:EventList
+
+
     Attributes
     ----------
     norm: {``leahy`` | ``frac`` | ``abs`` | ``none`` }

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1,18 +1,17 @@
 import warnings
+
 import numpy as np
 import scipy
-import scipy.stats
 import scipy.fftpack
 import scipy.optimize
+import scipy.stats
 
 import stingray.lightcurve as lightcurve
 import stingray.utils as utils
-from stingray.gti import bin_intervals_from_gtis, check_gtis
 from stingray.crossspectrum import Crossspectrum, AveragedCrossspectrum
+from stingray.gti import bin_intervals_from_gtis, check_gtis
 from stingray.stats import pds_probability
-
 from .events import EventList
-
 from .gti import cross_two_gtis
 
 try:
@@ -84,6 +83,9 @@ class Powerspectrum(Crossspectrum):
     """
     def __init__(self, data=None, norm="frac", gti=None,
                  dt=None, lc=None):
+        if lc is not None:
+            warnings.warn("The lc keyword is now deprecated. Use data "
+                          "instead", DeprecationWarning)
         if data is None:
             data = lc
 
@@ -353,6 +355,9 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
                  silent=False, dt=None, lc=None):
 
         self.type = "powerspectrum"
+        if lc is not None:
+            warnings.warn("The lc keyword is now deprecated. Use data "
+                          "instead", DeprecationWarning)
         # Backwards compatibility: user might have supplied lc instead
         if data is None:
             data = lc

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -482,7 +482,8 @@ class TestCrossspectrum(object):
 
     def test_norm_leahy(self):
         with pytest.warns(UserWarning) as record:
-            cs = Crossspectrum(lc1=self.lc1, lc2=self.lc1, norm='leahy')
+            cs = Crossspectrum(lc1=self.lc1, lc2=self.lc1,
+                               norm='leahy')
         assert len(cs.power) == 4999
         assert cs.norm == 'leahy'
         leahy_noise = 2.0  # expected Poisson noise level
@@ -661,12 +662,13 @@ class TestAveragedCrossspectrum(object):
                                              [self.lc2, self.lc1],
                                              segment_size=1)
         acs_test.type = 'invalid_type'
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as excinfo:
             assert AveragedCrossspectrum._make_crossspectrum(acs_test,
                                                              lc1=[self.lc1,
                                                                   self.lc2],
                                                              lc2=[self.lc2,
                                                                   self.lc1])
+        assert "Type of spectrum not recognized" in str(excinfo.value)
 
     def test_different_dt(self):
         time1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -726,8 +728,9 @@ class TestAveragedCrossspectrum(object):
             aps = AveragedCrossspectrum(lc1=self.lc1, lc2=self.lc2,
                                         segment_size=1, norm='leahy')
         aps.type = 'invalid_type'
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as excinfo:
             assert aps.rebin(df=new_df, method=aps.type)
+        assert "Method for summing or averaging not recognized. " in str(excinfo.value)
 
     def test_rebin_with_valid_type_attribute(self):
         new_df = 2

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -133,9 +133,17 @@ class TestAveragedCrossspectrumEvents(object):
 
         self.events = EventList(times, gti=gti)
 
-        self.cs = AveragedCrossspectrum(self.events, copy.deepcopy(self.events),
+        self.cs = Crossspectrum(self.events, copy.deepcopy(self.events),
+                                dt=self.dt)
+
+        self.acs = AveragedCrossspectrum(self.events, copy.deepcopy(self.events),
                                         segment_size=1, dt=self.dt)
         self.lc1 = self.lc2 = self.events
+
+    def test_it_works_with_events(self):
+        lc = self.events.to_lc(self.dt)
+        lccs = Crossspectrum(lc, lc)
+        assert np.allclose(lccs.power, self.cs.power)
 
     def test_make_empty_crossspectrum(self):
         cs = AveragedCrossspectrum()
@@ -171,7 +179,7 @@ class TestAveragedCrossspectrumEvents(object):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            coh = self.cs.coherence()
+            coh = self.acs.coherence()
 
             assert len(coh[0]) == 4999
             assert len(coh[1]) == 4999
@@ -179,40 +187,40 @@ class TestAveragedCrossspectrumEvents(object):
 
     def test_failure_when_normalization_not_recognized(self):
         with pytest.raises(ValueError):
-            self.cs = AveragedCrossspectrum(self.lc1, self.lc2,
-                                            segment_size=1,
-                                            norm="wrong", dt=self.dt)
+            cs = AveragedCrossspectrum(self.lc1, self.lc2,
+                                       segment_size=1,
+                                       norm="wrong", dt=self.dt)
 
     def test_failure_when_power_type_not_recognized(self):
         with pytest.raises(ValueError):
-            self.cs = AveragedCrossspectrum(self.lc1, self.lc2,
-                                            segment_size=1,
-                                            power_type="wrong", dt=self.dt)
+            cs = AveragedCrossspectrum(self.lc1, self.lc2,
+                                       segment_size=1,
+                                       power_type="wrong", dt=self.dt)
 
     def test_rebin(self):
-        new_cs = self.cs.rebin(df=1.5)
+        new_cs = self.acs.rebin(df=1.5)
         assert new_cs.df == 1.5
         new_cs.time_lag()
 
     def test_rebin_factor(self):
-        new_cs = self.cs.rebin(f=1.5)
-        assert new_cs.df == self.cs.df * 1.5
+        new_cs = self.acs.rebin(f=1.5)
+        assert new_cs.df == self.acs.df * 1.5
         new_cs.time_lag()
 
     def test_rebin_log(self):
         # For now, just verify that it doesn't crash
-        new_cs = self.cs.rebin_log(f=0.1)
-        assert type(new_cs) == type(self.cs)
+        new_cs = self.acs.rebin_log(f=0.1)
+        assert type(new_cs) == type(self.acs)
         new_cs.time_lag()
 
     def test_rebin_log_returns_complex_values(self):
         # For now, just verify that it doesn't crash
-        new_cs = self.cs.rebin_log(f=0.1)
+        new_cs = self.acs.rebin_log(f=0.1)
         assert isinstance(new_cs.power[0], np.complex)
 
     def test_rebin_log_returns_complex_errors(self):
         # For now, just verify that it doesn't crash
-        new_cs = self.cs.rebin_log(f=0.1)
+        new_cs = self.acs.rebin_log(f=0.1)
         assert isinstance(new_cs.power_err[0], np.complex)
 
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -4,10 +4,9 @@ import pytest
 import warnings
 import matplotlib.pyplot as plt
 import scipy.special
-from stingray import Lightcurve, AveragedPowerspectrum
+from stingray import Lightcurve
 from stingray import Crossspectrum, AveragedCrossspectrum, coherence, time_lag
 from stingray.crossspectrum import  cospectra_pvalue, normalize_crossspectrum
-from ..simulator.simulator import Simulator
 from stingray import StingrayError
 from ..simulator.simulator import Simulator
 
@@ -379,6 +378,15 @@ class TestCrossspectrum(object):
         with pytest.warns(UserWarning) as record:
             self.cs = Crossspectrum(self.lc1, self.lc2)
 
+    def test_lc_keyword_deprecation(self):
+        cs1 = Crossspectrum(self.lc1, self.lc2)
+        with pytest.warns(DeprecationWarning) as record:
+            cs2 = Crossspectrum(lc1=self.lc1, lc2=self.lc2)
+        assert np.any(['lcN keywords' in r.message.args[0]
+                       for r in record])
+        assert np.allclose(cs1.power, cs2.power)
+        assert np.allclose(cs1.freq, cs2.freq)
+
     def test_make_empty_crossspectrum(self):
         cs = Crossspectrum()
         assert cs.freq is None
@@ -474,7 +482,7 @@ class TestCrossspectrum(object):
 
     def test_norm_abs(self):
         # Testing for a power spectrum of lc1
-        cs = Crossspectrum(lc1=self.lc1, lc2=self.lc1, norm='abs')
+        cs = Crossspectrum(self.lc1, self.lc1, norm='abs')
         assert len(cs.power) == 4999
         assert cs.norm == 'abs'
         abs_noise = 2. * self.rate1  # expected Poisson noise level
@@ -482,7 +490,7 @@ class TestCrossspectrum(object):
 
     def test_norm_leahy(self):
         with pytest.warns(UserWarning) as record:
-            cs = Crossspectrum(lc1=self.lc1, lc2=self.lc1,
+            cs = Crossspectrum(self.lc1, self.lc1,
                                norm='leahy')
         assert len(cs.power) == 4999
         assert cs.norm == 'leahy'
@@ -623,6 +631,17 @@ class TestAveragedCrossspectrum(object):
         with pytest.warns(UserWarning) as record:
             self.cs = AveragedCrossspectrum(self.lc1, self.lc2, segment_size=1)
 
+    def test_lc_keyword_deprecation(self):
+        cs1 = AveragedCrossspectrum(data1=self.lc1, data2=self.lc2,
+                                    segment_size=1)
+        with pytest.warns(DeprecationWarning) as record:
+            cs2 = AveragedCrossspectrum(lc1=self.lc1, lc2=self.lc2,
+                                        segment_size=1)
+        assert np.any(['lcN keywords' in r.message.args[0]
+                       for r in record])
+        assert np.allclose(cs1.power, cs2.power)
+        assert np.allclose(cs1.freq, cs2.freq)
+
     def test_make_empty_crossspectrum(self):
         cs = AveragedCrossspectrum()
         assert cs.freq is None
@@ -664,9 +683,9 @@ class TestAveragedCrossspectrum(object):
         acs_test.type = 'invalid_type'
         with pytest.raises(ValueError) as excinfo:
             assert AveragedCrossspectrum._make_crossspectrum(acs_test,
-                                                             lc1=[self.lc1,
-                                                                  self.lc2],
-                                                             lc2=[self.lc2,
+                                                             [self.lc1,
+                                                              self.lc2],
+                                                             [self.lc2,
                                                                   self.lc1])
         assert "Type of spectrum not recognized" in str(excinfo.value)
 
@@ -735,7 +754,7 @@ class TestAveragedCrossspectrum(object):
     def test_rebin_with_valid_type_attribute(self):
         new_df = 2
         with pytest.warns(UserWarning) as record:
-            aps = AveragedCrossspectrum(lc1=self.lc1, lc2=self.lc2,
+            aps = AveragedCrossspectrum(self.lc1, self.lc2,
                                         segment_size=1, norm='leahy')
         assert aps.rebin(df=new_df)
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -127,33 +127,24 @@ class TestAveragedCrossspectrumEvents(object):
         tend = 1.0
         self.dt = np.longdouble(0.0001)
 
-        times = np.sort(np.random.uniform(tstart, tend, 1000))
+        times1 = np.sort(np.random.uniform(tstart, tend, 1000))
+        times2 = np.sort(np.random.uniform(tstart, tend, 1000))
         gti = np.array([[tstart, tend]])
 
-        self.events = EventList(times, gti=gti)
+        self.events1 = EventList(times1, gti=gti)
+        self.events2 = EventList(times2, gti=gti)
 
-        self.cs = Crossspectrum(self.events, copy.deepcopy(self.events),
-                                dt=self.dt)
+        self.cs = Crossspectrum(self.events1, self.events2, dt=self.dt)
 
-        self.acs = AveragedCrossspectrum(self.events, copy.deepcopy(self.events),
-                                        segment_size=1, dt=self.dt)
-        self.lc1 = self.lc2 = self.events
+        self.acs = AveragedCrossspectrum(self.events1, self.events2,
+                                         segment_size=1, dt=self.dt)
+        self.lc1, self.lc2 = self.events1, self.events2
 
     def test_it_works_with_events(self):
-        lc = self.events.to_lc(self.dt)
-        lccs = Crossspectrum(lc, lc)
+        lc1 = self.events1.to_lc(self.dt)
+        lc2 = self.events2.to_lc(self.dt)
+        lccs = Crossspectrum(lc1, lc2)
         assert np.allclose(lccs.power, self.cs.power)
-
-    def test_make_empty_crossspectrum(self):
-        cs = AveragedCrossspectrum()
-        assert cs.freq is None
-        assert cs.power is None
-        assert cs.df is None
-        assert cs.nphots1 is None
-        assert cs.nphots2 is None
-        assert cs.m == 1
-        assert cs.n is None
-        assert cs.power_err is None
 
     def test_no_segment_size(self):
         with pytest.raises(ValueError):

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -59,7 +59,7 @@ class TestAveragedPowerspectrumEvents(object):
         TODO: Not sure how to write tests for the rebin method!
         """
 
-        aps = AveragedPowerspectrum(lc=self.lc, segment_size=self.segment_size,
+        aps = AveragedPowerspectrum(self.lc, segment_size=self.segment_size,
                                     norm="Leahy", dt=self.dt)
         bin_aps = aps.rebin(df)
         assert np.isclose(bin_aps.freq[1]-bin_aps.freq[0], bin_aps.df,
@@ -74,7 +74,7 @@ class TestAveragedPowerspectrumEvents(object):
         TODO: Not sure how to write tests for the rebin method!
         """
 
-        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+        aps = AveragedPowerspectrum(self.lc, segment_size=1,
                                     norm="Leahy", dt=self.dt)
         bin_aps = aps.rebin(f=f)
         assert np.isclose(bin_aps.freq[1]-bin_aps.freq[0], bin_aps.df,
@@ -86,13 +86,13 @@ class TestAveragedPowerspectrumEvents(object):
     @pytest.mark.parametrize('df', [0.01, 0.1])
     def test_rebin_log(self, df):
         # For now, just verify that it doesn't crash
-        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+        aps = AveragedPowerspectrum(self.lc, segment_size=1,
                                     norm="Leahy", dt=self.dt)
         bin_aps = aps.rebin_log(df)
 
     def test_rebin_with_invalid_type_attribute(self):
         new_df = 2
-        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+        aps = AveragedPowerspectrum(self.lc, segment_size=1,
                                     norm='leahy', dt=self.dt)
         aps.type = 'invalid_type'
         with pytest.raises(AttributeError):
@@ -144,7 +144,7 @@ class TestPowerspectrum(object):
         assert ps.n is None
 
     def test_make_periodogram_from_lightcurve(self):
-        ps = Powerspectrum(lc=self.lc)
+        ps = Powerspectrum(self.lc)
         assert ps.freq is not None
         assert ps.power is not None
         assert ps.power_err is not None
@@ -155,7 +155,7 @@ class TestPowerspectrum(object):
         assert ps.nphots == np.sum(self.lc.counts)
 
     def test_periodogram_types(self):
-        ps = Powerspectrum(lc=self.lc)
+        ps = Powerspectrum(self.lc)
         assert isinstance(ps.freq, np.ndarray)
         assert isinstance(ps.power, np.ndarray)
         assert isinstance(ps.power_err, np.ndarray)
@@ -190,7 +190,7 @@ class TestPowerspectrum(object):
         Note: make sure the factors of ncounts match!
         Also, make sure to *exclude* the zeroth power!
         """
-        ps = Powerspectrum(lc=self.lc)
+        ps = Powerspectrum(self.lc)
         nn = ps.n
         pp = ps.unnorm_power / np.float(nn) ** 2
         p_int = np.sum(pp[:-1] * ps.df) + (pp[-1] * ps.df) / 2
@@ -202,7 +202,7 @@ class TestPowerspectrum(object):
         Make sure the standard normalization of a periodogram is
         rms and it stays that way!
         """
-        ps = Powerspectrum(lc=self.lc)
+        ps = Powerspectrum(self.lc)
         assert ps.norm == "frac"
 
     def test_frac_normalization_correct(self):
@@ -211,7 +211,7 @@ class TestPowerspectrum(object):
         equal to the variance of the light curve divided by the mean
         of the light curve squared.
         """
-        ps = Powerspectrum(lc=self.lc, norm="frac")
+        ps = Powerspectrum(self.lc, norm="frac")
         ps_int = np.sum(ps.power[:-1] * ps.df) + ps.power[-1] * ps.df / 2
         std_lc = np.var(self.lc.counts) / np.mean(self.lc.counts) ** 2
         assert np.isclose(ps_int, std_lc, atol=0.01, rtol=0.01)
@@ -224,11 +224,11 @@ class TestPowerspectrum(object):
 
         lc = Lightcurve(time, counts=poisson_counts, dt=1,
                             gti=[[0, 100]])
-        ps = Powerspectrum(lc=lc, norm="leahy")
+        ps = Powerspectrum(lc, norm="leahy")
         rms_ps_l, rms_err_l = ps.compute_rms(min_freq=ps.freq[1],
                                          max_freq=ps.freq[-1], white_noise_offset=0)
 
-        ps = Powerspectrum(lc=lc, norm="frac")
+        ps = Powerspectrum(lc, norm="frac")
         rms_ps, rms_err = ps.compute_rms(min_freq=ps.freq[1],
                                          max_freq=ps.freq[-1], white_noise_offset=0)
         assert np.allclose(rms_ps, rms_ps_l, atol=0.01)
@@ -242,12 +242,12 @@ class TestPowerspectrum(object):
 
         lc = Lightcurve(time, counts=poisson_counts, dt=1,
                             gti=[[0, 400]])
-        ps = AveragedPowerspectrum(lc=lc, norm="leahy", segment_size=100,
+        ps = AveragedPowerspectrum(lc, norm="leahy", segment_size=100,
                                    silent=True)
         rms_ps_l, rms_err_l = ps.compute_rms(min_freq=ps.freq[1],
                                          max_freq=ps.freq[-1], white_noise_offset=0)
 
-        ps = AveragedPowerspectrum(lc=lc, norm="frac", segment_size=100)
+        ps = AveragedPowerspectrum(lc, norm="frac", segment_size=100)
         rms_ps, rms_err = ps.compute_rms(min_freq=ps.freq[1],
                                          max_freq=ps.freq[-1], white_noise_offset=0)
         assert np.allclose(rms_ps, rms_ps_l, atol=0.01)
@@ -261,7 +261,7 @@ class TestPowerspectrum(object):
 
         lc = Lightcurve(time, counts=poisson_counts, dt=1,
                             gti=[[0, 400]])
-        ps = AveragedPowerspectrum(lc=lc, norm="frac", segment_size=100)
+        ps = AveragedPowerspectrum(lc, norm="frac", segment_size=100)
         rms_ps, rms_err = ps.compute_rms(min_freq=ps.freq[1],
                                          max_freq=ps.freq[-1],
                                          white_noise_offset=0)
@@ -287,7 +287,7 @@ class TestPowerspectrum(object):
         powers multiplied by the number of counts and divided by the
         square of the number of data points in the light curve
         """
-        ps = Powerspectrum(lc=self.lc, norm="Leahy")
+        ps = Powerspectrum(self.lc, norm="Leahy")
         ps_var = (np.sum(self.lc.counts) / ps.n ** 2.) * \
                  (np.sum(ps.power[:-1]) + ps.power[-1] / 2.)
 
@@ -299,7 +299,7 @@ class TestPowerspectrum(object):
         deviation divided by the mean of the light curve. Therefore, we allow
         for a larger tolerance in np.isclose()
         """
-        ps = Powerspectrum(lc=self.lc, norm="Leahy")
+        ps = Powerspectrum(self.lc, norm="Leahy")
         rms_ps, rms_err = ps.compute_rms(min_freq=ps.freq[0],
                                          max_freq=ps.freq[-1])
 
@@ -308,7 +308,7 @@ class TestPowerspectrum(object):
 
     def test_fractional_rms_fails_when_rms_not_leahy(self):
         with pytest.raises(Exception):
-            ps = Powerspectrum(lc=self.lc, norm="rms")
+            ps = Powerspectrum(self.lc, norm="rms")
             rms_ps, rms_err = ps.compute_rms(min_freq=ps.freq[0],
                                              max_freq=ps.freq[-1])
 
@@ -337,7 +337,7 @@ class TestPowerspectrum(object):
         pass
 
     def test_rebin_makes_right_attributes(self):
-        ps = Powerspectrum(lc=self.lc, norm="Leahy")
+        ps = Powerspectrum(self.lc, norm="Leahy")
         # replace powers
         ps.power = np.ones_like(ps.power) * 2.0
 
@@ -360,7 +360,7 @@ class TestPowerspectrum(object):
         Note: function defaults come as a tuple, so the first keyword argument
         had better be 'method'
         """
-        ps = Powerspectrum(lc=self.lc, norm="Leahy")
+        ps = Powerspectrum(self.lc, norm="Leahy")
         assert ps.rebin.__defaults__[2] == "mean"
 
     @pytest.mark.parametrize('df', [2, 3, 5, 1.5, 1, 85])
@@ -368,7 +368,7 @@ class TestPowerspectrum(object):
         """
         TODO: Not sure how to write tests for the rebin method!
         """
-        ps = Powerspectrum(lc=self.lc, norm="Leahy")
+        ps = Powerspectrum(self.lc, norm="Leahy")
         bin_ps = ps.rebin(df)
         assert np.isclose(bin_ps.freq[1] - bin_ps.freq[0], bin_ps.df,
                           atol=1e-4, rtol=1e-4)
@@ -376,17 +376,27 @@ class TestPowerspectrum(object):
                           (ps.freq[0] - ps.df * 0.5 + bin_ps.df * 0.5),
                           atol=1e-4, rtol=1e-4)
 
+    def test_lc_keyword_deprecation(self):
+        cs1 = Powerspectrum(self.lc, norm="Leahy")
+        with pytest.warns(DeprecationWarning) as record:
+            cs2 = Powerspectrum(lc=self.lc, norm="Leahy")
+        assert np.any(['lc keyword' in r.message.args[0]
+                       for r in record])
+        assert np.allclose(cs1.power, cs2.power)
+        assert np.allclose(cs1.freq, cs2.freq)
+
+
     def test_classical_significances_runs(self):
-        ps = Powerspectrum(lc=self.lc, norm="Leahy")
+        ps = Powerspectrum(self.lc, norm="Leahy")
         ps.classical_significances()
 
     def test_classical_significances_fails_in_rms(self):
-        ps = Powerspectrum(lc=self.lc, norm="frac")
+        ps = Powerspectrum(self.lc, norm="frac")
         with pytest.raises(ValueError):
             ps.classical_significances()
 
     def test_classical_significances_threshold(self):
-        ps = Powerspectrum(lc=self.lc, norm="leahy")
+        ps = Powerspectrum(self.lc, norm="leahy")
 
         # change the powers so that just one exceeds the threshold
         ps.power = np.zeros_like(ps.power) + 2.0
@@ -402,7 +412,7 @@ class TestPowerspectrum(object):
         assert pval[1, 0] == index
 
     def test_classical_significances_trial_correction(self):
-        ps = Powerspectrum(lc=self.lc, norm="leahy")
+        ps = Powerspectrum(self.lc, norm="leahy")
         # change the powers so that just one exceeds the threshold
         ps.power = np.zeros_like(ps.power) + 2.0
         index = 1
@@ -414,7 +424,7 @@ class TestPowerspectrum(object):
 
 
     def test_classical_significances_with_logbinned_psd(self):
-        ps = Powerspectrum(lc=self.lc, norm="leahy")
+        ps = Powerspectrum(self.lc, norm="leahy")
         ps_log = ps.rebin_log()
         pval = ps_log.classical_significances(threshold=1.1,
                                               trial_correction=False)
@@ -422,7 +432,7 @@ class TestPowerspectrum(object):
         assert len(pval[0]) == len(ps_log.power)
 
     def test_pvals_is_numpy_array(self):
-        ps = Powerspectrum(lc=self.lc, norm="leahy")
+        ps = Powerspectrum(self.lc, norm="leahy")
         # change the powers so that just one exceeds the threshold
         ps.power = np.zeros_like(ps.power) + 2.0
 
@@ -461,6 +471,15 @@ class TestAveragedPowerspectrum(object):
 
         ps = AveragedPowerspectrum(self.lc, segment_size)
         assert np.isclose(ps.segment_size, segment_size)
+
+    def test_lc_keyword_deprecation(self):
+        cs1 = AveragedPowerspectrum(self.lc, segment_size=self.lc.tseg)
+        with pytest.warns(DeprecationWarning) as record:
+            cs2 = AveragedPowerspectrum(lc=self.lc, segment_size=self.lc.tseg)
+        assert np.any(['lc keyword' in r.message.args[0]
+                       for r in record])
+        assert np.allclose(cs1.power, cs2.power)
+        assert np.allclose(cs1.freq, cs2.freq)
 
     def test_no_counts_warns(self):
         newlc = copy.deepcopy(self.lc)
@@ -568,7 +587,7 @@ class TestAveragedPowerspectrum(object):
         TODO: Not sure how to write tests for the rebin method!
         """
 
-        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+        aps = AveragedPowerspectrum(self.lc, segment_size=1,
                                     norm="Leahy")
         bin_aps = aps.rebin(df)
         assert np.isclose(bin_aps.freq[1]-bin_aps.freq[0], bin_aps.df,
@@ -583,7 +602,7 @@ class TestAveragedPowerspectrum(object):
         TODO: Not sure how to write tests for the rebin method!
         """
 
-        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+        aps = AveragedPowerspectrum(self.lc, segment_size=1,
                                     norm="Leahy")
         bin_aps = aps.rebin(f=f)
         assert np.isclose(bin_aps.freq[1]-bin_aps.freq[0], bin_aps.df,
@@ -595,13 +614,13 @@ class TestAveragedPowerspectrum(object):
     @pytest.mark.parametrize('df', [0.01, 0.1])
     def test_rebin_log(self, df):
         # For now, just verify that it doesn't crash
-        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+        aps = AveragedPowerspectrum(self.lc, segment_size=1,
                                     norm="Leahy")
         bin_aps = aps.rebin_log(df)
 
     def test_rebin_with_invalid_type_attribute(self):
         new_df = 2
-        aps = AveragedPowerspectrum(lc=self.lc, segment_size=1,
+        aps = AveragedPowerspectrum(self.lc, segment_size=1,
                                     norm='leahy')
         aps.type = 'invalid_type'
         with pytest.raises(AttributeError):

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -54,6 +54,12 @@ except ImportError:
         return range(x)
 
 try:
+    from tqdm import tqdm as show_progress
+except ImportError:
+    def show_progress(a):
+        return a
+
+try:
     from statsmodels.robust import mad as mad  # pylint: disable=unused-import
 except ImportError:
     def mad(data, c=0.6745, axis=None):


### PR DESCRIPTION
Event lists can now return a list (through a generator, so not all at once) of light curves from each of their GTIs.
This allows to use the existing machinery in `Average*spectrum` objects to iterate over these light curves and calculate the periodograms directly from events. 
This is *very* useful in very long observations of objects with high-frequency variability, where the number of bins in the complete light curve can easily reach hundreds of millions.
