### PR TITLE
Optimize FFT

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -12,12 +12,7 @@ try:
 except ImportError:
     from scipy.special import factorial
 
-try:
-    from pyfftw.builders import fft
-    from pyfftw.interfaces.scipy_fftpack import fftfreq
-except ImportError:
-    warnings.warn("Using standard scipy fft")
-    from scipy.fftpack import fft, fftfreq
+from scipy.fftpack import fft, fftfreq
 
 
 from stingray.lightcurve import Lightcurve
@@ -582,7 +577,7 @@ class Crossspectrum(object):
         fourier_2 = fft(lc2.counts)  # do Fourier transform 2
 
         freqs = fftfreq(lc1.n, lc1.dt)
-        cross = np.multiply(fourier_1()[freqs > 0], np.conj(fourier_2()[freqs > 0]))
+        cross = np.multiply(fourier_1[freqs > 0], np.conj(fourier_2[freqs > 0]))
 
         return freqs[freqs > 0], cross
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 from collections.abc import Iterable, Iterator
 import numpy as np
@@ -39,7 +38,6 @@ __all__ = ["Crossspectrum", "AveragedCrossspectrum",
            "coherence", "time_lag", "cospectra_pvalue",
             "normalize_crossspectrum"]
 
-CPU_COUNT = os.cpu_count()
 
 def normalize_crossspectrum(unnorm_power, tseg, nbins, nphots1, nphots2, norm="none", power_type="real"):
     """
@@ -580,13 +578,11 @@ class Crossspectrum(object):
             The squared absolute value of the Fourier amplitudes
 
         """
-        fourier_1 = fft(lc1.counts,
-                        threads=int(CPU_COUNT / 4))  # do Fourier transform 1
-        fourier_2 = fft(lc2.counts,
-                        int(CPU_COUNT / 4))  # do Fourier transform 2
+        fourier_1 = fft(lc1.counts)  # do Fourier transform 1
+        fourier_2 = fft(lc2.counts)  # do Fourier transform 2
 
         freqs = fftfreq(lc1.n, lc1.dt)
-        cross = np.multiply(fourier_1[freqs > 0], np.conj(fourier_2[freqs > 0]))
+        cross = np.multiply(fourier_1()[freqs > 0], np.conj(fourier_2()[freqs > 0]))
 
         return freqs[freqs > 0], cross
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 import scipy
-import scipy.fftpack
 import scipy.optimize
 import scipy.stats
 


### PR DESCRIPTION
I tested the code extensively for many AveragedCrossspectrum sizes, but **SURPRISINGLY!!** the normal `scipy.fftpack` is faster than the `pyfftw.builders` by a margin of 10 seconds for an AveragedCrossspectrum of size 10**7 making it ~22% faster than `pyfftw.builders` and ~26.5% faster than `pyfftw.interfaces.scipy_fftpack`

![results](https://user-images.githubusercontent.com/39396816/91240568-fd8ce480-e75f-11ea-817b-d906d66bf9cc.jpg)
