### PR TITLE
Crossspec fullspec parameter

### DIFF
--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -70,7 +70,7 @@ class CrossCorrelation(object):
     """
 
     def __init__(self, lc1=None, lc2=None, cross=None, mode='same'):
-     
+
         self.auto = False
         if isinstance(mode, str) is False:
             raise TypeError("mode must be a string")
@@ -91,8 +91,7 @@ class CrossCorrelation(object):
 
             else:
                 if cross is None:
-                    # all object input params are ``None`` .
-                  
+                    # all object input params are ``None`` 
                     self.corr = None
                     self.time_shift = None
                     self.time_lags = None
@@ -106,41 +105,40 @@ class CrossCorrelation(object):
 
     def _make_cross_corr(self, cross):
 
-         """
-         Do some checks on the cross spectrum supplied to the method, and then calculate the time
-         shifts, time lags and cross correlation.
+        """
+        Do some checks on the cross spectrum supplied to the method,
+        and then calculate the time shifts, time lags and cross correlation.
 
-         Parameters
-         ----------
-         cross: :class:`stingray.Crossspectrum` object
-             The crossspectrum, averaged or not.
+        Parameters
+        ----------
+        cross: :class:`stingray.Crossspectrum` object
+            The crossspectrum, averaged or not.
 
-         """
-         print(type(cross))   
-         if not isinstance(cross, crossspectrum.Crossspectrum):
-             if not isinstance(cross, crossspectrum.AveragedCrossspectrum):
-                 raise TypeError("cross must be a crossspectrum.Crossspectrum or crossspectrum.AveragedCrossspectrum object")
- 
-         if self.cross is None:
-             self.cross = cross
-             self.dt = 1/(cross.df * cross.n)
-         
-         #So ifft produces a curve that is basically mirrored around zero, but in the opposite way that we would like
-         #need to adjust for that
+        """
 
-         prelim_corr = ifft(cross.power).real #keep only the real, pads with zeros
-         self.n = len(prelim_corr)
-         
-         # Splitting and correcting the mirrored correlation data from the ifft
-         temp_corr = np.zeros(self.n)
-         half = int(self.n/2)
-         temp_corr[half:] = prelim_corr[0:half+1]
-         temp_corr[:half+1] = prelim_corr[half:]
-         self.corr = temp_corr
-         
-         self.time_shift, self.time_lags, self.n = self.cal_timeshift(dt=self.dt)
+        if not isinstance(cross, crossspectrum.Crossspectrum):
+            if not isinstance(cross, crossspectrum.AveragedCrossspectrum):
+                raise TypeError("cross must be a crossspectrum.Crossspectrum or crossspectrum.AveragedCrossspectrum object")
 
-    
+        if self.cross is None:
+            self.cross = cross
+            self.dt = 1/(cross.df * cross.n)
+
+        # So ifft produces a curve that is basically mirrored around zero,
+        # but in the opposite way that we would like
+
+        prelim_corr = ifft(cross.power).real #keep only the real, pads with zeros
+        self.n = len(prelim_corr)
+
+        # Splitting and correcting the mirrored correlation data from the ifft
+        temp_corr = np.zeros(self.n)
+        half = int(self.n/2)
+        temp_corr[half:] = prelim_corr[0:half+1]
+        temp_corr[:half+1] = prelim_corr[half:]
+        self.corr = temp_corr
+
+        self.time_shift, self.time_lags, self.n = self.cal_timeshift(dt=self.dt)
+
 
     def _make_corr(self, lc1, lc2):
 
@@ -157,12 +155,12 @@ class CrossCorrelation(object):
             The second light curve data.
 
         """
-        
+
         if not isinstance(lc1, lightcurve.Lightcurve):
             raise TypeError("lc1 must be a lightcurve.Lightcurve object")
         if not isinstance(lc2, lightcurve.Lightcurve):
             raise TypeError("lc2 must be a lightcurve.Lightcurve object")
-        
+
         if not np.isclose(lc1.dt, lc2.dt):
             raise StingrayError("Light curves do not have "
                                 "same time binning dt.")
@@ -211,18 +209,22 @@ class CrossCorrelation(object):
         if self.corr is None:
             if self.lc1 is None or self.lc2 is None:
                 if self.cross is None:
-                    raise StingrayError('Please provide a stingray object or your own data to calculate correlation and timeshift')
+                    raise StingrayError('Please provide a stingray object or \
+                            data to calculate correlation and timeshift')
                 else:
-                    raise StingrayError('lc1 and lc2 should be provided to calculate correlation and time_shift')
+                    raise StingrayError('lc1 and lc2 should be provided to \
+                            calculate correlation and time_shift')
             else:
-                # This will cover very rare case of assigning self.lc1 and self.lc2 or self.cross and also self.corr = ``None``.
-                # In this case, correlation is calculated using self.lc1 and self.lc2 and using that correlation data,
+                # This will cover very rare case of assigning self.lc1 and self.lc2 
+                # or self.cross and also self.corr = ``None``.
+                # In this case, correlation is calculated using self.lc1 
+                # and self.lc2 and using that correlation data,
                 # time_shift is calculated.
                 if self.cross is not None:
                     self._make_cross_corr(self.cross)
                 else:
                     self._make_corr(self.lc1, self.lc2)
-                
+
         self.n = len(self.corr)
         dur = int(self.n / 2)
         # Correlation against all possible lags, positive as well as negative lags are stored

--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -211,13 +211,9 @@ class CrossCorrelation(object):
             self.dt = dt
 
         if self.corr is None:
-            if self.lc1 is None or self.lc2 is None:
-                if self.cross is None:
-                    raise StingrayError('Please provide a stingray object or \
-                            data to calculate correlation and timeshift')
-                else:
-                    raise StingrayError('lc1 and lc2 should be provided to \
-                            calculate correlation and time_shift')
+            if (self.lc1 is None or self.lc2 is None) or (self.cross is None):
+                raise StingrayError('Please provide either two lightcurve objects or \
+                 a [average]crossspectrum object to calculate correlation and time_shift')
             else:
                 # This will cover very rare case of assigning self.lc1 and lc2
                 # or self.cross and also self.corr = ``None``.

--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -3,7 +3,8 @@ import numpy as np
 from scipy import signal
 from scipy.fftpack import ifft
 
-from stingray import lightcurve, crossspectrum
+from stingray.lightcurve import Lightcurve
+from stingray.crossspectrum import Crossspectrum, AveragedCrossspectrum
 from stingray.exceptions import StingrayError
 import stingray.utils as utils
 
@@ -116,9 +117,9 @@ class CrossCorrelation(object):
 
         """
 
-        if not isinstance(cross, crossspectrum.Crossspectrum):
-            if not isinstance(cross, crossspectrum.AveragedCrossspectrum):
-                raise TypeError("cross must be a crossspectrum.Crossspectrum \
+        if not isinstance(cross, Crossspectrum):
+            if not isinstance(cross, AveragedCrossspectrum):
+                raise TypeError("cross must be a crosspectrum.Crossspectrum \
                         or crossspectrum.AveragedCrossspectrum object")
 
         if self.cross is None:
@@ -136,9 +137,7 @@ class CrossCorrelation(object):
         # correcting for this by putting them in order
 
         times = np.fft.fftfreq(self.n, cross.df)
-        time, corr = (list(t) for t in zip(*sorted(zip(times, prelim_corr))))
-        time = np.array(time) #this could be used in place of time_lags below
-        corr = np.array(corr)
+        time, corr = np.array(sorted(zip(times, prelim_corr))).T
         self.corr = corr
         
         self.time_shift, self.time_lags, self.n = self.cal_timeshift(dt=self.dt)
@@ -160,9 +159,9 @@ class CrossCorrelation(object):
 
         """
 
-        if not isinstance(lc1, lightcurve.Lightcurve):
+        if not isinstance(lc1, Lightcurve):
             raise TypeError("lc1 must be a lightcurve.Lightcurve object")
-        if not isinstance(lc2, lightcurve.Lightcurve):
+        if not isinstance(lc2, Lightcurve):
             raise TypeError("lc2 must be a lightcurve.Lightcurve object")
 
         if not np.isclose(lc1.dt, lc2.dt):

--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -91,7 +91,7 @@ class CrossCorrelation(object):
 
             else:
                 if cross is None:
-                    # all object input params are ``None`` 
+                    # all object input params are ``None``
                     self.corr = None
                     self.time_shift = None
                     self.time_lags = None
@@ -118,7 +118,8 @@ class CrossCorrelation(object):
 
         if not isinstance(cross, crossspectrum.Crossspectrum):
             if not isinstance(cross, crossspectrum.AveragedCrossspectrum):
-                raise TypeError("cross must be a crossspectrum.Crossspectrum or crossspectrum.AveragedCrossspectrum object")
+                raise TypeError("cross must be a crossspectrum.Crossspectrum \
+                        or crossspectrum.AveragedCrossspectrum object")
 
         if self.cross is None:
             self.cross = cross
@@ -127,7 +128,7 @@ class CrossCorrelation(object):
         # So ifft produces a curve that is basically mirrored around zero,
         # but in the opposite way that we would like
 
-        prelim_corr = ifft(cross.power).real #keep only the real, pads with zeros
+        prelim_corr = ifft(cross.power).real  # keep only the real
         self.n = len(prelim_corr)
 
         # Splitting and correcting the mirrored correlation data from the ifft
@@ -215,9 +216,9 @@ class CrossCorrelation(object):
                     raise StingrayError('lc1 and lc2 should be provided to \
                             calculate correlation and time_shift')
             else:
-                # This will cover very rare case of assigning self.lc1 and self.lc2 
+                # This will cover very rare case of assigning self.lc1 and lc2
                 # or self.cross and also self.corr = ``None``.
-                # In this case, correlation is calculated using self.lc1 
+                # In this case, correlation is calculated using self.lc1
                 # and self.lc2 and using that correlation data,
                 # time_shift is calculated.
                 if self.cross is not None:

--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -1,8 +1,9 @@
 from __future__ import division
 import numpy as np
 from scipy import signal
+from scipy.fftpack import ifft
 
-from stingray import lightcurve
+from stingray import lightcurve, crossspectrum
 from stingray.exceptions import StingrayError
 import stingray.utils as utils
 
@@ -10,7 +11,7 @@ __all__ = ['CrossCorrelation', 'AutoCorrelation']
 
 
 class CrossCorrelation(object):
-    """Make a cross-correlation from a light curves.
+    """Make a cross-correlation from light curves or a cross spectrum.
 
     You can also make an empty :class:`Crosscorrelation` object to populate
     with your own cross-correlation data.
@@ -22,6 +23,9 @@ class CrossCorrelation(object):
 
     lc2: :class:`stingray.Lightcurve` object, optional, default ``None``
         The light curve data for the correlation calculations.
+
+    cross: :class: `stingray.Crossspectrum` object, default ``None``
+        The cross spectrum data for the correlation calculations.
 
     mode: {``full``, ``valid``, ``same``}, optional, default ``same``
         A string indicating the size of the correlation output.
@@ -35,6 +39,9 @@ class CrossCorrelation(object):
 
     lc2: :class:`stingray.Lightcurve`
         The light curve data for the correlation calculations.
+
+    cross: :class: `stingray.Crossspectrum`
+        The cross spectrum data for the correlation calculations.
 
     corr: numpy.ndarray
          An array of correlation data calculated from two light curves
@@ -62,8 +69,8 @@ class CrossCorrelation(object):
 
     """
 
-    def __init__(self, lc1=None, lc2=None, mode='same'):
-
+    def __init__(self, lc1=None, lc2=None, cross=None, mode='same'):
+     
         self.auto = False
         if isinstance(mode, str) is False:
             raise TypeError("mode must be a string")
@@ -74,22 +81,66 @@ class CrossCorrelation(object):
         self.mode = mode.lower()
         self.lc1 = None
         self.lc2 = None
+        self.cross = None
 
         # Populate all attributes by ``None` if user passes no lightcurve data
         if lc1 is None or lc2 is None:
             if lc1 is not None or lc2 is not None:
                 raise TypeError("You can't do a cross correlation with just one "
                                 "light curve!")
+
             else:
-                # both lc1 and lc2 are ``Non.
-                self.corr = None
-                self.time_shift = None
-                self.time_lags = None
-                self.dt = None
-                self.n = None
-                return
+                if cross is None:
+                    # all object input params are ``None`` .
+                  
+                    self.corr = None
+                    self.time_shift = None
+                    self.time_lags = None
+                    self.dt = None
+                    self.n = None
+                else:
+                    self._make_cross_corr(cross)
+                    return
         else:
             self._make_corr(lc1, lc2)
+
+    def _make_cross_corr(self, cross):
+
+         """
+         Do some checks on the cross spectrum supplied to the method, and then calculate the time
+         shifts, time lags and cross correlation.
+
+         Parameters
+         ----------
+         cross: :class:`stingray.Crossspectrum` object
+             The crossspectrum, averaged or not.
+
+         """
+         print(type(cross))   
+         if not isinstance(cross, crossspectrum.Crossspectrum):
+             if not isinstance(cross, crossspectrum.AveragedCrossspectrum):
+                 raise TypeError("cross must be a crossspectrum.Crossspectrum or crossspectrum.AveragedCrossspectrum object")
+ 
+         if self.cross is None:
+             self.cross = cross
+             self.dt = 1/(cross.df * cross.n)
+         
+         #So ifft produces a curve that is basically mirrored around zero, but in the opposite way that we would like
+         #need to adjust for that
+
+         prelim_corr = ifft(cross.power).real #keep only the real, pads with zeros
+         self.n = len(prelim_corr)
+         
+         # Splitting and correcting the mirrored correlation data from the ifft
+         temp_corr = np.zeros(self.n)
+         half = int(self.n/2)
+         temp_corr[half:] = prelim_corr[0:half+1]
+         temp_corr[:half+1] = prelim_corr[half:]
+         self.corr = temp_corr
+         
+         self.time_shift, self.time_lags, self.n = self.cal_timeshift(dt=self.dt)
+
+    
 
     def _make_corr(self, lc1, lc2):
 
@@ -106,12 +157,12 @@ class CrossCorrelation(object):
             The second light curve data.
 
         """
-
+        
         if not isinstance(lc1, lightcurve.Lightcurve):
             raise TypeError("lc1 must be a lightcurve.Lightcurve object")
         if not isinstance(lc2, lightcurve.Lightcurve):
             raise TypeError("lc2 must be a lightcurve.Lightcurve object")
-
+        
         if not np.isclose(lc1.dt, lc2.dt):
             raise StingrayError("Light curves do not have "
                                 "same time binning dt.")
@@ -159,14 +210,19 @@ class CrossCorrelation(object):
 
         if self.corr is None:
             if self.lc1 is None or self.lc2 is None:
-                raise StingrayError('lc1 and lc2 should be provided to calculate correlation and time_shift')
+                if self.cross is None:
+                    raise StingrayError('Please provide a stingray object or your own data to calculate correlation and timeshift')
+                else:
+                    raise StingrayError('lc1 and lc2 should be provided to calculate correlation and time_shift')
             else:
-                # This will cover very rare case of assigning self.lc1 and self.lc2 and self.corr = ``None``.
+                # This will cover very rare case of assigning self.lc1 and self.lc2 or self.cross and also self.corr = ``None``.
                 # In this case, correlation is calculated using self.lc1 and self.lc2 and using that correlation data,
                 # time_shift is calculated.
-                self._make_corr(self.lc1, self.lc2)
-                return self.time_shift, self.time_lags, self.n
-
+                if self.cross is not None:
+                    self._make_cross_corr(self.cross)
+                else:
+                    self._make_corr(self.lc1, self.lc2)
+                
         self.n = len(self.corr)
         dur = int(self.n / 2)
         # Correlation against all possible lags, positive as well as negative lags are stored

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -89,7 +89,8 @@ class Crossspectrum(object):
     Make a cross spectrum from a (binned) light curve.
     You can also make an empty :class:`Crossspectrum` object to populate with your
     own Fourier-transformed data (this can sometimes be useful when making
-    binned power spectra).
+    binned power spectra). Stingray uses the scipy.fftpack standards for the sign 
+    of the Nyquist frequency.
 
     Parameters
     ----------
@@ -850,7 +851,8 @@ class AveragedCrossspectrum(Crossspectrum):
         Auxiliary method computing the normalized cross spectrum from two light curves.
         This includes checking for the presence of and applying Good Time Intervals, computing the
         unnormalized Fourier cross-amplitude, and then renormalizing using the required normalization.
-        Also computes an uncertainty estimate on the cross spectral powers.
+        Also computes an uncertainty estimate on the cross spectral powers. Stingray uses the 
+        scipy.fftpack standards for the sign of the Nyquist frequency.
 
         Parameters
         ----------

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -104,6 +104,9 @@ class Crossspectrum(object):
 
     power_type: string, optional, default ``real`` Parameter to choose among
     complete, real part and magnitude of the cross spectrum.
+    
+    fullspec: boolean, optional, default ``False``
+    Parameter to either only keep the positive frequencies, or all of them.
 
     Other Parameters
     ----------------
@@ -144,7 +147,7 @@ class Crossspectrum(object):
         The total number of photons in light curve 2
     """
     def __init__(self, lc1=None, lc2=None, norm='none', gti=None,
-                 power_type="real"):
+                 power_type="real", fullspec=False):
         if isinstance(norm, str) is False:
             raise TypeError("norm must be a string")
 
@@ -173,8 +176,9 @@ class Crossspectrum(object):
         self.lc1 = lc1
         self.lc2 = lc2
         self.power_type = power_type
+        self.fullspec = fullspec
 
-        self._make_crossspectrum(lc1, lc2)
+        self._make_crossspectrum(lc1, lc2, fullspec)
 
         # These are needed to calculate coherence
         self._make_auxil_pds(lc1, lc2)
@@ -193,7 +197,7 @@ class Crossspectrum(object):
             self.pds1 = Crossspectrum(lc1, lc1, norm='none')
             self.pds2 = Crossspectrum(lc2, lc2, norm='none')
 
-    def _make_crossspectrum(self, lc1, lc2):
+    def _make_crossspectrum(self, lc1, lc2, fullspec=False):
         """
         Auxiliary method computing the normalized cross spectrum from two
         light curves. This includes checking for the presence of and
@@ -207,7 +211,11 @@ class Crossspectrum(object):
         lc1, lc2 : :class:`stingray.Lightcurve` objects
             Two light curves used for computing the cross spectrum.
 
+        fullspec: boolean, default ``False``
+            Full frequency array (True) or just positive (False)
+
         """
+
         # make sure the inputs work!
         if not isinstance(lc1, Lightcurve):
             raise TypeError("lc1 must be a lightcurve.Lightcurve object")
@@ -264,7 +272,7 @@ class Crossspectrum(object):
         self.m = 1
 
         # make the actual Fourier transform and compute cross spectrum
-        self.freq, self.unnorm_power = self._fourier_cross(lc1, lc2)
+        self.freq, self.unnorm_power = self._fourier_cross(lc1, lc2, fullspec)
 
         # If co-spectrum is desired, normalize here. Otherwise, get raw back
         # with the imaginary part still intact.
@@ -294,11 +302,12 @@ class Crossspectrum(object):
         else:
             self.power_err = np.zeros(len(self.power))
 
-    def _fourier_cross(self, lc1, lc2):
+    def _fourier_cross(self, lc1, lc2, fullspec=False):
         """
         Fourier transform the two light curves, then compute the cross spectrum.
         Computed as CS = lc1 x lc2* (where lc2 is the one that gets
-        complex-conjugated)
+        complex-conjugated). The user has the option to either get just the
+        positive frequencies or the full spectrum.
 
         Parameters
         ----------
@@ -310,6 +319,9 @@ class Crossspectrum(object):
             Another light curve to be Fourier transformed.
             This is the reference band.
 
+        fullspec: boolean. Default is False. Whole array of frequencies (True)
+        or only positive (False).
+
         Returns
         -------
         fr: numpy.ndarray
@@ -320,9 +332,14 @@ class Crossspectrum(object):
         fourier_2 = scipy.fftpack.fft(lc2.counts)  # do Fourier transform 2
 
         freqs = scipy.fftpack.fftfreq(lc1.n, lc1.dt)
-        cross = np.multiply(fourier_1[freqs > 0], np.conj(fourier_2[freqs > 0]))
 
-        return freqs[freqs > 0], cross
+        if fullspec is  True:
+            cross = np.multiply(fourier_1, np.conj(fourier_2))
+            return freqs, cross
+
+        else:
+            cross = np.multiply(fourier_1[freqs > 0], np.conj(fourier_2[freqs > 0]))
+            return freqs[freqs > 0], cross
 
     def rebin(self, df=None, f=None, method="mean"):
         """
@@ -666,6 +683,9 @@ class AveragedCrossspectrum(Crossspectrum):
     power_type: string, optional, default ``real`` Parameter to choose among
     complete, real part and magnitude of the cross spectrum.
 
+    fullspec: boolean, optional, default ``False`` Parameter to either
+    return the full array of frequencies (True) or just the positive (False)
+
     Attributes
     ----------
     freq: numpy.ndarray
@@ -704,7 +724,8 @@ class AveragedCrossspectrum(Crossspectrum):
     """
 
     def __init__(self, lc1=None, lc2=None, segment_size=None,
-                 norm='none', gti=None, power_type="real"):
+                 norm='none', gti=None, power_type="real",
+                 fullspec=False):
 
         self.type = "crossspectrum"
 
@@ -713,12 +734,13 @@ class AveragedCrossspectrum(Crossspectrum):
         if segment_size is not None and not np.isfinite(segment_size):
             raise ValueError("segment_size must be finite!")
 
+
         self.segment_size = segment_size
         self.power_type = power_type
+        self.fullspec = fullspec
 
         Crossspectrum.__init__(self, lc1, lc2, norm, gti=gti,
-                               power_type=power_type)
-
+                               power_type=power_type, fullspec=fullspec)
         return
 
     def _make_auxil_pds(self, lc1, lc2):
@@ -734,10 +756,12 @@ class AveragedCrossspectrum(Crossspectrum):
         if lc1 is not lc2 and isinstance(lc1, Lightcurve):
             self.pds1 = AveragedCrossspectrum(lc1, lc1,
                                               segment_size=self.segment_size,
-                                              norm='none', gti=lc1.gti, power_type=self.power_type)
+                                              norm='none', gti=lc1.gti, power_type=self.power_type,
+                                              fullspec=self.fullspec)
             self.pds2 = AveragedCrossspectrum(lc2, lc2,
                                               segment_size=self.segment_size,
-                                              norm='none', gti=lc2.gti, power_type=self.power_type)
+                                              norm='none', gti=lc2.gti, power_type=self.power_type,
+                                              fullspec=self.fullspec)
 
     def _make_segment_spectrum(self, lc1, lc2, segment_size):
         """
@@ -813,14 +837,15 @@ class AveragedCrossspectrum(Crossspectrum):
                                  err_dist=lc2.err_dist,
                                  gti=gti2,
                                  dt=lc2.dt)
-            cs_seg = Crossspectrum(lc1_seg, lc2_seg, norm=self.norm, power_type=self.power_type)
+            cs_seg = Crossspectrum(lc1_seg, lc2_seg, norm=self.norm, power_type=self.power_type,
+                                 fullspec=self.fullspec)
             cs_all.append(cs_seg)
             nphots1_all.append(np.sum(lc1_seg.counts))
             nphots2_all.append(np.sum(lc2_seg.counts))
 
         return cs_all, nphots1_all, nphots2_all
 
-    def _make_crossspectrum(self, lc1, lc2):
+    def _make_crossspectrum(self, lc1, lc2, fullspec=False):
         """
         Auxiliary method computing the normalized cross spectrum from two light curves.
         This includes checking for the presence of and applying Good Time Intervals, computing the
@@ -831,6 +856,10 @@ class AveragedCrossspectrum(Crossspectrum):
         ----------
         lc1, lc2 : :class:`stingray.Lightcurve` objects
             Two light curves used for computing the cross spectrum.
+
+        fullspec: boolean, default ``False``, all frequencies returned (True),
+        or just positive (False)
+
         """
 
         # chop light curves into segments

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -75,6 +75,23 @@ class TestCrossCorrelation(object):
         assert cr.mode == 'same'
         assert cr.auto is False
 
+     def test_crossparam_input(self):
+        # need to create new results to check against
+        spec = Crossspectrum(self.lc1, self.lc2)
+        ifft = abs(scipy.fftpack.ifft(spec.power).real)
+        time = scipy.fftpack.fftfreq(len(ifft), spec.df)
+        time, resultifft = (list(t) for t in zip(*sorted(zip(time, ifft))))
+        cr2 = CrossCorrelation(cross=spec)
+
+        assert np.allclose(cr2.cross.power, spec.power)
+        assert np.allclose(cr2.cross.freq, spec.freq)
+        assert np.allclose(cr2.corr, resultifft)
+        assert np.isclose(cr2.dt, self.lc1.dt)
+        assert cr2.n == 5
+        assert np.allclose(cr2.time_lags, lags_result)
+        assert cr2.mode == 'same'
+        assert cr2.auto is False
+
     def test_cross_correlation_with_unequal_lc(self):
         result = np.array([-0.66666667, -0.33333333, -1., 0.66666667, 3.13333333])
         lags_result = np.array([-2, -1, 0, 1, 2])

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -266,7 +266,7 @@ class TestCrossspectrum(object):
         csT = Crossspectrum(self.lc1, self.lc2, fullspec=True)
         assert csT.fullspec == True
         assert self.cs.fullspec == False
-        assert csT.n == cs.n
+        assert csT.n == self.cs.n
         assert csT.n == len(csT.power)
         assert self.cs.n != len(self.cs.power)
         assert len(csT.power) >= len(self.cs.power)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -262,6 +262,15 @@ class TestCrossspectrum(object):
         with pytest.raises(ValueError):
             cs.rebin()
 
+    def test_fullspec(self):
+        csT = Crossspectrum(self.lc1, self.lc2, fullspec=True)
+        assert csT.fullspec == True
+        assert self.cs.fullspec == False
+        assert csT.n == cs.n
+        assert csT.n == len(csT.power)
+        assert self.cs.n != len(self.cs.power)
+        assert len(csT.power) >= len(self.cs.power)
+        assert csT.freq[csT.n//2] <= 0.
 
 class TestAveragedCrossspectrum(object):
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -270,6 +270,7 @@ class TestCrossspectrum(object):
         assert csT.n == len(csT.power)
         assert self.cs.n != len(self.cs.power)
         assert len(csT.power) >= len(self.cs.power)
+        assert len(csT.power) == len(self.lc1)
         assert csT.freq[csT.n//2] <= 0.
 
 class TestAveragedCrossspectrum(object):


### PR DESCRIPTION
Adding the ability for users to specify whether to return the full cross spectrum (including values associated with negative frequencies) or not( default, this is what the code was originally doing, just returning the positives frequencies). This means that nothing _should_ change for those already using Stingray CrossSpectrum. 

We (@abigailStev and I) needed this to continue with CrossCorrelation- related development and usage. There is also a new function within the test_crossspectrum.py to make sure that it is working accordingly.  I will be updating the notebooks to show people that this is an option. Looking forward to feedback!