### PR TITLE
Update astropy-helpers to v3.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
         # Try without using statsmodels
         - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='emcee'
 
-        - env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='nbsphinx' SETUP_CMD='build_docs -w'
+        - env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='nbsphinx sphinx-astropy' SETUP_CMD='build_docs -w'
 
         # Try Astropy development version
         - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=development

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -48,10 +48,7 @@ import sys
 from distutils import log
 from distutils.debug import DEBUG
 
-try:
-    from ConfigParser import ConfigParser, RawConfigParser
-except ImportError:
-    from configparser import ConfigParser, RawConfigParser
+from configparser import ConfigParser, RawConfigParser
 
 import pkg_resources
 
@@ -119,24 +116,27 @@ if SETUP_CFG.has_option('options', 'python_requires'):
 
     # We want the Python version as a string, which we can get from the platform module
     import platform
-    python_version = platform.python_version()
-
-    if not req.specifier.contains(python_version):
+    # strip off trailing '+' incase this is a dev install of python
+    python_version = platform.python_version().strip('+')
+    # allow pre-releases to count as 'new enough'
+    if not req.specifier.contains(python_version, True):
         if parent_package is None:
-            print("ERROR: Python {} is required by this package".format(req.specifier))
+            message = "ERROR: Python {} is required by this package\n".format(req.specifier)
         else:
-            print("ERROR: Python {} is required by {}".format(req.specifier, parent_package))
+            message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
+        sys.stderr.write(message)
         sys.exit(1)
 
 if sys.version_info < __minimum_python_version__:
 
     if parent_package is None:
-        print("ERROR: Python {} or later is required by astropy-helpers".format(
-            __minimum_python_version__))
+        message = "ERROR: Python {} or later is required by astropy-helpers\n".format(
+            __minimum_python_version__)
     else:
-        print("ERROR: Python {} or later is required by astropy-helpers for {}".format(
-            __minimum_python_version__, parent_package))
+        message = "ERROR: Python {} or later is required by astropy-helpers for {}\n".format(
+            __minimum_python_version__, parent_package)
 
+    sys.stderr.write(message)
     sys.exit(1)
 
 _str_types = (str, bytes)
@@ -146,14 +146,14 @@ _str_types = (str, bytes)
 # issues with either missing or misbehaving pacakges (including making sure
 # setuptools itself is installed):
 
-# Check that setuptools 1.0 or later is present
+# Check that setuptools 30.3 or later is present
 from distutils.version import LooseVersion
 
 try:
     import setuptools
-    assert LooseVersion(setuptools.__version__) >= LooseVersion('1.0')
+    assert LooseVersion(setuptools.__version__) >= LooseVersion('30.3')
 except (ImportError, AssertionError):
-    print("ERROR: setuptools 1.0 or later is required by astropy-helpers")
+    sys.stderr.write("ERROR: setuptools 30.3 or later is required by astropy-helpers\n")
     sys.exit(1)
 
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after

--- a/stingray/conftest.py
+++ b/stingray/conftest.py
@@ -2,7 +2,18 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+from astropy.tests.helper import enable_deprecations_as_exceptions
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v3.2.1. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed. 

A full list of changes can be found in the [changelog](https://github.com/astropy/astropy-helpers/blob/v3.2.1/CHANGES.rst). 

We've also noticed that you likely used the astropy package template in the past for your package and that your conftest.py file is now out of date and imports pytest plugins from astropy:

```python
from astropy.tests.pytest_plugins import *
```

This astropy sub-package has been removed, so your tests will likely be failing now that astropy v3.2 has been released. This PR therefore fixes this import by checking the astropy version and adjusting the import as needed.

 
We also wanted to let you know that we have made new releases of the astropy package-template. You can find the latest [cookiecutter template here](https://github.com/astropy/package-template) or if you prefer you can find a [rendered version of the template here](https://github.com/astropy/package-template/tree/master). 

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!* 

Similarly to the core package, the v3.0+ releases of astropy-helpers require Python 3.5+. We will open automated update PRs with astropy-helpers v3.2.x only for packages that specifically opt in for it when they start supporting Python 3.5+ only. Please let @bsipocz or @astrofrog know or add your package to the list in https://github.com/astropy/astropy-procedures/blob/master/update-packages/helpers_3.py