### PR TITLE
Added if statement to skip over light curves with no counts

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1082,26 +1082,26 @@ class AveragedCrossspectrum(Crossspectrum):
 
             if np.sum(counts_1) == 0 or np.sum(counts_2) == 0:
                 continue
-            else:
-                gti1 = np.array([[time_1[0] - lc1.dt / 2,
-                                  time_1[-1] + lc1.dt / 2]])
-                gti2 = np.array([[time_2[0] - lc2.dt / 2,
-                                  time_2[-1] + lc2.dt / 2]])
-                lc1_seg = Lightcurve(time_1, counts_1, err=counts_1_err,
-                                     err_dist=lc1.err_dist,
-                                     gti=gti1,
-                                     dt=lc1.dt, skip_checks=True)
-                lc2_seg = Lightcurve(time_2, counts_2, err=counts_2_err,
-                                     err_dist=lc2.err_dist,
-                                     gti=gti2,
-                                     dt=lc2.dt, skip_checks=True)
-                with warnings.catch_warnings(record=True) as w:
-                    cs_seg = Crossspectrum(lc1_seg, lc2_seg, norm=self.norm,
-                                           power_type=self.power_type)
 
-                cs_all.append(cs_seg)
-                nphots1_all.append(np.sum(lc1_seg.counts))
-                nphots2_all.append(np.sum(lc2_seg.counts))
+            gti1 = np.array([[time_1[0] - lc1.dt / 2,
+                              time_1[-1] + lc1.dt / 2]])
+            gti2 = np.array([[time_2[0] - lc2.dt / 2,
+                              time_2[-1] + lc2.dt / 2]])
+            lc1_seg = Lightcurve(time_1, counts_1, err=counts_1_err,
+                                 err_dist=lc1.err_dist,
+                                 gti=gti1,
+                                 dt=lc1.dt, skip_checks=True)
+            lc2_seg = Lightcurve(time_2, counts_2, err=counts_2_err,
+                                 err_dist=lc2.err_dist,
+                                 gti=gti2,
+                                 dt=lc2.dt, skip_checks=True)
+            with warnings.catch_warnings(record=True) as w:
+                cs_seg = Crossspectrum(lc1_seg, lc2_seg, norm=self.norm,
+                                       power_type=self.power_type)
+
+            cs_all.append(cs_seg)
+            nphots1_all.append(np.sum(lc1_seg.counts))
+            nphots2_all.append(np.sum(lc2_seg.counts))
 
         return cs_all, nphots1_all, nphots2_all
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1082,7 +1082,8 @@ class AveragedCrossspectrum(Crossspectrum):
 
             if np.sum(counts_1) == 0 or np.sum(counts_2) == 0:
                 warnings.warn(
-                    f"No counts in interval {time_1[0]}--{time_1[-1]}s")
+                    "No counts in interval {}--{}s".format(time_1[0],
+                                                           time_1[-1]))
                 continue
 
             gti1 = np.array([[time_1[0] - lc1.dt / 2,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -789,11 +789,11 @@ class Crossspectrum(object):
                 plt.xlabel(labels[0])
                 plt.ylabel(labels[1])
             except TypeError:
-                utils.simon("``labels`` must be either a list or tuple with "
+                simon("``labels`` must be either a list or tuple with "
                             "x and y labels.")
                 raise
             except IndexError:
-                utils.simon("``labels`` must have two labels for x and y "
+                simon("``labels`` must have two labels for x and y "
                             "axes.")
                 # Not raising here because in case of len(labels)==1, only
                 # x-axis will be labelled.

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1079,24 +1079,29 @@ class AveragedCrossspectrum(Crossspectrum):
             time_2 = lc2.time[start_ind:end_ind]
             counts_2 = lc2.counts[start_ind:end_ind]
             counts_2_err = lc2.counts_err[start_ind:end_ind]
-            gti1 = np.array([[time_1[0] - lc1.dt / 2,
-                              time_1[-1] + lc1.dt / 2]])
-            gti2 = np.array([[time_2[0] - lc2.dt / 2,
-                              time_2[-1] + lc2.dt / 2]])
-            lc1_seg = Lightcurve(time_1, counts_1, err=counts_1_err,
-                                 err_dist=lc1.err_dist,
-                                 gti=gti1,
-                                 dt=lc1.dt, skip_checks=True)
-            lc2_seg = Lightcurve(time_2, counts_2, err=counts_2_err,
-                                 err_dist=lc2.err_dist,
-                                 gti=gti2,
-                                 dt=lc2.dt, skip_checks=True)
-            with warnings.catch_warnings(record=True) as w:
-                cs_seg = Crossspectrum(lc1_seg, lc2_seg, norm=self.norm, power_type=self.power_type)
 
-            cs_all.append(cs_seg)
-            nphots1_all.append(np.sum(lc1_seg.counts))
-            nphots2_all.append(np.sum(lc2_seg.counts))
+            if np.sum(counts_1) == 0 or np.sum(counts_2) == 0:
+                continue
+            else:
+                gti1 = np.array([[time_1[0] - lc1.dt / 2,
+                                  time_1[-1] + lc1.dt / 2]])
+                gti2 = np.array([[time_2[0] - lc2.dt / 2,
+                                  time_2[-1] + lc2.dt / 2]])
+                lc1_seg = Lightcurve(time_1, counts_1, err=counts_1_err,
+                                     err_dist=lc1.err_dist,
+                                     gti=gti1,
+                                     dt=lc1.dt, skip_checks=True)
+                lc2_seg = Lightcurve(time_2, counts_2, err=counts_2_err,
+                                     err_dist=lc2.err_dist,
+                                     gti=gti2,
+                                     dt=lc2.dt, skip_checks=True)
+                with warnings.catch_warnings(record=True) as w:
+                    cs_seg = Crossspectrum(lc1_seg, lc2_seg, norm=self.norm,
+                                           power_type=self.power_type)
+
+                cs_all.append(cs_seg)
+                nphots1_all.append(np.sum(lc1_seg.counts))
+                nphots2_all.append(np.sum(lc2_seg.counts))
 
         return cs_all, nphots1_all, nphots2_all
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1081,6 +1081,8 @@ class AveragedCrossspectrum(Crossspectrum):
             counts_2_err = lc2.counts_err[start_ind:end_ind]
 
             if np.sum(counts_1) == 0 or np.sum(counts_2) == 0:
+                warnings.warn(
+                    f"No counts in interval {time_1[0]}--{time_1[-1]}s")
                 continue
 
             gti1 = np.array([[time_1[0] - lc1.dt / 2,

--- a/stingray/deadtime/fad.py
+++ b/stingray/deadtime/fad.py
@@ -88,7 +88,7 @@ def calculate_FAD_correction(lc1, lc2, segment_size, norm="none", gti=None,
         segments, as the result gets better as one averages more and more
         segments.
 
-     norm: {``frac``, ``abs``, ``leahy``, ``none``}, default ``none``
+    norm: {``frac``, ``abs``, ``leahy``, ``none``}, default ``none``
         The normalization of the (real part of the) cross spectrum.
 
 
@@ -115,6 +115,7 @@ def calculate_FAD_correction(lc1, lc2, segment_size, norm="none", gti=None,
         stdtheor = 2 / np.sqrt(n)
         std = (average_corrected_fourier_diff / n).std()
         np.abs((std - stdtheor) / stdtheor) < tolerance
+        ```
     strict : bool, default False
         Decide what to do if the condition on tolerance is not met. If True,
         raise a ``RuntimeError``. If False, just throw a warning.
@@ -137,7 +138,7 @@ def calculate_FAD_correction(lc1, lc2, segment_size, norm="none", gti=None,
         + cs: the corrected cospectrum
         + ptot: the corrected PDS of lc1 + lc2
 
-        If ``return_objects==True``, ``results`` is a ``dict``, with keys
+        If ``return_objects`` is True, ``results`` is a ``dict``, with keys
         named like the columns
         listed above but with `AveragePowerspectrum` or
         `AverageCrossspectrum` objects instead of arrays.
@@ -150,7 +151,7 @@ def calculate_FAD_correction(lc1, lc2, segment_size, norm="none", gti=None,
         gti = cross_two_gtis(lc1.gti, lc2.gti)
 
     if all_leahy:
-        warnings.warn("`all_leahy` is deprecated. Use `norm` instead! "  + 
+        warnings.warn("`all_leahy` is deprecated. Use `norm` instead! "  +
                       " Setting `norm`=`leahy`.", DeprecationWarning)
         norm="leahy"
 
@@ -215,14 +216,14 @@ def calculate_FAD_correction(lc1, lc2, segment_size, norm="none", gti=None,
         c = c / smooth_real * 2
 
 
-        power1 = normalize_crossspectrum(p1, segment_size, nbins1, nph1, 
+        power1 = normalize_crossspectrum(p1, segment_size, nbins1, nph1,
                                          nph1, norm=norm)
 
-        power2 = normalize_crossspectrum(p2, segment_size, nbins2, nph2,    
+        power2 = normalize_crossspectrum(p2, segment_size, nbins2, nph2,
                                          nph2, norm=norm)
-        power_tot = normalize_crossspectrum(pt, segment_size, nbinstot, nphtot,    
+        power_tot = normalize_crossspectrum(pt, segment_size, nbinstot, nphtot,
                                          nphtot, norm=norm)
-        cs_power = normalize_crossspectrum(c, segment_size, nbins1, nph1,    
+        cs_power = normalize_crossspectrum(c, segment_size, nbins1, nph1,
                                          nph2, norm=norm)
 
         if n == 0 and plot:

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1133,8 +1133,8 @@ class Lightcurve(object):
         lc_split : iterable of `Lightcurve` objects
             The list of all contiguous light curves
 
-        Example
-        -------
+        Examples
+        --------
         >>> time = np.array([1, 2, 3, 6, 7, 8, 11, 12, 13])
         >>> counts = np.random.rand(time.shape[0])
         >>> lc = Lightcurve(time, counts, dt=1)

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1,4 +1,4 @@
-
+import warnings
 import numpy as np
 import scipy
 import scipy.stats
@@ -397,6 +397,11 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
             time = lc.time[start_ind:end_ind]
             counts = lc.counts[start_ind:end_ind]
             counts_err = lc.counts_err[start_ind: end_ind]
+
+            if np.sum(counts) == 0:
+                warnings.warn(f"No counts in interval {time[0]}--{time[-1]}s")
+                continue
+
             lc_seg = lightcurve.Lightcurve(time, counts, err=counts_err,
                                            err_dist=lc.err_dist.lower(),
                                            skip_checks=True, dt=lc.dt)

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -399,7 +399,8 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
             counts_err = lc.counts_err[start_ind: end_ind]
 
             if np.sum(counts) == 0:
-                warnings.warn(f"No counts in interval {time[0]}--{time[-1]}s")
+                warnings.warn(
+                    "No counts in interval {}--{}s".format(time[0], time[-1]))
                 continue
 
             lc_seg = lightcurve.Lightcurve(time, counts, err=counts_err,

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -405,6 +405,7 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
             lc_seg = lightcurve.Lightcurve(time, counts, err=counts_err,
                                            err_dist=lc.err_dist.lower(),
                                            skip_checks=True, dt=lc.dt)
+
             power_seg = Powerspectrum(lc_seg, norm=self.norm)
             power_all.append(power_seg)
             nphots_all.append(np.sum(lc_seg.counts))

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -51,19 +51,22 @@ def _logp_multitrial_from_single_logp(logp1, n):
 
 
 def p_multitrial_from_single_trial(p1, n):
-    """Calculate a multi-trial p-value from a single-trial one.
+    r"""Calculate a multi-trial p-value from a single-trial one.
 
-    Calling _p_ the probability of a single success, the Binomial
-    distributions says that the probability _at least_ one outcome
+    Calling *p* the probability of a single success, the Binomial
+    distributions says that the probability *at least* one outcome
     in n trials is
-                         n
-    P (k ≥ 1) =   Σ    (   ) p^k (1 - p)^(n - k)
-                k ≥ 1    k
+
+    .. math::
+
+        P(k\geq 1) = \sum_{k\geq 1} \binom{n}{k} p^k (1-p)^{(n-k)}
 
     or more simply, using P(k ≥ 0) = 1
-                          n
-    P (k ≥ 1) =   1 -   (   ) (1 - p)^n = 1 - (1 - p)^n
-                          0
+
+    .. math::
+
+        P(k\geq 1) = 1 - \binom{n}{0} (1-p)^n = 1 - (1-p)^n
+
 
     Parameters
     ----------
@@ -123,7 +126,7 @@ def _logp_single_trial_from_logp_multitrial(logpn, n):
 
 
 def p_single_trial_from_p_multitrial(pn, n):
-    """Calculate the single-trial p-value from a total p-value
+    r"""Calculate the single-trial p-value from a total p-value
 
     Let us say that we want to reject a null hypothesis at the
     ``pn`` level, after executing ``n`` different measurements.
@@ -138,19 +141,23 @@ def p_single_trial_from_p_multitrial(pn, n):
     approximation, when ``pn`` is low: ``p1 = pn / n``.
 
     However, if ``pn`` is close to 1, this approximation gives
-   incorrect results.
+    incorrect results.
 
     Here we calculate this probability by inverting the Binomial
     problem. Given that (see ``p_multitrial_from_single_trial``)
     the probability of getting more than one hit in n trials,
-    given the single-trial probability _p_, is
+    given the single-trial probability *p*, is
 
-    P (k ≥ 1) =  1 - (1 - p)^n,
+    .. math ::
+
+        P (k \geq 1) =  1 - (1 - p)^n,
 
     we get the single trial probability from the multi-trial one
     from
 
-    p = 1 - (1 - P)^(1/n)
+    .. math ::
+
+        p = 1 - (1 - P)^{(1/n)}
 
     This is also known as Šidák correction.
 
@@ -377,13 +384,13 @@ def pds_detection_level(epsilon=0.01, ntrial=1, n_summed_spectra=1, n_rebin=1):
 def classical_pvalue(power, nspec):
     """
     Note:
-    This is stingray's original implementation of the probability 
-    distribution for the power spectrum. It is superseded by the 
-    implementation in pds_probability for practical purposes, but 
-    remains here for backwards compatibility and for its educational 
-    value as a clear, explicit implementation of the correct 
+    This is stingray's original implementation of the probability
+    distribution for the power spectrum. It is superseded by the
+    implementation in pds_probability for practical purposes, but
+    remains here for backwards compatibility and for its educational
+    value as a clear, explicit implementation of the correct
     probability distribution.
-    
+
     Compute the probability of detecting the current power under
     the assumption that there is no periodic oscillation in the data.
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -589,6 +589,23 @@ class TestAveragedCrossspectrum(object):
             assert np.any(["same tseg" in r.message.args[0]
                            for r in record])
 
+    def test_with_zero_counts(self):
+        nbins = 100
+        x = np.linspace(0, 10, nbins)
+        ycounts1 = np.random.normal(loc=10, scale=0.5, size=int(0.4*nbins))
+        ycounts2 = np.random.normal(loc=10, scale=0.5, size=int(0.4*nbins))
+
+        yzero = np.zeros(int(0.6*nbins))
+        y1 = np.hstack([ycounts1, yzero])
+        y2 = np.hstack([ycounts2, yzero])
+
+        lc1 = Lightcurve(x, y1)
+        lc2 = Lightcurve(x, y2)
+
+        acs = AveragedCrossspectrum(lc1, lc2, segment_size=5.0, norm="leahy")
+        assert acs.m == 1
+
+
     def test_rebin_with_invalid_type_attribute(self):
         new_df = 2
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -227,7 +227,7 @@ class TestNormalization(object):
     def test_norm_abs(self):
         # Testing for a power spectrum of lc1
         power = normalize_crossspectrum(self.cs.power, self.lc1.tseg, self.lc1.n,
-                                        self.cs.nphots1, self.cs.nphots2, 
+                                        self.cs.nphots1, self.cs.nphots2,
                                         norm="abs")
 
         abs_noise = 2. * self.rate1  # expected Poisson noise level
@@ -236,7 +236,7 @@ class TestNormalization(object):
     def test_norm_leahy(self):
 
         power = normalize_crossspectrum(self.cs.power, self.lc1.tseg, self.lc1.n,
-                                        self.cs.nphots1, self.cs.nphots2, 
+                                        self.cs.nphots1, self.cs.nphots2,
                                         norm="leahy")
 
         leahy_noise = 2.0  # expected Poisson noise level
@@ -244,7 +244,7 @@ class TestNormalization(object):
 
     def test_norm_frac(self):
         power = normalize_crossspectrum(self.cs.power, self.lc1.tseg, self.lc1.n,
-                                        self.cs.nphots1, self.cs.nphots2, 
+                                        self.cs.nphots1, self.cs.nphots2,
                                         norm="frac")
 
         norm = 2. / self.rate1
@@ -255,7 +255,6 @@ class TestNormalization(object):
             power = normalize_crossspectrum(self.cs.power, self.lc1.tseg, self.lc1.n,
                                             self.cs.nphots1, self.cs.nphots2,
                                             norm="wrong")
-
 
 
 class TestCrossspectrum(object):
@@ -529,6 +528,16 @@ class TestAveragedCrossspectrum(object):
         assert cs.m == 1
         assert cs.n is None
         assert cs.power_err is None
+
+    def test_no_counts_warns(self):
+        newlc = copy.deepcopy(self.lc1)
+        newlc.counts[:newlc.counts.size // 2] = \
+            0 * newlc.counts[:newlc.counts.size // 2]
+        with pytest.warns(UserWarning) as record:
+            ps = AveragedCrossspectrum(newlc, self.lc2, segment_size=0.2)
+
+        assert np.any(["No counts in "
+                       in r.message.args[0] for r in record])
 
     def test_no_segment_size(self):
         with pytest.raises(ValueError):

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -311,7 +311,8 @@ class TestPowerspectrum(object):
     def test_classical_significances_with_logbinned_psd(self):
         ps = Powerspectrum(lc=self.lc, norm="leahy")
         ps_log = ps.rebin_log()
-        pval = ps_log.classical_significances(threshold=1.1, trial_correction=False)
+        pval = ps_log.classical_significances(threshold=1.1,
+                                              trial_correction=False)
 
         assert len(pval[0]) == len(ps_log.power)
 
@@ -425,6 +426,17 @@ class TestAveragedPowerspectrum(object):
 
         segment_size = 0.5
         assert AveragedPowerspectrum(lc_all, segment_size)
+
+    def test_with_zero_counts(self):
+        nbins = 100
+        x = np.linspace(0, 10, nbins)
+        y0 = np.random.normal(loc=10, scale=0.5, size=int(0.4*nbins))
+        y1 = np.zeros(int(0.6*nbins))
+        y = np.hstack([y0, y1])
+
+        lc = Lightcurve(x, y)
+        aps = AveragedPowerspectrum(lc, segment_size=5.0, norm="leahy")
+        assert aps.m == 1
 
     def test_with_iterable_of_variable_length_lightcurves(self):
         gti = [[0, 0.05], [0.05, 0.5], [0.555, 1.0]]

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -357,6 +357,17 @@ class TestAveragedPowerspectrum(object):
         ps = AveragedPowerspectrum(self.lc, segment_size)
         assert np.isclose(ps.segment_size, segment_size)
 
+    def test_no_counts_warns(self):
+        newlc = copy.deepcopy(self.lc)
+        newlc.counts[:newlc.counts.size // 2] = \
+            0 * newlc.counts[:newlc.counts.size // 2]
+
+        with pytest.warns(UserWarning) as record:
+            ps = AveragedPowerspectrum(newlc, 0.2)
+
+        assert np.any(["No counts in "
+                       in r.message.args[0] for r in record])
+
     def test_make_empty_periodogram(self):
         ps = AveragedPowerspectrum()
         assert ps.norm == "frac"

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -139,7 +139,14 @@ class VarEnergySpectrum(object):
             self.ref_band = np.asarray([self.ref_band])
 
         self.segment_size = segment_size
-        self.spectrum, self.spectrum_error = self._spectrum_function()
+
+        if len(events.time) == 0:
+            simon("There are no events in your event list!" +
+                  "Can't make a spectrum!")
+            self.spectrum = 0
+            self.spectrum_error = 0
+        else:
+            self.spectrum, self.spectrum_error = self._spectrum_function()
 
     def _decide_ref_intervals(self, channel_band, ref_band):
         """


### PR DESCRIPTION
I occasionally have light curves with fairly low counts and particularly variable count rates, so that when making an averaged PSD, I end up with segments that have no counts. 

Currently this always fails during the periodogram creation of that segment, but I think what it should really do is throw that segment away and continue without it.