### PR TITLE
Normalizations in FAD + bug fix in absolute rms normalization

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1206,6 +1206,7 @@ class AveragedCrossspectrum(Crossspectrum):
     def coherence(self):
         """Averaged Coherence function.
 
+
         Coherence is defined in Vaughan and Nowak, 1996 [vaughan-1996].
         It is a Fourier frequency dependent measure of the linear correlation
         between time series measured simultaneously in two energy channels.
@@ -1243,10 +1244,13 @@ class AveragedCrossspectrum(Crossspectrum):
         unnorm_powers_avg_2 = self.pds2.power.real
 
         coh = num / (unnorm_powers_avg_1 * unnorm_powers_avg_2)
+        coh[~np.isfinite(coh)] = 0.0
 
         # Calculate uncertainty
         uncertainty = \
             (2 ** 0.5 * coh * (1 - coh)) / (np.abs(coh) * self.m ** 0.5)
+
+        uncertainty[coh == 0] = 0.0
 
         return (coh, uncertainty)
 
@@ -1265,7 +1269,11 @@ class AveragedCrossspectrum(Crossspectrum):
         """
         lag = super(AveragedCrossspectrum, self).time_lag()
         coh, uncert = self.coherence()
+
         dum = (1. - coh) / (2. * coh)
+
+        dum[coh == 0] = 0.0
+
         lag_err = np.sqrt(dum / self.m) / (2 * np.pi * self.freq)
 
         return lag, lag_err

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -56,9 +56,7 @@ def _averaged_cospectra_cdf(xcoord, n):
 
     for i, x in enumerate(xcoord):
         prefac_bottom1 = factorial(n - 1)
-        # print("x: " + str(x))
         for j in range(n):
-            # print("j: " + str(j))
             prefac_top = factorial(n - 1 + j)
             prefac_bottom2 = factorial(
                 n - 1 - j) * factorial(j)
@@ -67,15 +65,11 @@ def _averaged_cospectra_cdf(xcoord, n):
             prefac = prefac_top / (
             prefac_bottom1 * prefac_bottom2 * prefac_bottom3)
 
-            # print("prefac: " + str(prefac))
             gf = -j + n
 
-            # print("gamma_fac: " + str(gf))
             first_fac = scipy.special.gamma(gf)
-            # print("first_fac: " + str(first_fac))
             if x >= 0:
                 second_fac = scipy.special.gammaincc(gf, n * x) * first_fac
-                # print("second_fac: " + str(second_fac))
                 fac = 2.0 * first_fac - second_fac
             else:
                 fac = scipy.special.gammaincc(gf, -n * x) * first_fac
@@ -581,7 +575,7 @@ class Crossspectrum(object):
         actual_nphots = np.float64(np.sqrt(np.exp(log_nphots1 + log_nphots2)))
         actual_mean = np.sqrt(self.meancounts1 * self.meancounts2)
 
-        meanrate = np.sqrt((self.nphots1 * self.nphots2) / tseg)
+        meanrate = np.sqrt((self.nphots1 * self.nphots2)) / tseg
 
         assert actual_mean > 0.0, \
             "Mean count rate is <= 0. Something went wrong."

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -634,45 +634,8 @@ class Crossspectrum(object):
             'none' normalization, imaginary part is returned as well.
         """
 
-        # The "effective" counts/bin is the geometrical mean of the counts/bin
-        # of the two light curves. Same goes for counts/second in meanrate.
-
         return normalize_crossspectrum(unnorm_power, tseg, self.n, self.nphots1, self.nphots2, self.norm, self.power_type)
 
-#        log_nphots1 = np.log(self.nphots1)
-#        log_nphots2 = np.log(self.nphots2)
-#
-#        actual_nphots = np.float64(np.sqrt(np.exp(log_nphots1 + log_nphots2)))
-#        actual_mean = np.sqrt(self.meancounts1 * self.meancounts2)
-#
-#        meanrate = np.sqrt((self.nphots1 * self.nphots2)) / tseg
-#
-#        assert actual_mean > 0.0, \
-#            "Mean count rate is <= 0. Something went wrong."
-#
-#        if self.power_type == "all":
-#            c_num = unnorm_power
-#        elif self.power_type == "real":
-#            c_num = unnorm_power.real
-#        elif self.power_type == "absolute":
-#            c_num = np.absolute(unnorm_power)
-#        else:
-#            raise ValueError("`power_type` not recognized!")
-#
-#        if self.norm.lower() == 'leahy':
-#            power = c_num * 2. / actual_nphots
-#
-#        elif self.norm.lower() == 'frac':
-#            c = c_num / np.float(self.n ** 2.)
-#            power = c * 2. * tseg / (actual_mean ** 2.0)
-#
-#        elif self.norm.lower() == 'abs':
-#            power = c_num * 2. * meanrate / actual_nphots
-#
-#        elif self.norm.lower() == 'none':
-#            power = unnorm_power
-#        return power
-#
     def rebin_log(self, f=0.01):
         """
         Logarithmic rebin of the periodogram.

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -70,7 +70,6 @@ def normalize_crossspectrum(unnorm_power, tseg, nbins, nphots1, nphots2, norm="n
         raise ValueError("`power_type` not recognized!")
 
     if norm.lower() == 'leahy':
-        actual_nphots = np.float64(np.sqrt(np.exp(log_nphots1 + log_nphots2)))
         power = c_num * 2. / actual_nphots
 
     elif norm.lower() == 'frac':
@@ -92,6 +91,9 @@ def normalize_crossspectrum(unnorm_power, tseg, nbins, nphots1, nphots2, norm="n
 
     elif norm.lower() == 'none':
         power = unnorm_power
+
+    else:
+        raise ValueError("Value for `norm` not recognized.")
 
     return power
 

--- a/stingray/deadtime/fad.py
+++ b/stingray/deadtime/fad.py
@@ -20,8 +20,10 @@ def _get_fourier_intv(lc, start_ind, end_ind):
     ----------
     lc : a :class:`Lightcurve` object
         Input light curve
+
     start_ind : int
         Start index of the light curve chunk
+
     end_ind : int
         End index of the light curve chunk
 
@@ -29,23 +31,33 @@ def _get_fourier_intv(lc, start_ind, end_ind):
     -------
     freq : array of floats
         Frequencies of the Fourier transform
+
     fft : array of complex numbers
         The Fourier transform
+   
     nph : int
         Number of photons in the interval of the light curve
+
+    nbins : int
+        Number of bins in the light curve segment
+
+    meancounts : float
+        The mean counts/bin in the light curve    
     """
     time = lc.time[start_ind:end_ind]
     counts = lc.counts[start_ind:end_ind]
+    meancounts = np.mean(counts)
 
     fourier = scipy.fftpack.fft(counts)
 
     freq = scipy.fftpack.fftfreq(len(time), lc.dt)
     good = freq > 0
 
-    return freq[good], fourier[good], np.sum(counts)
+    nbins = len(time)
+    return freq[good], fourier[good], np.sum(counts), nbins,  meancounts
 
 
-def calculate_FAD_correction(lc1, lc2, segment_size, gti=None,
+def calculate_FAD_correction(lc1, lc2, segment_size, norm="none", gti=None,
                              plot=False, ax=None, smoothing_alg='gauss',
                              smoothing_length=None, verbose=False,
                              tolerance=0.05, strict=False, all_leahy=False,
@@ -77,6 +89,10 @@ def calculate_FAD_correction(lc1, lc2, segment_size, gti=None,
         segments, as the result gets better as one averages more and more
         segments.
 
+     norm: {``frac``, ``abs``, ``leahy``, ``none``}, default ``none``
+        The normalization of the (real part of the) cross spectrum.
+
+
     Other parameters
     ----------------
     plot : bool, default False
@@ -103,7 +119,7 @@ def calculate_FAD_correction(lc1, lc2, segment_size, gti=None,
     strict : bool, default False
         Decide what to do if the condition on tolerance is not met. If True,
         raise a ``RuntimeError``. If False, just throw a warning.
-    all_leahy : bool, default False
+    all_leahy : **deprecated** bool, default False
         Save all spectra in Leahy normalization. Otherwise, leave unnormalized.
     output_file : str, default None
         Name of an output file (any extension automatically recognized by
@@ -134,6 +150,10 @@ def calculate_FAD_correction(lc1, lc2, segment_size, gti=None,
     if gti is None:
         gti = cross_two_gtis(lc1.gti, lc2.gti)
 
+    if all_leahy:
+        warnings.warn("`all_leahy` is deprecated. Use `norm` instead! Setting `norm`=`leahy`.", DeprecationWarning)
+        norm="leahy"
+
     lc1.gti = gti
     lc2.gti = gti
     lc1.apply_gtis()
@@ -158,11 +178,11 @@ def calculate_FAD_correction(lc1, lc2, segment_size, gti=None,
             fig, ax = plt.subplots()
 
     for start_ind, end_ind in zip(start_inds, end_inds):
-        freq, f1, nph1 = _get_fourier_intv(lc1, start_ind, end_ind)
+        freq, f1, nph1, nbins1, mc1 = _get_fourier_intv(lc1, start_ind, end_ind)
         f1_leahy = f1 * np.sqrt(2 / nph1)
-        freq, f2, nph2 = _get_fourier_intv(lc2, start_ind, end_ind)
+        freq, f2, nph2, nbins2, mc2 = _get_fourier_intv(lc2, start_ind, end_ind)
         f2_leahy = f2 * np.sqrt(2 / nph2)
-        freq, ftot, nphtot = \
+        freq, ftot, nphtot, nbinstot, mctot = \
             _get_fourier_intv(summed_lc, start_ind, end_ind)
         ftot_leahy = ftot * np.sqrt(2 / nphtot)
         nph1_tot += nph1
@@ -181,10 +201,10 @@ def calculate_FAD_correction(lc1, lc2, segment_size, gti=None,
         if plot:
             ax.scatter(freq, fourier_diff, s=1)
 
-        if all_leahy:
-            f1 = f1_leahy
-            f2 = f2_leahy
-            ftot = ftot_leahy
+        #if all_leahy:
+        #    f1 = f1_leahy
+        #    f2 = f2_leahy
+        #    ftot = ftot_leahy
         p1 = (f1 * f1.conj()).real
         p1 = p1 / smooth_real * 2
         p2 = (f2 * f2.conj()).real
@@ -195,15 +215,46 @@ def calculate_FAD_correction(lc1, lc2, segment_size, gti=None,
         c = (f2 * f1.conj()).real
         c = c / smooth_real * 2
 
+        if norm == "none":
+            power1 = p1
+            power2 = p2
+            power_tot = pt
+            cs_power = c
+
+        elif norm == "leahy":
+            power1 = p1 * 2. / nph1
+            power2 = p2 * 2. / nph2 
+            power_tot = pt * 2. / nphtot
+            cs_power = c * 2. / np.sqrt(nph1 * nph2)
+
+        elif norm == "frac":
+            actual_mean = np.sqrt(mc1 * mc2)
+            power1 = p1 * 2. * segment_size / (np.float(nbins1**2.) * (mc1 ** 2.))
+            power2 = p2 * 2. * segment_size / (np.float(nbins1**2.) * (mc2 ** 2.))
+            power_tot = pt * 2. * segment_size / (np.float(nbins1**2.) * (mctot ** 2.))
+            cs_power = c * 2. * segment_size / (np.float(nbins1**2.) * (actual_mean ** 2.))
+
+        elif norm == "abs":
+            meanrate = np.sqrt((nph1 * nph2) / segment_size)
+            actual_nphots = np.sqrt(np.exp((np.log(nph1) + np.log(nph2))))
+
+            power1 = p1 * 2. / segment_size
+            power2 = p2 * 2. / segment_size
+            power_tot = pt * 2. / segment_size
+            cs_power = c * 2. * meanrate / actual_nphots
+
+        else: 
+            raise ValueError("Value for `norm` keyword not recognized!")  
+
         if n == 0 and plot:
             ax.plot(freq, smooth_real, zorder=10, lw=3)
             ax.plot(freq, f1_leahy, zorder=5, lw=1)
             ax.plot(freq, f2_leahy, zorder=5, lw=1)
 
-        ptot += pt
-        pds1 += p1
-        pds2 += p2
-        cs += c
+        ptot += power_tot
+        pds1 += power1
+        pds2 += power2
+        cs += cs_power
         average_diff += fourier_diff / smooth_real ** 0.5 * np.sqrt(2)
         average_diff_uncorr += fourier_diff
         n += 1
@@ -245,6 +296,8 @@ def calculate_FAD_correction(lc1, lc2, segment_size, gti=None,
                            'selected. Exiting.')
 
     results = Table()
+
+    print("n: " + str(n))
 
     results['freq'] = freq
     results['pds1'] = pds1 / n

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -1284,10 +1284,13 @@ class PSDParEst(ParameterEstimation):
         """
         self.lpost = lpost
 
-        fit_res = ParameterEstimation.fit(self, self.lpost, t0, neg=True)
+        if cov is not None:
+            fit_res = ParameterEstimation.fit(self, self.lpost, t0, neg=True)
+            cov = fit_res.cov
+            t0 = fit_res.p_opt
 
-        res = ParameterEstimation.sample(self, self.lpost, fit_res.p_opt,
-                                         cov=fit_res.cov,
+        res = ParameterEstimation.sample(self, self.lpost, t0,
+                                         cov=cov,
                                          nwalkers=nwalkers,
                                          niter=niter, burnin=burnin,
                                          threads=threads,

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -1289,6 +1289,7 @@ class PSDParEst(ParameterEstimation):
             cov = fit_res.cov
             t0 = fit_res.p_opt
 
+
         res = ParameterEstimation.sample(self, self.lpost, t0,
                                          cov=cov,
                                          nwalkers=nwalkers,

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -1284,7 +1284,7 @@ class PSDParEst(ParameterEstimation):
         """
         self.lpost = lpost
 
-        if cov is not None:
+        if cov is None:   
             fit_res = ParameterEstimation.fit(self, self.lpost, t0, neg=True)
             cov = fit_res.cov
             t0 = fit_res.p_opt

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import scipy.special
 from stingray import Lightcurve, AveragedPowerspectrum
 from stingray import Crossspectrum, AveragedCrossspectrum, coherence, time_lag
-from stingray.crossspectrum import  cospectra_pvalue
+from stingray.crossspectrum import  cospectra_pvalue, normalize_crossspectrum
 from ..simulator.simulator import Simulator
 from stingray import StingrayError
 from ..simulator.simulator import Simulator
@@ -205,6 +205,59 @@ class TestCoherence(object):
 
         np.testing.assert_almost_equal(np.mean(coh).real, 1.0)
 
+
+
+class TestNormalization(object):
+
+    def setup_class(self):
+        tstart = 0.0
+        self.tseg = 10.0
+        dt = 0.0001
+
+        time = np.arange(tstart + 0.5 * dt, self.tseg + 0.5 * dt, dt)
+
+        np.random.seed(100)
+        counts1 = np.random.poisson(0.01, size=time.shape[0])
+        self.lc1 = Lightcurve(time, counts1, gti=[[tstart, self.tseg]], dt=dt)
+        self.rate1 = 100.  # mean count rate (counts/sec) of light curve 1
+
+        with pytest.warns(UserWarning) as record:
+            self.cs = Crossspectrum(self.lc1, self.lc1, norm="none")
+
+    def test_norm_abs(self):
+        # Testing for a power spectrum of lc1
+        power = normalize_crossspectrum(self.cs.power, self.lc1.tseg, self.lc1.n,
+                                        self.cs.nphots1, self.cs.nphots2, 
+                                        norm="abs")
+
+        abs_noise = 2. * self.rate1  # expected Poisson noise level
+        assert np.isclose(np.mean(power[1:]), abs_noise, rtol=0.001)
+
+    def test_norm_leahy(self):
+
+        power = normalize_crossspectrum(self.cs.power, self.lc1.tseg, self.lc1.n,
+                                        self.cs.nphots1, self.cs.nphots2, 
+                                        norm="leahy")
+
+        leahy_noise = 2.0  # expected Poisson noise level
+        assert np.isclose(np.mean(power[1:]), leahy_noise, rtol=0.02)
+
+    def test_norm_frac(self):
+        power = normalize_crossspectrum(self.cs.power, self.lc1.tseg, self.lc1.n,
+                                        self.cs.nphots1, self.cs.nphots2, 
+                                        norm="frac")
+
+        norm = 2. / self.rate1
+        assert np.isclose(np.mean(power[1:]), norm, rtol=0.1)
+
+    def test_failure_when_normalization_not_recognized(self):
+        with pytest.raises(ValueError):
+            power = normalize_crossspectrum(self.cs.power, self.lc1.tseg, self.lc1.n,
+                                            self.cs.nphots1, self.cs.nphots2,
+                                            norm="wrong")
+
+
+
 class TestCrossspectrum(object):
 
     def setup_class(self):
@@ -322,7 +375,6 @@ class TestCrossspectrum(object):
         assert len(cs.power) == 4999
         assert cs.norm == 'abs'
         abs_noise = 2. * self.rate1  # expected Poisson noise level
-        print(np.mean(cs.power), abs_noise)
         assert np.isclose(np.mean(cs.power[1:]), abs_noise)
 
     def test_norm_leahy(self):
@@ -331,7 +383,6 @@ class TestCrossspectrum(object):
         assert len(cs.power) == 4999
         assert cs.norm == 'leahy'
         leahy_noise = 2.0  # expected Poisson noise level
-        print(np.mean(cs.power), leahy_noise)
         assert np.isclose(np.mean(cs.power[1:]), leahy_noise, rtol=0.02)
 
     def test_norm_frac(self):
@@ -340,7 +391,7 @@ class TestCrossspectrum(object):
         assert len(cs.power) == 4999
         assert cs.norm == 'frac'
         norm = 2. / self.rate1
-        assert np.isclose(np.mean(cs.power[1:]), norm, rtol=0.1)
+        assert np.isclose(np.mean(cs.power[1:]), norm, rtol=0.2)
 
     def test_norm_abs(self):
         with pytest.warns(UserWarning) as record:

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -323,7 +323,7 @@ class TestCrossspectrum(object):
         assert cs.norm == 'abs'
         abs_noise = 2. * self.rate1  # expected Poisson noise level
         print(np.mean(cs.power), abs_noise)
-        assert np.isclose(np.mean(cs.power[1:]), abs_noise, atol=30)
+        assert np.isclose(np.mean(cs.power[1:]), abs_noise)
 
     def test_norm_leahy(self):
         with pytest.warns(UserWarning) as record:
@@ -332,13 +332,15 @@ class TestCrossspectrum(object):
         assert cs.norm == 'leahy'
         leahy_noise = 2.0  # expected Poisson noise level
         print(np.mean(cs.power), leahy_noise)
-        assert np.isclose(np.mean(cs.power[1:]), leahy_noise, atol=0.2)
+        assert np.isclose(np.mean(cs.power[1:]), leahy_noise, rtol=0.02)
 
     def test_norm_frac(self):
         with pytest.warns(UserWarning) as record:
-            cs = Crossspectrum(self.lc1, self.lc2, norm='frac')
+            cs = Crossspectrum(self.lc1, self.lc1, norm='frac')
         assert len(cs.power) == 4999
         assert cs.norm == 'frac'
+        norm = 2. / self.rate1
+        assert np.isclose(np.mean(cs.power[1:]), norm, rtol=0.1)
 
     def test_norm_abs(self):
         with pytest.warns(UserWarning) as record:

--- a/stingray/varenergyspectrum.py
+++ b/stingray/varenergyspectrum.py
@@ -411,6 +411,7 @@ class LagEnergySpectrum(VarEnergySpectrum):
                 lag, lag_err = xspect.time_lag()
                 good_lag, good_lag_err = lag[good], lag_err[good]
                 coh, coh_err = xspect.coherence()
+
                 lag_spec[i] = np.mean(good_lag)
                 coh_check = coh > 1.2 / (1 + 0.2 * xspect.m)
                 if not np.all(coh_check[good]):


### PR DESCRIPTION
In the course of implementing normalizations for the FAD, I discovered a bug in the method that calculates normalizations: ```meanrate = np.sqrt((self.nphots1 * self.nphots2) / tseg)``` (wrong!) is not the same as ```meanrate = np.sqrt((self.nphots1 * self.nphots2)) / tseg```. 

The latter leads to a normalization where the PSD of white noise corresponds to 2 * the mean count rate, which I think should be right?

After fixing that, I gave `calculate_FAD_correction` the same `norm` keyword that `Crossspectrum` and `Powerspectrum` have, and normalized the Fourier products for each segment after deadtime correction.