### PR TITLE
Have tests inspect an exception's e.value instead of just e as pytest 5.0.0 changed its behavior

### DIFF
--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -44,7 +44,7 @@ class TestAll(object):
             phaseogr, phases, times, additional_info = \
                 phaseogram(self.event_times, self.pulse_frequency,
                            weights=[0, 2])
-        assert 'must match' in str(excinfo)
+        assert 'must match' in str(excinfo.value)
 
     def test_phaseogram_weights(self):
         phaseogr, phases, times, additional_info = \
@@ -169,7 +169,7 @@ class TestAll(object):
         with pytest.raises(ValueError) as excinfo:
             freq, stat = epoch_folding_search(self.event_times, frequencies,
                                               nbin=23, expocorr=True)
-        assert 'To calculate exposure correction' in str(excinfo)
+        assert 'To calculate exposure correction' in str(excinfo.value)
 
     def test_epoch_folding_search_expocorr(self):
         """Test pulse phase calculation, frequency only."""
@@ -288,7 +288,7 @@ class TestAll(object):
         with pytest.raises(ValueError) as excinfo:
             freq, stat = z_n_search(self.event_times, frequencies, nharm=1,
                                     nbin=35, expocorr=True)
-        assert 'To calculate exposure correction' in str(excinfo)
+        assert 'To calculate exposure correction' in str(excinfo.value)
 
     def test_z_n_search_weights(self):
         """Test pulse phase calculation, frequency only."""

--- a/stingray/tests/test_gti.py
+++ b/stingray/tests/test_gti.py
@@ -64,14 +64,14 @@ class TestGTI(object):
         gti = np.array([[0, 2.1], [3.9, 5]])
         with pytest.raises(ValueError) as excinfo:
             create_gti_mask(arr, gti, return_new_gtis=True)
-        assert 'empty time array' in str(excinfo)
+        assert 'empty time array' in str(excinfo.value)
 
     def test_gti_mask_fails_empty_gti(self):
         arr = np.array([0, 1, 2, 3, 4, 5, 6])
         gti = np.array([])
         with pytest.raises(ValueError) as excinfo:
             create_gti_mask(arr, gti, return_new_gtis=True)
-        assert 'empty GTI array' in str(excinfo)
+        assert 'empty GTI array' in str(excinfo.value)
 
     def test_gti_mask_complete(self):
         arr = np.array([0, 1, 2, 3, 4, 5, 6])
@@ -241,5 +241,5 @@ class TestGTI(object):
     def test_check_gti_fails_empty(self):
         with pytest.raises(ValueError) as excinfo:
             check_gtis([])
-        assert 'Empty' in str(excinfo)
+        assert 'Empty' in str(excinfo.value)
 


### PR DESCRIPTION
This fix addresses https://github.com/twongCMU/stingray/issues/1 in which the some unit tests fail under pytest 5.0.0. This version changed an exception to only show the exception type and not the custom text; that info is in e.value now. 