### PR TITLE
Added some alternative routes to running the tests to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,23 +129,14 @@ Test suite
 
 Stingray uses `py.test` for testing. To run the tests, try::
 
-.. doctest::
-    :options: +SKIP
-
    $ python setup.py test
 
 If you have installed Stingray via pip or conda, the source directory might 
 not be easily accessible. Once installed, you can also run the tests using::
 
-.. doctest::
-    :options: +SKIP
-
    $ python -c 'import stingray; stingray.test()'
 
 or from within a python interpreter::
-
-.. doctest::
-    :options: +SKIP
 
    >>> import stingray
    >>> stingray.test()

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,17 @@ Stingray uses `py.test` for testing. To run the tests, try::
 
    $ python setup.py test
 
+If you have installed Stingray via pip or conda, the source directly might 
+not be easily accessible. Once installed, you can also run the tests using::
+
+   $ python -c 'import stingray; stingray.test()'
+
+or from within a python interpreter::
+
+   >>> import stingray
+   >>> stingray.test()
+
+
 Copyright
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -129,14 +129,23 @@ Test suite
 
 Stingray uses `py.test` for testing. To run the tests, try::
 
+.. doctest::
+    :options: +SKIP
+
    $ python setup.py test
 
 If you have installed Stingray via pip or conda, the source directory might 
 not be easily accessible. Once installed, you can also run the tests using::
 
+.. doctest::
+    :options: +SKIP
+
    $ python -c 'import stingray; stingray.test()'
 
 or from within a python interpreter::
+
+.. doctest::
+    :options: +SKIP
 
    >>> import stingray
    >>> stingray.test()

--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ Stingray uses `py.test` for testing. To run the tests, try::
 
    $ python setup.py test
 
-If you have installed Stingray via pip or conda, the source directly might 
+If you have installed Stingray via pip or conda, the source directory might 
 not be easily accessible. Once installed, you can also run the tests using::
 
    $ python -c 'import stingray; stingray.test()'

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -63,14 +63,23 @@ you think might be bugs on our GitHub `Issues page <https://github.com/StingrayS
 Stingray uses `py.test <https://doc.pytest.org/en/latest/>`_ for testing. To run the tests, go into
 the ``stingray`` root directory and execute ::
 
+.. doctest::
+    :options: +SKIP
+
     $ python setup.py test
 
 If you have installed Stingray via pip or conda, the source directory might
 not be easily accessible. Once installed, you can also run the tests using::
 
+.. doctest::
+    :options: +SKIP
+
    $ python -c 'import stingray; stingray.test()'
 
 or from within a python interpreter::
+
+.. doctest::
+    :options: +SKIP
 
    >>> import stingray
    >>> stingray.test()

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -63,23 +63,16 @@ you think might be bugs on our GitHub `Issues page <https://github.com/StingrayS
 Stingray uses `py.test <https://doc.pytest.org/en/latest/>`_ for testing. To run the tests, go into
 the ``stingray`` root directory and execute ::
 
-.. doctest::
-    :options: +SKIP
-
     $ python setup.py test
 
 If you have installed Stingray via pip or conda, the source directory might
 not be easily accessible. Once installed, you can also run the tests using::
 
-.. doctest::
-    :options: +SKIP
-
    $ python -c 'import stingray; stingray.test()'
 
-or from within a python interpreter::
+or from within a python interpreter:
 
-.. doctest::
-    :options: +SKIP
+.. doctest-skip::
 
    >>> import stingray
    >>> stingray.test()

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -65,6 +65,18 @@ the ``stingray`` root directory and execute ::
 
     $ python setup.py test
 
+If you have installed Stingray via pip or conda, the source directly might
+not be easily accessible. Once installed, you can also run the tests using::
+
+   $ python -c 'import stingray; stingray.test()'
+
+or from within a python interpreter::
+
+   >>> import stingray
+   >>> stingray.test()
+
+
+
 Documentation
 -------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -65,7 +65,7 @@ the ``stingray`` root directory and execute ::
 
     $ python setup.py test
 
-If you have installed Stingray via pip or conda, the source directly might
+If you have installed Stingray via pip or conda, the source directory might
 not be easily accessible. Once installed, you can also run the tests using::
 
    $ python -c 'import stingray; stingray.test()'


### PR DESCRIPTION
Because people keep asking me how to run the tests if they've installed through pip and conda, I've added a couple of lines to the readme with a way to do that.