### PR TITLE
Fix deprecated use of Iterable

### DIFF
--- a/stingray/covariancespectrum.py
+++ b/stingray/covariancespectrum.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import collections
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -419,7 +419,7 @@ class Covariancespectrum(object):
         """Return std calculated for the possible types of `std`"""
         if self.std is None:
             std = np.mean(lc)**0.5
-        elif isinstance(self.std, collections.Iterable):
+        elif isinstance(self.std, Iterable):
             std = np.mean(self.std)  # Iterable of numbers
         else:  # Single float number
             std = self.std

--- a/stingray/deadtime/fad.py
+++ b/stingray/deadtime/fad.py
@@ -13,6 +13,9 @@ from ..powerspectrum import AveragedPowerspectrum
 from ..gti import cross_two_gtis, bin_intervals_from_gtis
 
 
+__all__ = ["calculate_FAD_correction", "get_periodograms_from_FAD_results"]
+
+
 def _get_fourier_intv(lc, start_ind, end_ind):
     """Calculate the Fourier transform of a light curve chunk.
 

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -3,7 +3,7 @@
 import numpy as np
 import logging
 import warnings
-import collections
+from collections.abc import Iterable
 import copy
 
 from astropy.io import fits
@@ -251,7 +251,7 @@ def create_gti_mask(time, gtis, safe_interval=None, min_length=0,
     gti_mask = np.zeros(len(gtis), dtype=bool)
 
     if safe_interval is not None:
-        if not isinstance(safe_interval, collections.Iterable):
+        if not isinstance(safe_interval, Iterable):
             safe_interval = np.array([safe_interval, safe_interval])
         # These are the gtis that will be returned (filtered!). They are only
         # modified by the safe intervals
@@ -334,7 +334,7 @@ def create_gti_mask_complete(time, gtis, safe_interval=0, min_length=0,
 
     if safe_interval is None:
         safe_interval = [0, 0]
-    elif not isinstance(safe_interval, collections.Iterable):
+    elif not isinstance(safe_interval, Iterable):
         safe_interval = [safe_interval, safe_interval]
 
     newgtis = np.zeros_like(gtis)
@@ -393,7 +393,7 @@ def create_gti_from_condition(time, condition,
 
     idxs = contiguous_regions(condition)
 
-    if not isinstance(safe_interval, collections.Iterable):
+    if not isinstance(safe_interval, Iterable):
         safe_interval = [safe_interval, safe_interval]
 
     dt = assign_value_if_none(dt,

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -1,6 +1,6 @@
 
 
-import collections
+from collections.abc import Iterable
 import logging
 import math
 import numpy as np
@@ -276,7 +276,7 @@ def ref_mjd(fits_file, hdu=1):
         the reference MJD
     """
 
-    if isinstance(fits_file, collections.Iterable) and\
+    if isinstance(fits_file, Iterable) and\
             not is_string(fits_file):  # pragma: no cover
         fits_file = fits_file[0]
         logging.info("opening %s" % fits_file)
@@ -346,7 +346,7 @@ def split_numbers(number):
         Second part of high precision number
     """
 
-    if isinstance(number, collections.Iterable):
+    if isinstance(number, Iterable):
         mods = [math.modf(n) for n in number]
         number_F = [f for f, _ in mods]
         number_I = [i for _, i in mods]

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -3,7 +3,7 @@ Basic pulsar-related functions and statistics.
 """
 
 import numpy as np
-import collections
+from collections.abc import Iterable
 import warnings
 from scipy.optimize import minimize, basinhopping
 
@@ -243,7 +243,7 @@ def fold_events(times, *frequency_derivatives, **opts):
     ref_time = _default_value_if_no_key(opts, "ref_time", 0)
     expocorr = _default_value_if_no_key(opts, "expocorr", False)
 
-    if not isinstance(weights, collections.Iterable):
+    if not isinstance(weights, Iterable):
         weights *= np.ones(len(times))
 
     gtis = gtis - ref_time

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-import collections
+from collections.abc import Iterable
 from .pulsar import profile_stat, fold_events, z_n, pulse_phase
 from ..utils import jit, HAS_NUMBA
 from ..utils import contiguous_regions
@@ -44,7 +44,7 @@ def _folding_search(stat_func, times, frequencies, segment_size=5000,
                 if use_times:
                     kwargs_copy = {}
                     for key in kwargs.keys():
-                        if isinstance(kwargs[key], collections.Iterable) and \
+                        if isinstance(kwargs[key], Iterable) and \
                                 len(kwargs[key]) == len(times):
 
                             kwargs_copy[key] = kwargs[key][good]
@@ -133,7 +133,7 @@ def epoch_folding_search(times, frequencies, nbin=128, segment_size=5000,
     stats : array-like
         the epoch folding statistics corresponding to each frequency bin.
     """
-    if expocorr or not HAS_NUMBA or isinstance(weights, collections.Iterable):
+    if expocorr or not HAS_NUMBA or isinstance(weights, Iterable):
         if expocorr and gti is None:
             raise ValueError('To calculate exposure correction, you need to'
                              ' specify the GTIs')
@@ -210,7 +210,7 @@ def z_n_search(times, frequencies, nharm=4, nbin=128, segment_size=5000,
         the Z^2_n statistics corresponding to each frequency bin.
     """
     phase = np.arange(0, 1, 1 / nbin)
-    if expocorr or not HAS_NUMBA or isinstance(weights, collections.Iterable):
+    if expocorr or not HAS_NUMBA or isinstance(weights, Iterable):
         if expocorr and gti is None:
             raise ValueError('To calculate exposure correction, you need to'
                              ' specify the GTIs')
@@ -486,7 +486,7 @@ def phaseogram(times, f, nph=128, nt=32, ph0=0, mjdref=None, fdot=0, fddot=0,
     allts = \
         np.concatenate([times, times]).astype('float64')
 
-    if weights is not None and isinstance(weights, collections.Iterable):
+    if weights is not None and isinstance(weights, Iterable):
         if len(weights) != len(times):
             raise ValueError('The length of weights must match the length of '
                              'times')

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -1,6 +1,6 @@
 
 import sys
-import collections
+from collections.abc import Iterable
 import numbers
 from six import string_types
 
@@ -440,7 +440,7 @@ def is_iterable(var):
     is_iter : bool
         Returns ``True`` if ``var`` is an ``Iterable``, ``False`` otherwise
     """
-    return isinstance(var, collections.Iterable)
+    return isinstance(var, Iterable)
 
 
 def order_list_of_arrays(data, order):


### PR DESCRIPTION
Change all imports of `Iterable` from `collections` (deprecated) into imports from `collections.abc`

Resolve #475 