### PR TITLE
Implement lightkurve methods

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1608,3 +1608,39 @@ class Lightcurve(object):
         self._n = None
         self.tseg = np.max(self.gti) - np.min(self.gti)
         self.tstart = self.time - 0.5 * self.dt
+
+    def to_lightkurve(self):
+        """
+        Returns a `lightkurve.Lightcurve` object.
+
+        This feature requires `Lightkurve <https://docs.lightkurve.org/>`_
+        to be installed (e.g. ``pip install lightkurve``).  An `ImportError` will
+        be raised if this package is not available.
+
+        Returns
+        -------
+        lightcurve : `lightkurve.LightCurve`
+            A lightkurve.LightCurve object.
+        """
+        try:
+            from lightkurve import LightCurve
+        except ImportError:
+            raise ImportError("You need to install Lightkurve to use "
+                              "the Lightcurve.to_lightkurve() method.")
+        return LightCurve(time=self.time, flux=self.counts, flux_err=self.counts_err)
+
+    @staticmethod
+    def from_lightkurve(lc):
+        """Create a new `Lightcurve` from a `lightkurve.LightCurve`.
+
+        Parameters
+        ----------
+        lc : `lightkurve.LightCurve`
+            A lightkurve LightCurve object.
+
+        Returns
+        -------
+        lightcurve : `stingray.Lightcurve`
+            A stingray.Lightcurve object.
+        """
+        return Lightcurve(time=lc.time, counts=lc.flux, err=lc.flux_err, input_counts=False)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -4,6 +4,7 @@ from astropy.tests.helper import pytest
 import warnings
 import os
 import matplotlib.pyplot as plt
+from numpy.testing import assert_allclose
 
 from stingray import Lightcurve
 from stingray.exceptions import StingrayError
@@ -18,13 +19,16 @@ try:
 except ImportError:
     _H5PY_INSTALLED = False
 
+
 def fvar_fun(lc):
     from stingray.utils import excess_variance
     return excess_variance(lc, normalization='fvar')
 
+
 def nvar_fun(lc):
     from stingray.utils import excess_variance
     return excess_variance(lc, normalization='norm_xs')
+
 
 def evar_fun(lc):
     from stingray.utils import excess_variance
@@ -38,7 +42,7 @@ class TestProperties(object):
         tstart = 0
         tstop = 1
         times = np.arange(tstart, tstop, dt)
-        cls.gti = np.array([[tstart - dt/2, tstop - dt/2]])
+        cls.gti = np.array([[tstart - dt / 2, tstop - dt / 2]])
         # Simulate something *clearly* non-constant
         counts = np.zeros_like(times) + 100
 
@@ -136,7 +140,6 @@ class TestProperties(object):
         # (because low_memory, and input_counts is now False)
         assert lc._counts_err is None
 
-
     @pytest.mark.parametrize('property', 'time,counts,counts_err,'
                                          'countrate,countrate_err'.split(','))
     def test_assign_bad_shape_fails(self, property):
@@ -149,6 +152,7 @@ class TestProperties(object):
         with pytest.raises(ValueError):
             setattr(lc, property, np.arange(2))
 
+
 class TestChunks(object):
     @classmethod
     def setup_class(cls):
@@ -156,7 +160,7 @@ class TestChunks(object):
         tstart = 0
         tstop = 100
         times = np.arange(tstart, tstop, dt)
-        cls.gti = np.array([[tstart - dt/2, tstop - dt/2]])
+        cls.gti = np.array([[tstart - dt / 2, tstop - dt / 2]])
         # Simulate something *clearly* non-constant
         counts = np.random.poisson(
             10000 + 2000 * np.sin(2 * np.pi * times))
@@ -164,7 +168,6 @@ class TestChunks(object):
         cls.lc = Lightcurve(times, counts, gti=cls.gti)
 
     def test_analyze_lc_chunks_fvar_fracstep(self):
-
         start, stop, res = self.lc.analyze_lc_chunks(20, fvar_fun,
                                                      fraction_step=0.5)
         # excess_variance returns fvar and fvar_err
@@ -184,7 +187,7 @@ class TestChunks(object):
                                                      fraction_step=0.5)
         # excess_variance returns fvar and fvar_err
         nevar, nevar_err = res
-        assert np.allclose(nevar, fvar**2, rtol=0.01)
+        assert np.allclose(nevar, fvar ** 2, rtol=0.01)
 
     def test_analyze_lc_chunks_nvar_fracstep_mean(self):
         start, stop, mean = self.lc.analyze_lc_chunks(20, np.mean,
@@ -263,12 +266,12 @@ class TestLightcurve(object):
             lc = Lightcurve(times, counts)
 
         with pytest.raises(ValueError):
-            lc = Lightcurve(times, [2]*5, err=counts_err)
+            lc = Lightcurve(times, [2] * 5, err=counts_err)
 
         times[2] = np.inf
 
         with pytest.raises(ValueError):
-            lc = Lightcurve(times, [2]*5)
+            lc = Lightcurve(times, [2] * 5)
 
     def test_n(self):
         lc = Lightcurve(self.times, self.counts)
@@ -279,13 +282,14 @@ class TestLightcurve(object):
 
         def func(lc):
             return lc.time[0]
+
         start, stop, res = lc.analyze_lc_chunks(2, func)
         assert start[0] == 0.5
         assert np.all(start + lc.dt / 2 == res)
 
     def test_bin_edges(self):
-        bin_lo = [0.5,  1.5,  2.5,  3.5]
-        bin_hi = [1.5,  2.5,  3.5,  4.5]
+        bin_lo = [0.5, 1.5, 2.5, 3.5]
+        bin_hi = [1.5, 2.5, 3.5, 4.5]
         lc = Lightcurve(self.times, self.counts)
         assert np.allclose(lc.bin_lo, bin_lo)
         assert np.allclose(lc.bin_hi, bin_hi)
@@ -294,7 +298,7 @@ class TestLightcurve(object):
         lc = Lightcurve.make_lightcurve(self.times, self.dt, use_hist=True,
                                         tstart=0.5)
         lc2 = Lightcurve.make_lightcurve(self.times, self.dt, use_hist=False,
-                                        tstart=0.5)
+                                         tstart=0.5)
         assert np.allclose(lc.time, lc2.time)
         assert np.all(lc.counts == lc2.counts)
 
@@ -313,7 +317,7 @@ class TestLightcurve(object):
         lc = Lightcurve.make_lightcurve(times, self.dt, use_hist=True,
                                         tstart=0.5)
         lc2 = Lightcurve.make_lightcurve(times, self.dt, use_hist=False,
-                                        tstart=0.5)
+                                         tstart=0.5)
         assert np.allclose(lc.time, lc2.time)
         assert np.all(lc.counts == lc2.counts)
 
@@ -321,7 +325,7 @@ class TestLightcurve(object):
         tstart = 0.0
         lc = Lightcurve.make_lightcurve(self.times, self.dt, tstart=0.0)
         assert lc.tstart == tstart
-        assert lc.time[0] == tstart + 0.5*self.dt
+        assert lc.time[0] == tstart + 0.5 * self.dt
 
     def test_tseg(self):
         tstart = 0.0
@@ -341,7 +345,7 @@ class TestLightcurve(object):
         tseg = 5.5
         lc = Lightcurve.make_lightcurve(self.times, self.dt,
                                         tseg=tseg, tstart=tstart)
-        assert lc.tseg == int(tseg/self.dt)
+        assert lc.tseg == int(tseg / self.dt)
 
     def test_correct_timeresolution(self):
         lc = Lightcurve.make_lightcurve(self.times, self.dt)
@@ -352,7 +356,7 @@ class TestLightcurve(object):
         tstart = 0.0
         tseg = 4.0
 
-        toa = np.hstack([np.random.uniform(i, i+1, size=n)
+        toa = np.hstack([np.random.uniform(i, i + 1, size=n)
                          for i, n in enumerate(ncounts)])
 
         dt = 1.0
@@ -363,20 +367,20 @@ class TestLightcurve(object):
     def test_countrate(self):
         dt = 0.5
         mean_counts = 2.0
-        times = np.arange(0 + dt/2, 5 - dt/2, dt)
+        times = np.arange(0 + dt / 2, 5 - dt / 2, dt)
         counts = np.zeros_like(times) + mean_counts
         lc = Lightcurve(times, counts)
         assert np.allclose(lc.countrate, np.zeros_like(counts) +
-                           mean_counts/dt)
+                           mean_counts / dt)
 
     def test_input_countrate(self):
         dt = 0.5
         mean_counts = 2.0
-        times = np.arange(0 + dt/2, 5 - dt/2, dt)
+        times = np.arange(0 + dt / 2, 5 - dt / 2, dt)
         countrate = np.zeros_like(times) + mean_counts
         lc = Lightcurve(times, countrate, input_counts=False)
         assert np.allclose(lc.counts, np.zeros_like(countrate) +
-                           mean_counts*dt)
+                           mean_counts * dt)
 
     def test_meanrate(self):
         times = [0.5, 1.0, 1.5, 2.0]
@@ -401,7 +405,7 @@ class TestLightcurve(object):
     def test_creating_lightcurve_raises_type_error_when_input_is_none(self):
         dt = 0.5
         mean_counts = 2.0
-        times = np.arange(0 + dt/2, 5 - dt/2, dt)
+        times = np.arange(0 + dt / 2, 5 - dt / 2, dt)
         counts = np.array([None] * times.shape[0])
         with pytest.raises(TypeError):
             lc = Lightcurve(times, counts)
@@ -409,7 +413,7 @@ class TestLightcurve(object):
     def test_creating_lightcurve_raises_type_error_when_input_is_inf(self):
         dt = 0.5
         mean_counts = 2.0
-        times = np.arange(0 + dt/2, 5 - dt/2, dt)
+        times = np.arange(0 + dt / 2, 5 - dt / 2, dt)
         counts = np.array([np.inf] * times.shape[0])
         with pytest.raises(ValueError):
             lc = Lightcurve(times, counts)
@@ -417,7 +421,7 @@ class TestLightcurve(object):
     def test_creating_lightcurve_raises_type_error_when_input_is_nan(self):
         dt = 0.5
         mean_counts = 2.0
-        times = np.arange(0 + dt/2, 5 - dt/2, dt)
+        times = np.arange(0 + dt / 2, 5 - dt / 2, dt)
         counts = np.array([np.nan] * times.shape[0])
         with pytest.raises(ValueError):
             lc = Lightcurve(times, counts)
@@ -434,7 +438,6 @@ class TestLightcurve(object):
         _counts = [2, 2, 2, 2, 2]
 
         with pytest.raises(ValueError):
-
             lc1 = Lightcurve(self.times, self.counts)
             lc2 = Lightcurve(_times, _counts)
 
@@ -624,11 +627,11 @@ class TestLightcurve(object):
         assert np.all(lc.counts == np.array([2, 2, 3, 3, 4, 4]))
 
     def test_join_different_err_dist_disjoint_times(self):
-        _times = [5 , 6, 7, 8]
-        _counts =[2, 2, 2, 2]
+        _times = [5, 6, 7, 8]
+        _counts = [2, 2, 2, 2]
 
-        lc1 = Lightcurve(self.times, self.counts, err_dist = "poisson")
-        lc2 = Lightcurve(_times, _counts, err_dist = "gauss")
+        lc1 = Lightcurve(self.times, self.counts, err_dist="poisson")
+        lc2 = Lightcurve(_times, _counts, err_dist="gauss")
 
         lc3 = lc1.join(lc2)
 
@@ -639,8 +642,8 @@ class TestLightcurve(object):
         _times = [3, 4, 5, 6]
         _counts = [4, 4, 4, 4]
 
-        lc1 = Lightcurve(self.times, self.counts, err_dist = "poisson")
-        lc2 = Lightcurve(_times, _counts, err_dist = "gauss")
+        lc1 = Lightcurve(self.times, self.counts, err_dist="poisson")
+        lc2 = Lightcurve(_times, _counts, err_dist="gauss")
 
         with warnings.catch_warnings(record=True) as w:
             lc3 = lc1.join(lc2)
@@ -703,7 +706,7 @@ class TestLightcurve(object):
         slc = lc_test.split(1.5)
 
         assert np.all((slc[0].time == [1, 2, 3]))
-        assert np.all((slc[1].time == [6, 7 ,8]))
+        assert np.all((slc[1].time == [6, 7, 8]))
         assert np.all((slc[0].counts == test_counts[:3]))
         assert np.all((slc[1].counts == test_counts[3:]))
 
@@ -722,8 +725,8 @@ class TestLightcurve(object):
         slc = lc_test.split(1.5)
 
         assert np.all((slc[0].time == [1, 2, 3]))
-        assert np.all((slc[1].time == [6, 7 ,8]))
-        assert np.all((slc[2].time == [10, 11 ,12]))
+        assert np.all((slc[1].time == [6, 7, 8]))
+        assert np.all((slc[2].time == [10, 11, 12]))
         assert np.all((slc[0].counts == test_counts[:3]))
         assert np.all((slc[1].counts == test_counts[3:6]))
         assert np.all((slc[2].counts == test_counts[6:]))
@@ -731,12 +734,12 @@ class TestLightcurve(object):
     def test_split_with_gtis(self):
         test_time = np.array([1, 2, 3, 6, 7, 8, 10, 11, 12])
         test_counts = np.random.rand(len(test_time))
-        gti = [[0,4], [9, 13]]
+        gti = [[0, 4], [9, 13]]
         lc_test = Lightcurve(test_time, test_counts, gti=gti)
         slc = lc_test.split(1.5)
 
         assert np.all((slc[0].time == [1, 2, 3]))
-        assert np.all((slc[1].time == [10, 11 ,12]))
+        assert np.all((slc[1].time == [10, 11, 12]))
         assert np.all((slc[0].counts == test_counts[:3]))
         assert np.all((slc[1].counts == test_counts[6:]))
 
@@ -768,7 +771,7 @@ class TestLightcurve(object):
 
         lc_new = lc.sort(reverse=True)
 
-        assert np.all(lc_new.counts == np.array([5, 20, 40,  10]))
+        assert np.all(lc_new.counts == np.array([5, 20, 40, 10]))
         assert np.all(lc_new.time == np.array([4, 3, 2, 1]))
         assert lc_new.mjdref == mjdref
 
@@ -786,16 +789,16 @@ class TestLightcurve(object):
 
         lc_new = lc.sort_counts(reverse=True)
 
-        assert np.all(lc_new.counts == np.array([40, 20, 10,  5]))
+        assert np.all(lc_new.counts == np.array([40, 20, 10, 5]))
         assert np.all(lc_new.time == np.array([1, 3, 2, 4]))
         assert lc_new.mjdref == mjdref
 
     def test_sort_reverse(self):
         times = np.arange(1000)
-        counts = np.random.rand(1000)*100
+        counts = np.random.rand(1000) * 100
         lc = Lightcurve(times, counts)
         lc_1 = lc
-        lc_2 = Lightcurve(np.arange(1000, 2000), np.random.rand(1000)*1000)
+        lc_2 = Lightcurve(np.arange(1000, 2000), np.random.rand(1000) * 1000)
         lc_long = lc_1.join(lc_2)  # Or vice-versa
         new_lc_long = lc_long[:]  # Copying into a new object
         assert new_lc_long.n == lc_long.n
@@ -936,13 +939,12 @@ class TestLightcurve(object):
 
 
 class TestLightcurveRebin(object):
-
     @classmethod
     def setup_class(cls):
         dt = 0.0001220703125
         n = 1384132
         mean_counts = 2.0
-        times = np.arange(dt/2, dt/2 + n*dt, dt)
+        times = np.arange(dt / 2, dt / 2 + n * dt, dt)
         counts = np.zeros_like(times) + mean_counts
         cls.lc = Lightcurve(times, counts)
 
@@ -951,7 +953,7 @@ class TestLightcurveRebin(object):
         lc_binned = self.lc.rebin(dt_new)
         assert np.isclose(lc_binned.dt, dt_new)
         counts_test = np.zeros_like(lc_binned.time) + \
-            self.lc.counts[0]*dt_new/self.lc.dt
+                      self.lc.counts[0] * dt_new / self.lc.dt
         assert np.allclose(lc_binned.counts, counts_test)
 
     def test_rebin_even_factor(self):
@@ -960,7 +962,7 @@ class TestLightcurveRebin(object):
         lc_binned = self.lc.rebin(f=f)
         assert np.isclose(dt_new, f * self.lc.dt)
         counts_test = np.zeros_like(lc_binned.time) + \
-            self.lc.counts[0]*dt_new/self.lc.dt
+                      self.lc.counts[0] * dt_new / self.lc.dt
         assert np.allclose(lc_binned.counts, counts_test)
 
     def test_rebin_odd(self):
@@ -969,7 +971,7 @@ class TestLightcurveRebin(object):
         assert np.isclose(lc_binned.dt, dt_new)
 
         counts_test = np.zeros_like(lc_binned.time) + \
-            self.lc.counts[0]*dt_new/self.lc.dt
+                      self.lc.counts[0] * dt_new / self.lc.dt
         assert np.allclose(lc_binned.counts, counts_test)
 
     def test_rebin_odd_factor(self):
@@ -978,7 +980,7 @@ class TestLightcurveRebin(object):
         lc_binned = self.lc.rebin(f=f)
         assert np.isclose(dt_new, f * self.lc.dt)
         counts_test = np.zeros_like(lc_binned.time) + \
-            self.lc.counts[0]*dt_new/self.lc.dt
+                      self.lc.counts[0] * dt_new / self.lc.dt
         assert np.allclose(lc_binned.counts, counts_test)
 
     def rebin_several(self, dt):
@@ -1009,7 +1011,7 @@ class TestLightcurveRebin(object):
     def test_lc_baseline(self):
         times = np.arange(0, 100, 0.01)
         counts = np.random.normal(100, 0.1, len(times)) + \
-            0.001 * times
+                 0.001 * times
         gti = [[-0.005, 50.005], [59.005, 100.005]]
         good = create_gti_mask(times, gti)
         counts[np.logical_not(good)] = 0
@@ -1021,7 +1023,7 @@ class TestLightcurveRebin(object):
         times = np.arange(0, 100, 0.01)
         input_stdev = 0.1
         counts = np.random.normal(100, input_stdev, len(times)) + \
-            0.001 * times
+                 0.001 * times
         gti = [[-0.005, 50.005], [59.005, 100.005]]
         good = create_gti_mask(times, gti)
         counts[np.logical_not(good)] = 0
@@ -1033,7 +1035,7 @@ class TestLightcurveRebin(object):
         times = np.arange(0, 4, 1)
         input_stdev = 0.1
         counts = np.random.normal(100, input_stdev, len(times)) + \
-            0.001 * times
+                 0.001 * times
         gti = [[-0.005, 4.005]]
         lc = Lightcurve(times, counts, gti=gti)
         with pytest.warns(UserWarning) as record:
@@ -1090,3 +1092,29 @@ class TestLightcurveRebin(object):
         lc1 = Lightcurve(time, count1)
         lc2 = Lightcurve(time, count2)
         assert not lc1 == lc2
+
+    def test_to_lightkurve(self):
+        from stingray import sampledata
+        lc = sampledata.sample_data()
+        try:
+            lk = lc.to_lightkurve()
+            assert_allclose(lk.time, lc.time)
+            assert_allclose(lk.flux, lc.counts)
+            assert_allclose(lk.flux_err, lc.counts_err)
+        except ImportError:
+            # Requires lightkurve
+            pass
+
+    def test_from_lightkurve(self):
+        try:
+            from lightkurve import LightCurve
+
+            time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
+            lk = LightCurve(time, flux, flux_err, time_format="jd")
+            lc = Lightcurve.from_lightkurve(lk)
+            assert_allclose(lc.time, time)
+            assert_allclose(lc.counts, flux)
+            assert_allclose(lc.counts_err, flux_err)
+        except ImportError:
+            # Requires lightkurve
+            pass


### PR DESCRIPTION
This PR resolves #429. It includes
- `Lightcurve.to_lightkurve` and `Lightcurve.from_lightkurve` method
- their docstrings
- `test_to_lightkurve` and `test_from_lightkurve`

I found a spelling mistake in the docstring of `Lightkurve.LightCurve.to_stingray`. I'll create a PR to fix that too.