### PR TITLE
add support to lightkurve package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,15 @@ MANIFEST
 docs/api
 docs/_build
 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
 # Eclipse editor project files
 .project
 .pydevproject
@@ -27,6 +36,9 @@ docs/_build
 
 # Pycharm editor project files
 .idea
+
+# VSCode editor project files
+.vscode/*
 
 # Packages/installer info
 *.egg

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
         - env: PYTHON_VERSION=3.8
 
         - env: PYTHON_VERSION=3.6
-               PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner'
+               PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem emcee statsmodels corner lightkurve'
                SETUP_CMD='test --remote-data --coverage'
 
         - env: PYTHON_VERSION=3.7  CONDA_DEPENDENCIES='scipy matplotlib numba'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
         - NUMPY_VERSION=stable
 
         - SETUP_CMD='test --coverage'
-        - PIP_DEPENDENCIES='emcee statsmodels corner'
+        - PIP_DEPENDENCIES='emcee statsmodels corner Lightkurve'
         - CONDA_DEPENDENCIES='scipy h5py matplotlib'
         - SETUP_XVFB=True
 

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1368,6 +1368,39 @@ class Lightcurve(object):
             results = [results[:, i] for i in range(results.shape[1])]
         return start_times, stop_times, results
 
+    def to_lightkurve(self):
+        """
+        Returns a `lightkurve.LightCurve` object.
+        This feature requires `Lightkurve
+        <https://docs.lightkurve.org/index.html/>`_ to be installed
+        (e.g. ``pip install lightkurve``).  An `ImportError` will
+        be raised if this package is not available.
+
+        Returns
+        -------
+        lightcurve : `lightkurve.LightCurve`
+            A lightkurve LightCurve object.
+        """
+        try:
+            from lightkurve import LightCurve as lk
+        except ImportError:
+            raise ImportError("You need to install Lightkurve to use "
+                              "the Lightcurve.to_lightkurve() method.")
+        return lk(time=self.time, flux=self.counts, flux_err=self.counts_err)
+
+    @staticmethod
+    def from_lightkurve(lk):
+        """
+        Creates a new `Lightcurve` from a `lightkurve.LightCurve`.
+
+        Parameters
+        ----------
+        lk : `lightkurve.LightCurve`
+            A lightkurve LightCurve object.
+        """
+        return Lightcurve(time=lc.time, counts=lc.flux,
+                          err=lc.flux_err, input_counts=False)
+
     def plot(self, witherrors=False, labels=None, axis=None, title=None,
              marker='-', save=False, filename=None):
         """

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -807,31 +807,25 @@ class TestLightcurve(object):
         new_lc_long = lc_long[:]  # Copying into a new object
         assert new_lc_long.n == lc_long.n
 
+    @pytest.mark.skipif('not _HAS_LIGHTKURVE')
     def test_to_lightkurve(self):
         time, counts, counts_err = range(3), np.ones(3), np.zeros(3)
         lc = Lightcurve(time, counts, counts_err)
-        try:
-            lk = lc.to_lightkurve()
-            assert_allclose(lk.time, time)
-            assert_allclose(lk.flux, counts)
-            assert_allclose(lk.flux_err, counts_err)
-        except ImportError:
-            # Requires Lightkurve
-            pass
+        lk = lc.to_lightkurve()
+        assert_allclose(lk.time, time)
+        assert_allclose(lk.flux, counts)
+        assert_allclose(lk.flux_err, counts_err)
 
     @pytest.mark.skipif(not _HAS_LIGHTKURVE,
                         reason='Lightkurve not installed')
     def test_from_lightkurve(self):
-        try:
-            from Lightkurve import LightCurve
-            time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
-            lk = LightCurve(time, flux, flux_err)
-            sr = Lightcurve.from_lightkurve(lk)
-            assert_allclose(sr.time, lc.time)
-            assert_allclose(sr.counts, lc.flux)
-            assert_allclose(sr.counts_err, lc.flux_err)
-        except ImportError:
-            pass
+        from Lightkurve import LightCurve
+        time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
+        lk = LightCurve(time, flux, flux_err)
+        sr = Lightcurve.from_lightkurve(lk)
+        assert_allclose(sr.time, lc.time)
+        assert_allclose(sr.counts, lc.flux)
+        assert_allclose(sr.counts_err, lc.flux_err)
 
     def test_plot_matplotlib_not_installed(self):
         try:

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -800,6 +800,30 @@ class TestLightcurve(object):
         new_lc_long = lc_long[:]  # Copying into a new object
         assert new_lc_long.n == lc_long.n
 
+    def test_to_lightkurve(self):
+        time, counts, counts_err = range(3), np.ones(3), np.zeros(3)
+        lc = Lightcurve(time, counts, counts_err)
+        try:
+            lk = lc.to_lightkurve()
+            assert_allclose(lk.time, time)
+            assert_allclose(lk.flux, counts)
+            assert_allclose(lk.flux_err, counts_err)
+        except ImportError:
+            # Requires Lightkurve
+            pass
+
+    def test_from_lightkurve(self):
+        try:
+            from Lightkurve import LightCurve
+            time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
+            lk = LightCurve(time, flux, flux_err)
+            sr = Lightcurve.from_lightkurve(lk)
+            assert_allclose(sr.time, lc.time)
+            assert_allclose(sr.counts, lc.flux)
+            assert_allclose(sr.counts_err, lc.flux_err)
+        except ImportError:
+            pass
+
     def test_plot_matplotlib_not_installed(self):
         try:
             import matplotlib.pyplot as plt

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -4,6 +4,7 @@ from astropy.tests.helper import pytest
 import warnings
 import os
 import matplotlib.pyplot as plt
+from numpy.testing import assert_allclose
 
 from stingray import Lightcurve
 from stingray.exceptions import StingrayError
@@ -12,11 +13,17 @@ from stingray.gti import create_gti_mask
 np.random.seed(20150907)
 
 _H5PY_INSTALLED = True
+_HAS_LIGHTKURVE = True
 
 try:
     import h5py
 except ImportError:
     _H5PY_INSTALLED = False
+
+try:
+    import Lightkurve
+except ImportError:
+    _HAS_LIGHTKURVE = False
 
 def fvar_fun(lc):
     from stingray.utils import excess_variance
@@ -812,6 +819,8 @@ class TestLightcurve(object):
             # Requires Lightkurve
             pass
 
+    @pytest.mark.skipif(not _HAS_LIGHTKURVE,
+                        reason='Lightkurve not installed')
     def test_from_lightkurve(self):
         try:
             from Lightkurve import LightCurve


### PR DESCRIPTION
- Implements `to_lightkurve` and `from_lightkurve` so as to provide connection to lightkurve package. 
- Modify .gitignore so as to include virtual environments and VSCode editor files

Fixes #429 
Closes #454