### PR TITLE
adding crossspectrum parameters and functionality

### DIFF
--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -1,8 +1,9 @@
 from __future__ import division
 import numpy as np
 from scipy import signal
+from scipy.fftpack import ifft
 
-from stingray import lightcurve
+from stingray import lightcurve, crossspectrum
 from stingray.exceptions import StingrayError
 import stingray.utils as utils
 
@@ -10,7 +11,7 @@ __all__ = ['CrossCorrelation', 'AutoCorrelation']
 
 
 class CrossCorrelation(object):
-    """Make a cross-correlation from a light curves.
+    """Make a cross-correlation from light curves or a cross spectrum.
 
     You can also make an empty :class:`Crosscorrelation` object to populate
     with your own cross-correlation data.
@@ -22,6 +23,9 @@ class CrossCorrelation(object):
 
     lc2: :class:`stingray.Lightcurve` object, optional, default ``None``
         The light curve data for the correlation calculations.
+
+    cross: :class: `stingray.Crossspectrum` object, default ``None``
+        The cross spectrum data for the correlation calculations.
 
     mode: {``full``, ``valid``, ``same``}, optional, default ``same``
         A string indicating the size of the correlation output.
@@ -35,6 +39,9 @@ class CrossCorrelation(object):
 
     lc2: :class:`stingray.Lightcurve`
         The light curve data for the correlation calculations.
+
+    cross: :class: `stingray.Crossspectrum`
+        The cross spectrum data for the correlation calculations.
 
     corr: numpy.ndarray
          An array of correlation data calculated from two light curves
@@ -62,7 +69,7 @@ class CrossCorrelation(object):
 
     """
 
-    def __init__(self, lc1=None, lc2=None, mode='same'):
+    def __init__(self, lc1=None, lc2=None, cross=None, mode='same'):
 
         self.auto = False
         if isinstance(mode, str) is False:
@@ -74,22 +81,65 @@ class CrossCorrelation(object):
         self.mode = mode.lower()
         self.lc1 = None
         self.lc2 = None
+        self.cross = None
 
         # Populate all attributes by ``None` if user passes no lightcurve data
         if lc1 is None or lc2 is None:
             if lc1 is not None or lc2 is not None:
                 raise TypeError("You can't do a cross correlation with just one "
                                 "light curve!")
+
             else:
-                # both lc1 and lc2 are ``Non.
-                self.corr = None
-                self.time_shift = None
-                self.time_lags = None
-                self.dt = None
-                self.n = None
-                return
+                if cross is None:
+                    # all object input params are ``None``
+                    self.corr = None
+                    self.time_shift = None
+                    self.time_lags = None
+                    self.dt = None
+                    self.n = None
+                else:
+                    self._make_cross_corr(cross)
+                    return
         else:
             self._make_corr(lc1, lc2)
+
+    def _make_cross_corr(self, cross):
+
+        """
+        Do some checks on the cross spectrum supplied to the method,
+        and then calculate the time shifts, time lags and cross correlation.
+
+        Parameters
+        ----------
+        cross: :class:`stingray.Crossspectrum` object
+            The crossspectrum, averaged or not.
+
+        """
+
+        if not isinstance(cross, crossspectrum.Crossspectrum):
+            if not isinstance(cross, crossspectrum.AveragedCrossspectrum):
+                raise TypeError("cross must be a crossspectrum.Crossspectrum \
+                        or crossspectrum.AveragedCrossspectrum object")
+
+        if self.cross is None:
+            self.cross = cross
+            self.dt = 1/(cross.df * cross.n)
+
+        # So ifft produces a curve that is basically mirrored around zero,
+        # but in the opposite way that we would like
+
+        prelim_corr = ifft(cross.power).real  # keep only the real
+        self.n = len(prelim_corr)
+
+        # Splitting and correcting the mirrored correlation data from the ifft
+        temp_corr = np.zeros(self.n)
+        half = int(self.n/2)
+        temp_corr[half:] = prelim_corr[0:half+1]
+        temp_corr[:half+1] = prelim_corr[half:]
+        self.corr = temp_corr
+
+        self.time_shift, self.time_lags, self.n = self.cal_timeshift(dt=self.dt)
+
 
     def _make_corr(self, lc1, lc2):
 
@@ -159,13 +209,22 @@ class CrossCorrelation(object):
 
         if self.corr is None:
             if self.lc1 is None or self.lc2 is None:
-                raise StingrayError('lc1 and lc2 should be provided to calculate correlation and time_shift')
+                if self.cross is None:
+                    raise StingrayError('Please provide a stingray object or \
+                            data to calculate correlation and timeshift')
+                else:
+                    raise StingrayError('lc1 and lc2 should be provided to \
+                            calculate correlation and time_shift')
             else:
-                # This will cover very rare case of assigning self.lc1 and self.lc2 and self.corr = ``None``.
-                # In this case, correlation is calculated using self.lc1 and self.lc2 and using that correlation data,
+                # This will cover very rare case of assigning self.lc1 and lc2
+                # or self.cross and also self.corr = ``None``.
+                # In this case, correlation is calculated using self.lc1
+                # and self.lc2 and using that correlation data,
                 # time_shift is calculated.
-                self._make_corr(self.lc1, self.lc2)
-                return self.time_shift, self.time_lags, self.n
+                if self.cross is not None:
+                    self._make_cross_corr(self.cross)
+                else:
+                    self._make_corr(self.lc1, self.lc2)
 
         self.n = len(self.corr)
         dur = int(self.n / 2)

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import scipy
 import pytest
 import warnings
 import os
@@ -74,6 +74,23 @@ class TestCrossCorrelation(object):
         assert np.isclose(cr.time_shift, 2.0)
         assert cr.mode == 'same'
         assert cr.auto is False
+
+    def test_crossparam_input(self):
+        # need to create new results to check against
+        spec = Crossspectrum(self.lc1, self.lc2)
+        ifft = abs(scipy.fftpack.ifft(spec.power).real)
+        time = scipy.fftpack.fftfreq(len(ifft), spec.df)
+        time, resultifft = (list(t) for t in zip(*sorted(zip(time, ifft))))
+        cr2 = CrossCorrelation(cross=spec)
+        
+        assert np.allclose(cr2.cross.power, spec.power)
+        assert np.allclose(cr2.cross.freq, spec.freq)
+        assert np.allclose(cr2.corr, resultifft)
+        assert np.isclose(cr2.dt, self.lc1.dt)
+        assert cr2.n == 5
+        assert np.allclose(cr2.time_lags, lags_result)
+        assert cr2.mode == 'same'
+        assert cr2.auto is False
 
     def test_cross_correlation_with_unequal_lc(self):
         result = np.array([-0.66666667, -0.33333333, -1., 0.66666667, 3.13333333])


### PR DESCRIPTION
Added the ability for CrossCorrelation to accept both Crossspectrum and AveragedCrossspectrum objects. This was done by applying an inverse fourier transform to the Crossspectrum in a new function and updating some if/else statements. There is some array manipulation in the _make_corr_cross function which may need some changing for clarity/otherwise. Looking forward to your comments!