### PR TITLE
fix aspect ratio of logo

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -5,8 +5,8 @@ Stingray: Next-Generation Spectral Timing Software
 Stingray is a new community-developed spectral-timing software package in Python for astrophysical data.
 
 .. image:: stingray_logo.png
-   :height: 100px
-   :scale: 50%
+   :width: 700
+   :scale: 40%
    :alt: Stingray logo, outline of a stingray on top of a graph of the power spectrum of an X-ray binary
    :align: center
 


### PR DESCRIPTION
Fixes #396 
The index page looks like this:
![Screenshot from 2019-05-21 00-52-00](https://user-images.githubusercontent.com/24570709/58046558-491b1080-7b63-11e9-9c3f-a181f5a00235.png)
