### PR TITLE
Fix numpy astropy issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
         # Try without using corner
         - env: PYTHON_VERSION=3.5 PIP_DEPENDENCIES='emcee statsmodels'
                NUMPY_VERSION=1.14
+               ASTROPY_VERSION=3.2.3
 
         - env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='nbsphinx sphinx-astropy' SETUP_CMD='build_docs -w'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
         - env: PYTHON_VERSION=3.6
                PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner'
                SETUP_CMD='test --remote-data --coverage'
+               ASTROPY_VERSION=3.2.3
 
         - env: PYTHON_VERSION=3.7  CONDA_DEPENDENCIES='scipy matplotlib numba'
 

--- a/stingray/modeling/tests/test_posterior.py
+++ b/stingray/modeling/tests/test_posterior.py
@@ -205,7 +205,8 @@ class TestPSDPosterior(object):
 
     def test_negative_loglikelihood(self):
         t0 = [2.0]
-        m = self.model(self.ps.freq[1:], t0)
+        self.model.amplitude = t0[0]
+        m = self.model(self.ps.freq[1:])
         loglike = np.sum(self.ps.power[1:]/m + np.log(m))
 
         lpost = PSDPosterior(self.ps.freq, self.ps.power,
@@ -218,7 +219,9 @@ class TestPSDPosterior(object):
 
     def test_posterior(self):
         t0 = [2.0]
-        m = self.model(self.ps.freq[1:], t0)
+        self.model.amplitude = t0[0]
+
+        m = self.model(self.ps.freq[1:])
         lpost = PSDPosterior(self.ps.freq, self.ps.power,
                              self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
@@ -233,7 +236,9 @@ class TestPSDPosterior(object):
 
     def test_negative_posterior(self):
         t0 = [2.0]
-        m = self.model(self.ps.freq[1:], t0)
+        self.model.amplitude = t0[0]
+
+        m = self.model(self.ps.freq[1:])
         lpost = PSDPosterior(self.ps.freq, self.ps.power,
                              self.model, m=self.ps.m)
         lpost.logprior = set_logprior(lpost, self.priors)
@@ -779,7 +784,8 @@ class TestPerPosteriorAveragedPeriodogram(object):
         ps_nan.power = np.nan*np.ones_like(self.ps.freq)
 
         t0 = [2.0]
-        m = self.model(self.ps.freq[1:], t0)
+        self.model.amplitude = t0[0]
+        m = self.model(self.ps.freq[1:])
         lpost = PSDPosterior(ps_nan.freq, ps_nan.power, self.model)
         lpost.logprior = set_logprior(lpost, self.priors)
 

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -168,7 +168,7 @@ class TestPowerspectrum(object):
         In Leahy normalization, the poisson noise level (so, in the absence of
         a signal, the average power) should be equal to 2.
         """
-        time = np.linspace(0, 10.0, 1e5)
+        time = np.linspace(0, 10.0, 10**5)
         counts = np.random.poisson(1000, size=time.shape[0])
 
         lc = Lightcurve(time, counts)
@@ -215,7 +215,7 @@ class TestPowerspectrum(object):
         """
         np.random.seed(101)
 
-        time = np.linspace(0, 1., 1e4)
+        time = np.linspace(0, 1., 10**4)
         counts = np.random.poisson(0.01, size=time.shape[0])
 
         lc = Lightcurve(time, counts)


### PR DESCRIPTION
Fix the issues related to the changes in the modeling interface in Astropy's 4.0 version. Some failures due to similar problems in the PINT dependency are expected, _only_ in the pulsar tests (anything else should be investigated and solved). 

Resolve #448 