### PR TITLE
Fixed usage of deprecated iterations keyword in emcee

### DIFF
--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -930,7 +930,7 @@ class SamplingResults(object):
         self.samples = sampler.flatchain
 
         self.nwalkers = np.float(sampler.chain.shape[0])
-        self.niter = np.float(sampler.iterations)
+        self.niter = np.float(sampler.chain.shape[1])
 
         # store number of dimensions
         self.ndim = sampler.dim


### PR DESCRIPTION
In  a new version of `emcee` the keyword `iterations` no longer exists. I've replaced it with the length of the Markov chain, which should work. This should fix the Travis errors in #397, I think.