### PR TITLE
Fix dynpowspec

### DIFF
--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1,3 +1,4 @@
+import copy
 import warnings
 
 import numpy as np
@@ -576,6 +577,7 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
             This keyword argument sets whether the counts in the new bins
             should be summed or averaged.
         """
+        new_dynspec_object = copy.deepcopy(self)
         dynspec_new = []
         for data in self.dyn_ps.T:
             freq_new, bin_counts, bin_err, _ = \
@@ -583,9 +585,10 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
                                  method=method)
             dynspec_new.append(bin_counts)
 
-        self.freq = freq_new
-        self.dyn_ps = np.array(dynspec_new).T
-        self.df = df_new
+        new_dynspec_object.freq = freq_new
+        new_dynspec_object.dyn_ps = np.array(dynspec_new).T
+        new_dynspec_object.df = df_new
+        return new_dynspec_object
 
     def trace_maximum(self, min_freq=None, max_freq=None, sigmaclip=False):
         """
@@ -648,10 +651,11 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         dynspec_new: numpy.ndarray
             New rebinned Dynamical Power Spectrum.
         """
-
         if dt_new < self.dt:
             raise ValueError("New time resolution must be larger than "
                              "old time resolution!")
+
+        new_dynspec_object = copy.deepcopy(self)
 
         dynspec_new = []
         for data in self.dyn_ps:
@@ -660,6 +664,7 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
                                  method=method)
             dynspec_new.append(bin_counts)
 
-        self.time = time_new
-        self.dyn_ps = np.array(dynspec_new)
-        self.dt = dt_new
+        new_dynspec_object.time = time_new
+        new_dynspec_object.dyn_ps = np.array(dynspec_new)
+        new_dynspec_object.dt = dt_new
+        return new_dynspec_object

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -590,7 +590,7 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         new_dynspec_object.df = df_new
         return new_dynspec_object
 
-    def trace_maximum(self, min_freq=None, max_freq=None, sigmaclip=False):
+    def trace_maximum(self, min_freq=None, max_freq=None):
         """
         Return the indices of the maximum powers in each segment :class:`Powerspectrum`
         between specified frequencies.

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -519,12 +519,15 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
 
     def _make_matrix(self, lc):
         """
-        Create a matrix of powers for each time step (rows) and each frequency step (columns).
+        Create a matrix of powers for each time step and each frequency step.
+
+        Time increases with row index, frequency with column index.
 
         Parameters
         ----------
         lc : :class:`Lightcurve` object
-            The :class:`Lightcurve` object from which to generate the dynamical power spectrum
+            The :class:`Lightcurve` object from which to generate the dynamical
+            power spectrum
         """
         ps_all, _ = AveragedPowerspectrum._make_segment_spectrum(
             self, lc, self.segment_size)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -216,6 +216,12 @@ class TestPowerspectrum(object):
         std_lc = np.var(self.lc.counts) / np.mean(self.lc.counts) ** 2
         assert np.isclose(ps_int, std_lc, atol=0.01, rtol=0.01)
 
+    def test_compute_rms_wrong_norm(self):
+        ps = Powerspectrum(self.lc)
+        ps.norm = 'gibberish'
+        with pytest.raises(TypeError):
+            ps.compute_rms(0, 10)
+
     def test_fractional_rms_in_frac_norm_is_consistent(self):
         time = np.arange(0, 100, 1) + 0.5
 

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -673,12 +673,14 @@ class TestDynamicalPowerspectrum(object):
     def setup_class(cls):
         # generate timestamps
         timestamps = np.linspace(1, 100, 10000)
+        dt = np.median(np.diff(timestamps))
         freq = 25 + 1.2 * np.sin(2 * np.pi * timestamps / 130)
         # variability signal with drifiting frequency
         vari = 25 * np.sin(2 * np.pi * freq * timestamps)
         signal = vari + 50
         # create a lightcurve
-        lc = Lightcurve(timestamps, signal, err_dist='gauss')
+        lc = Lightcurve(timestamps, signal, err_dist='gauss',
+                        dt=dt, gti=[[1 - dt/2, 100 + dt/2]])
         cls.lc = lc
 
         # Simple lc to demonstrate rebinning of dyn ps

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -742,10 +742,10 @@ class TestDynamicalPowerspectrum(object):
         rebin_time = np.array([ 2.,  6., 10.])
         rebin_dps = np.array([[0.7962963 , 1.16402116, 0.28571429]])
         dps = DynamicalPowerspectrum(self.lc_test, segment_size=segment_size)
-        dps.rebin_time(dt_new=dt_new)
-        assert np.allclose(dps.time, rebin_time)
-        assert np.allclose(dps.dyn_ps, rebin_dps)
-        assert np.isclose(dps.dt, dt_new)
+        new_dps = dps.rebin_time(dt_new=dt_new)
+        assert np.allclose(new_dps.time, rebin_time)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.dt, dt_new)
 
     def test_rebin_frequency_default_method(self):
         segment_size = 50
@@ -758,10 +758,10 @@ class TestDynamicalPowerspectrum(object):
                               [5.77470465e-05],
                               [1.76918128e-05]])
         dps = DynamicalPowerspectrum(self.lc, segment_size=segment_size)
-        dps.rebin_frequency(df_new=df_new)
-        assert np.allclose(dps.freq, rebin_freq)
-        assert np.allclose(dps.dyn_ps, rebin_dps)
-        assert np.isclose(dps.df, df_new)
+        new_dps = dps.rebin_frequency(df_new=df_new)
+        assert np.allclose(new_dps.freq, rebin_freq)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.df, df_new)
 
     def test_rebin_time_mean_method(self):
         segment_size = 3
@@ -769,10 +769,10 @@ class TestDynamicalPowerspectrum(object):
         rebin_time = np.array([ 2.,  6., 10.])
         rebin_dps = np.array([[0.59722222, 0.87301587, 0.21428571]])
         dps = DynamicalPowerspectrum(self.lc_test, segment_size=segment_size)
-        dps.rebin_time(dt_new=dt_new, method='mean')
-        assert np.allclose(dps.time, rebin_time)
-        assert np.allclose(dps.dyn_ps, rebin_dps)
-        assert np.isclose(dps.dt, dt_new)
+        new_dps = dps.rebin_time(dt_new=dt_new, method='mean')
+        assert np.allclose(new_dps.time, rebin_time)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.dt, dt_new)
 
     def test_rebin_frequency_mean_method(self):
         segment_size = 50
@@ -785,10 +785,10 @@ class TestDynamicalPowerspectrum(object):
                               [1.15516968e-07],
                               [3.53906336e-08]])
         dps = DynamicalPowerspectrum(self.lc, segment_size=segment_size)
-        dps.rebin_frequency(df_new=df_new, method="mean")
-        assert np.allclose(dps.freq, rebin_freq)
-        assert np.allclose(dps.dyn_ps, rebin_dps)
-        assert np.isclose(dps.df, df_new)
+        new_dps = dps.rebin_frequency(df_new=df_new, method="mean")
+        assert np.allclose(new_dps.freq, rebin_freq)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.df, df_new)
 
     def test_rebin_time_average_method(self):
         segment_size = 3
@@ -796,10 +796,10 @@ class TestDynamicalPowerspectrum(object):
         rebin_time = np.array([ 2.,  6., 10.])
         rebin_dps = np.array([[0.59722222, 0.87301587, 0.21428571]])
         dps = DynamicalPowerspectrum(self.lc_test, segment_size=segment_size)
-        dps.rebin_time(dt_new=dt_new, method='average')
-        assert np.allclose(dps.time, rebin_time)
-        assert np.allclose(dps.dyn_ps, rebin_dps)
-        assert np.isclose(dps.dt, dt_new)
+        new_dps = dps.rebin_time(dt_new=dt_new, method='average')
+        assert np.allclose(new_dps.time, rebin_time)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.dt, dt_new)
 
     def test_rebin_frequency_average_method(self):
         segment_size = 50
@@ -812,7 +812,7 @@ class TestDynamicalPowerspectrum(object):
                               [1.15516968e-07],
                               [3.53906336e-08]])
         dps = DynamicalPowerspectrum(self.lc, segment_size=segment_size)
-        dps.rebin_frequency(df_new=df_new, method="average")
-        assert np.allclose(dps.freq, rebin_freq)
-        assert np.allclose(dps.dyn_ps, rebin_dps)
-        assert np.isclose(dps.df, df_new)
+        new_dps = dps.rebin_frequency(df_new=df_new, method="average")
+        assert np.allclose(new_dps.freq, rebin_freq)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.df, df_new)


### PR DESCRIPTION
Fixes all `DynamicalPowerspectrum`-related issues. In particular:

- `DynamicalPowerspectrum.rebin_*` functions return a new object instead of changing the object itself
- The `sigmaclip` is eliminated from `DynamicalPowerspectrum.trace_maximum`
- Tests now verify that Issue #419 cannot be reproduced (it was a GTI problem, solved in previous PRs).

resolve #364, resolve #365, close #419