### PR TITLE
Fix binning of complex64

### DIFF
--- a/stingray/deadtime/fad.py
+++ b/stingray/deadtime/fad.py
@@ -13,6 +13,9 @@ from ..powerspectrum import AveragedPowerspectrum
 from ..gti import cross_two_gtis, bin_intervals_from_gtis
 
 
+__all__ = ["calculate_FAD_correction", "get_periodograms_from_FAD_results"]
+
+
 def _get_fourier_intv(lc, start_ind, end_ind):
     """Calculate the Fourier transform of a light curve chunk.
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -206,12 +206,13 @@ class TestAveragedCrossspectrumEvents(object):
     def test_rebin_log_returns_complex_values(self):
         # For now, just verify that it doesn't crash
         new_cs = self.acs.rebin_log(f=0.1)
-        assert isinstance(new_cs.power[0], np.complex)
+        assert np.iscomplexobj(new_cs.power[0])
 
     def test_rebin_log_returns_complex_errors(self):
         # For now, just verify that it doesn't crash
+
         new_cs = self.acs.rebin_log(f=0.1)
-        assert isinstance(new_cs.power_err[0], np.complex)
+        assert np.iscomplexobj(new_cs.power_err[0])
 
 
 class TestCoherenceFunction(object):
@@ -850,13 +851,13 @@ class TestAveragedCrossspectrum(object):
         # For now, just verify that it doesn't crash
         with warnings.catch_warnings(record=True) as w:
             new_cs = self.cs.rebin_log(f=0.1)
-        assert isinstance(new_cs.power[0], np.complex)
+        assert np.iscomplexobj(new_cs.power[0])
 
     def test_rebin_log_returns_complex_errors(self):
         # For now, just verify that it doesn't crash
         with warnings.catch_warnings(record=True) as w:
             new_cs = self.cs.rebin_log(f=0.1)
-        assert isinstance(new_cs.power_err[0], np.complex)
+        assert np.iscomplexobj(new_cs.power_err[0])
 
     def test_timelag(self):
         dt = 0.1

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -145,7 +145,7 @@ class TestRebinDataLog(object):
         re = np.arange(self.xmin, self.xmax, self.dx)
         im = np.arange(self.xmin, self.xmax, self.dx)
 
-        y = np.zeros(re.shape[0], dtype=np.complex)
+        y = np.zeros(re.shape[0], dtype=np.complex64)
         yerr = np.zeros(re.shape[0], dtype=np.complex)
 
         for k, (r, i) in enumerate(zip(re, im)):
@@ -157,10 +157,23 @@ class TestRebinDataLog(object):
         for i in range(self.true_values.shape[0]):
             real_binned[i] = self.true_values[i] + self.true_values[i] * 1j
 
-        _, biny, _, _ = utils.rebin_data_log(self.x, y, self.f, y_err=yerr,
-                                             dx=self.dx)
+        _, _, binyerr_real, _ = \
+            utils.rebin_data_log(self.x, y.real, self.f, y_err=yerr.real,
+                                 dx=self.dx)
+        _, biny, binyerr, _ = \
+            utils.rebin_data_log(self.x, y, self.f, y_err=yerr,
+                                 dx=self.dx)
 
+        assert np.iscomplexobj(biny)
+        assert np.iscomplexobj(binyerr)
         assert np.allclose(biny, real_binned)
+        assert np.allclose(binyerr, binyerr_real + 1.j * binyerr_real)
+
+    def test_return_float_with_floats(self):
+        _, biny, binyerr, _ = utils.rebin_data_log(
+            self.x, self.y, self.f, y_err=self.y_err, dx=self.dx)
+        assert not np.iscomplexobj(biny)
+        assert not np.iscomplexobj(binyerr)
 
 
 class TestUtils(object):

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -306,7 +306,7 @@ def rebin_data_log(x, y, f, y_err=None, dx=None):
         x.astype(np.double), real_err.astype(np.double),
         statistic=_root_squared_mean, bins=binx)
 
-    if isinstance(y[0], np.complex):
+    if np.iscomplexobj(y):
         imag = y.imag
         biny_imag, bin_edges, binno = scipy.stats.binned_statistic(
             x.astype(np.double), imag.astype(np.double),
@@ -314,7 +314,7 @@ def rebin_data_log(x, y, f, y_err=None, dx=None):
 
         biny = biny + 1j * biny_imag
 
-    if isinstance(y_err[0], np.complex):
+    if np.iscomplexobj(y_err):
         imag_err = y_err.imag
 
         biny_err_imag, bin_edges, binno = scipy.stats.binned_statistic(


### PR DESCRIPTION
Thanks to an email bug report by Tanuman Ghosh, I realized that we were not testing correctly for complex numbers in `rebin_data_log`. `isinstance(y, np.complex)` was in fact returning `False` for `np.complex64` objects.
This PR fixes this problem. Should be straightforward to review.