### PR TITLE
Fixes #1. Have tests inspect an exception's e.value instead of just t…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
         # Try without using statsmodels
         - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='emcee'
 
-        - env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='nbsphinx' SETUP_CMD='build_docs -w'
+        - env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='nbsphinx sphinx-astropy' SETUP_CMD='build_docs -w'
 
         # Try Astropy development version
         - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=development

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@
 Stingray
 ========
 
-+------------------+-------------------------+---------------+--------+---------+---------------------------+---------------------+
-| Master           | |Build Status Master|   | |Readthedocs| | |joss| | |Slack| | |Coverage Status Master|  | |Stage Release v0.1.3| |
-+------------------+-------------------------+---------------+--------+---------+---------------------------+---------------------+
++------------------+-------------------------+---------------+---------+--------+---------------------------+------------------+
+| Master           | |Build Status Master|   | |Readthedocs| | |Slack| | |joss| | |Coverage Status Master|  | |GitHub release| |
++------------------+-------------------------+---------------+---------+--------+---------------------------+------------------+
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 X-Ray Spectral Timing Made Easy
@@ -148,7 +148,7 @@ this project, please `get in touch via the issues
     :target: http://slack-invite.timelabtechnologies.com
 .. |Coverage Status Master| image:: https://coveralls.io/repos/github/StingraySoftware/stingray/badge.svg?branch=master
     :target: https://coveralls.io/github/StingraySoftware/stingray?branch=master
-.. |Stage Release v0.1.3| image:: .. image:: https://img.shields.io/github/release/StingraySoftware/stingray.svg   :alt: GitHub release
+.. |GitHub release| image:: https://img.shields.io/github/release/StingraySoftware/stingray.svg
     :target: https://coveralls.io/github/StingraySoftware/stingray?branch=master
 .. |joss| image:: http://joss.theoj.org/papers/10.21105/joss.01393/status.svg
    :target: https://doi.org/10.21105/joss.01393

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -48,10 +48,7 @@ import sys
 from distutils import log
 from distutils.debug import DEBUG
 
-try:
-    from ConfigParser import ConfigParser, RawConfigParser
-except ImportError:
-    from configparser import ConfigParser, RawConfigParser
+from configparser import ConfigParser, RawConfigParser
 
 import pkg_resources
 
@@ -119,24 +116,27 @@ if SETUP_CFG.has_option('options', 'python_requires'):
 
     # We want the Python version as a string, which we can get from the platform module
     import platform
-    python_version = platform.python_version()
-
-    if not req.specifier.contains(python_version):
+    # strip off trailing '+' incase this is a dev install of python
+    python_version = platform.python_version().strip('+')
+    # allow pre-releases to count as 'new enough'
+    if not req.specifier.contains(python_version, True):
         if parent_package is None:
-            print("ERROR: Python {} is required by this package".format(req.specifier))
+            message = "ERROR: Python {} is required by this package\n".format(req.specifier)
         else:
-            print("ERROR: Python {} is required by {}".format(req.specifier, parent_package))
+            message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
+        sys.stderr.write(message)
         sys.exit(1)
 
 if sys.version_info < __minimum_python_version__:
 
     if parent_package is None:
-        print("ERROR: Python {} or later is required by astropy-helpers".format(
-            __minimum_python_version__))
+        message = "ERROR: Python {} or later is required by astropy-helpers\n".format(
+            __minimum_python_version__)
     else:
-        print("ERROR: Python {} or later is required by astropy-helpers for {}".format(
-            __minimum_python_version__, parent_package))
+        message = "ERROR: Python {} or later is required by astropy-helpers for {}\n".format(
+            __minimum_python_version__, parent_package)
 
+    sys.stderr.write(message)
     sys.exit(1)
 
 _str_types = (str, bytes)
@@ -146,14 +146,14 @@ _str_types = (str, bytes)
 # issues with either missing or misbehaving pacakges (including making sure
 # setuptools itself is installed):
 
-# Check that setuptools 1.0 or later is present
+# Check that setuptools 30.3 or later is present
 from distutils.version import LooseVersion
 
 try:
     import setuptools
-    assert LooseVersion(setuptools.__version__) >= LooseVersion('1.0')
+    assert LooseVersion(setuptools.__version__) >= LooseVersion('30.3')
 except (ImportError, AssertionError):
-    print("ERROR: setuptools 1.0 or later is required by astropy-helpers")
+    sys.stderr.write("ERROR: setuptools 30.3 or later is required by astropy-helpers\n")
     sys.exit(1)
 
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after

--- a/stingray/conftest.py
+++ b/stingray/conftest.py
@@ -2,7 +2,18 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+from astropy.tests.helper import enable_deprecations_as_exceptions
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions

--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -44,7 +44,7 @@ class TestAll(object):
             phaseogr, phases, times, additional_info = \
                 phaseogram(self.event_times, self.pulse_frequency,
                            weights=[0, 2])
-        assert 'must match' in str(excinfo)
+        assert 'must match' in str(excinfo.value)
 
     def test_phaseogram_weights(self):
         phaseogr, phases, times, additional_info = \
@@ -169,7 +169,7 @@ class TestAll(object):
         with pytest.raises(ValueError) as excinfo:
             freq, stat = epoch_folding_search(self.event_times, frequencies,
                                               nbin=23, expocorr=True)
-        assert 'To calculate exposure correction' in str(excinfo)
+        assert 'To calculate exposure correction' in str(excinfo.value)
 
     def test_epoch_folding_search_expocorr(self):
         """Test pulse phase calculation, frequency only."""
@@ -288,7 +288,7 @@ class TestAll(object):
         with pytest.raises(ValueError) as excinfo:
             freq, stat = z_n_search(self.event_times, frequencies, nharm=1,
                                     nbin=35, expocorr=True)
-        assert 'To calculate exposure correction' in str(excinfo)
+        assert 'To calculate exposure correction' in str(excinfo.value)
 
     def test_z_n_search_weights(self):
         """Test pulse phase calculation, frequency only."""

--- a/stingray/tests/test_gti.py
+++ b/stingray/tests/test_gti.py
@@ -64,14 +64,14 @@ class TestGTI(object):
         gti = np.array([[0, 2.1], [3.9, 5]])
         with pytest.raises(ValueError) as excinfo:
             create_gti_mask(arr, gti, return_new_gtis=True)
-        assert 'empty time array' in str(excinfo)
+        assert 'empty time array' in str(excinfo.value)
 
     def test_gti_mask_fails_empty_gti(self):
         arr = np.array([0, 1, 2, 3, 4, 5, 6])
         gti = np.array([])
         with pytest.raises(ValueError) as excinfo:
             create_gti_mask(arr, gti, return_new_gtis=True)
-        assert 'empty GTI array' in str(excinfo)
+        assert 'empty GTI array' in str(excinfo.value)
 
     def test_gti_mask_complete(self):
         arr = np.array([0, 1, 2, 3, 4, 5, 6])
@@ -241,5 +241,5 @@ class TestGTI(object):
     def test_check_gti_fails_empty(self):
         with pytest.raises(ValueError) as excinfo:
             check_gtis([])
-        assert 'Empty' in str(excinfo)
+        assert 'Empty' in str(excinfo.value)
 


### PR DESCRIPTION
…he exception. pytest 5.0.0 no longer displays the custom text with str(e)