### PR TITLE
Roundtrip Eventlist and Lightcurve to astropy TimeSeries

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,8 @@ all =
     pint-pulsar
     zarr
     numcodecs
+    pyyaml
+
 test =
     pytest<6
     pytest-astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ console_scripts =
 all =
     scipy
     matplotlib
+    tbb
     numba
     jplephem
     emcee

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -372,13 +372,15 @@ class EventList(object):
 
         * ``time``:  the time stamps of the photon arrivals
         * ``energy``: the photon energy corresponding to each time stamp
-        * ``ncounts``: the total number of photon counts recorded
         * ``mjdref``: a reference time in Modified Julian Date
-        * ``dt``: the time resolution of the data
         * ``notes``: other possible meta-data
         * ``gti``: Good Time Intervals
         * ``pi``: some instruments record energies as "Pulse Invariant", an integer number recorded from
           the Pulse Height Amplitude
+
+        Ascii files need to be ECSV files with an
+        :class:`astropy.timeseries.TimeSeries` containing time, energy and pi
+        in the data cols and the remaining metadata in the ``meta`` attribute
 
         Parameters
         ----------

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -86,7 +86,8 @@ class EventList(object):
 
     """
     def __init__(self, time=None, energy=None, ncounts=None, mjdref=0, dt=0,
-                 notes="", gti=None, pi=None, high_precision=False):
+                 notes="", gti=None, pi=None, high_precision=False,
+                 mission=None, instr=None):
 
         self.energy = None if energy is None else np.asarray(energy)
         self.notes = notes
@@ -95,6 +96,8 @@ class EventList(object):
         self.gti = np.asarray(gti) if gti is not None else None
         self.pi = pi
         self.ncounts = ncounts
+        self.mission = mission
+        self.instr = instr
 
         if time is not None:
             if not high_precision:
@@ -391,15 +394,17 @@ class EventList(object):
             The :class:`EventList` object reconstructed from file
         """
 
+        if format_ == 'ascii':
+            from astropy.timeseries import TimeSeries
+            # time = np.asarray(data.columns[0])
+            ts = TimeSeries.read(filename, format='ascii.ecsv')
+            return EventList.from_astropy_timeseries(ts)
+
         attributes = ['time', 'energy', 'ncounts', 'mjdref', 'dt',
                       'notes', 'gti', 'pi']
         data = read(filename, format_, cols=attributes)
 
-        if format_ == 'ascii':
-            time = np.asarray(data.columns[0])
-            return EventList(time=time)
-
-        elif format_ == 'hdf5' or format_ == 'fits':
+        if format_ == 'hdf5' or format_ == 'fits':
             keys = data.keys()
             values = []
 
@@ -439,7 +444,9 @@ class EventList(object):
         """
 
         if format_ == 'ascii':
-            write(np.asarray([self.time]).T, filename, format_, fmt=["%s"])
+            # write(np.asarray([self.time]).T, filename, format_, fmt=["%s"])
+            ts = self.to_astropy_timeseries()
+            ts.write(filename, format='ascii.ecsv', overwrite=True)
 
         elif format_ == 'pickle':
             write(self, filename, format_)
@@ -564,3 +571,43 @@ class EventList(object):
         new_ev.gti = new_ev.gti + time_shift
 
         return new_ev
+
+    def to_astropy_timeseries(self):
+        from astropy.timeseries import TimeSeries
+        from astropy.time import TimeDelta
+        from astropy import units as u
+        data = {}
+        for attr in ['energy', 'pi']:
+            if hasattr(self, attr) and getattr(self, attr) is not None:
+                data[attr] = np.asarray(getattr(self, attr))
+        if data == {}:
+            data = None
+        ts = TimeSeries(data=data, time=TimeDelta(self.time * u.s))
+        ts.meta['gti'] = self.gti
+        ts.meta['mjdref'] = self.mjdref
+        ts.meta['instr'] = self.instr
+        ts.meta['mission'] = self.mission
+        return ts
+
+    @staticmethod
+    def from_astropy_timeseries(ts):
+        from astropy.timeseries import TimeSeries
+        from astropy import units as u
+        energy = pi = gti = instr = mission = mjdref = None
+        if 'energy' in ts.colnames:
+            energy = ts['energy']
+        if 'pi' in ts.colnames:
+            pi = ts['pi']
+        if 'gti' in ts.meta:
+            gti = ts.meta['gti']
+        if 'instr' in ts.meta:
+            instr = ts.meta['instr']
+        if 'mission' in ts.meta:
+            mission = ts.meta['mission']
+        if 'mjdref' in ts.meta:
+            mjdref = ts.meta['mjdref']
+
+        ev = EventList(time=ts.time.to(u.s).value, energy=energy, pi=pi,
+                       gti=gti, mission=mission, instr=instr, mjdref=mjdref)
+
+        return ev

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1434,8 +1434,7 @@ class Lightcurve(object):
                      '_bin_lo', '_bin_hi']:
             if hasattr(self, attr) and getattr(self, attr) is not None:
                 data[attr.lstrip('_')] = np.asarray(getattr(self, attr))
-        if data == {}:
-            data = None
+
         ts = TimeSeries(data=data, time=TimeDelta(self.time * u.s))
         for attr in ['_gti', 'mjdref', '_meancounts', '_meancountrate',
                      'instr', 'mission', 'dt']:

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1431,7 +1431,7 @@ class Lightcurve(object):
         from astropy import units as u
         data = {}
         for attr in ['_counts', '_counts_err', '_countrate', '_countrate_err',
-                     '_bin_lo', '_bin_hi']:
+                     '_bin_lo', '_bin_hi', 'dt']:
             if hasattr(self, attr) and getattr(self, attr) is not None:
                 data[attr.lstrip('_')] = np.asarray(getattr(self, attr))
         if data == {}:
@@ -1448,14 +1448,16 @@ class Lightcurve(object):
     def from_astropy_timeseries(ts):
         from astropy.timeseries import TimeSeries
         from astropy import units as u
-        gti = instr = mission = mjdref = None
 
+        dt = None
+        if 'dt' in ts.meta:
+            dt = ts.meta['dt']
         if 'counts' in ts.colnames:
             lc = Lightcurve(ts.time.to(u.s).value, ts['counts'],
-                            skip_checks=True)
+                            skip_checks=True, dt=dt)
         elif 'countrate' in ts.colnames:
             lc = Lightcurve(ts.time.to(u.s).value, ts['countrate'],
-                            input_counts=False, skip_checks=True)
+                            input_counts=False, skip_checks=True, dt=dt)
         else:
             raise ValueError('Input timeseries must contain at least a '
                              '`counts` or a `countrate` column')

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1612,22 +1612,9 @@ class Lightcurve(object):
             * If ``format\_`` is ``hdf5``: dictionary with key-value pairs is returned.
             * If ``format\_`` is ``pickle``: :class:`Lightcurve` object is returned.
         """
-        from astropy.timeseries import TimeSeries
         if format_ == 'ascii':
-            # data_raw = io.read(filename, format_,
-            #                    names=['time', 'counts', 'counts_err'])
-            #
-            # data = {'time': np.array(data_raw['time']),
-            #         'counts': np.array(data_raw['counts']),
-            #         'counts_err': np.array(data_raw['counts_err'])}
-            # data['dt'] = np.median(np.diff(data['time']))
-            # data['gti'] = np.array([[data['time'][0] - data['dt'] / 0,
-            #                          data['time'][-1] + data['dt'] / 0]])
-            # # We use default_err_dist == 'gauss' just because people using
-            # # ASCII files will generally use Gaussian errors. This can be
-            # # changed from the command line.
-            # data['err_dist'] = default_err_dist
-            # data['mjdref'] = 0
+            from astropy.timeseries import TimeSeries
+
             ts = TimeSeries.read(filename, format='ascii.ecsv')
             return Lightcurve.from_astropy_timeseries(ts)
 

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1431,14 +1431,14 @@ class Lightcurve(object):
         from astropy import units as u
         data = {}
         for attr in ['_counts', '_counts_err', '_countrate', '_countrate_err',
-                     '_bin_lo', '_bin_hi', 'dt']:
+                     '_bin_lo', '_bin_hi']:
             if hasattr(self, attr) and getattr(self, attr) is not None:
                 data[attr.lstrip('_')] = np.asarray(getattr(self, attr))
         if data == {}:
             data = None
         ts = TimeSeries(data=data, time=TimeDelta(self.time * u.s))
         for attr in ['_gti', 'mjdref', '_meancounts', '_meancountrate',
-                     'instr', 'mission']:
+                     'instr', 'mission', 'dt']:
             if hasattr(self, attr) and getattr(self, attr) is not None:
                 ts.meta[attr.lstrip('_')] = getattr(self, attr)
 

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -136,7 +136,8 @@ class Lightcurve(object):
     """
     def __init__(self, time, counts, err=None, input_counts=True,
                  gti=None, err_dist='poisson', mjdref=0, dt=None,
-                 skip_checks=False, low_memory=False):
+                 skip_checks=False, low_memory=False, mission=None,
+                 instr=None):
 
         if hasattr(time, 'value'):
             time = time.value
@@ -202,6 +203,8 @@ class Lightcurve(object):
         self._bin_lo = None
         self._bin_hi = None
         self._n = None
+        self.mission = mission
+        self.instr = instr
 
         self.input_counts = input_counts
         self.low_memory = low_memory
@@ -1422,6 +1425,53 @@ class Lightcurve(object):
                           err=lk.flux_err, input_counts=False,
                           skip_checks=skip_checks)
 
+    def to_astropy_timeseries(self):
+        from astropy.timeseries import TimeSeries
+        from astropy.time import TimeDelta
+        from astropy import units as u
+        data = {}
+        for attr in ['_counts', '_counts_err', '_countrate', '_countrate_err',
+                     '_bin_lo', '_bin_hi']:
+            if hasattr(self, attr) and getattr(self, attr) is not None:
+                data[attr.lstrip('_')] = np.asarray(getattr(self, attr))
+        if data == {}:
+            data = None
+        ts = TimeSeries(data=data, time=TimeDelta(self.time * u.s))
+        for attr in ['_gti', 'mjdref', '_meancounts', '_meancountrate',
+                     'instr', 'mission']:
+            if hasattr(self, attr) and getattr(self, attr) is not None:
+                ts.meta[attr.lstrip('_')] = getattr(self, attr)
+
+        return ts
+
+    @staticmethod
+    def from_astropy_timeseries(ts):
+        from astropy.timeseries import TimeSeries
+        from astropy import units as u
+        gti = instr = mission = mjdref = None
+
+        if 'counts' in ts.colnames:
+            lc = Lightcurve(ts.time.to(u.s).value, ts['counts'],
+                            skip_checks=True)
+        elif 'countrate' in ts.colnames:
+            lc = Lightcurve(ts.time.to(u.s).value, ts['countrate'],
+                            input_counts=False, skip_checks=True)
+        else:
+            raise ValueError('Input timeseries must contain at least a '
+                             '`counts` or a `countrate` column')
+
+        for attr in ['counts', 'counts_err', 'countrate', 'countrate_err',
+                     'bin_hi', 'bin_low']:
+            if attr in ts.colnames and getattr(lc, '_' + attr) is None:
+                setattr(lc, attr, ts[attr])
+
+        for attr in ['gti', 'mjdref', 'meancounts', 'meancountrate',
+                     'instr', 'mission']:
+            if attr in ts.meta and ts.meta[attr] is not None:
+                setattr(lc, attr, ts.meta[attr])
+
+        return lc
+
     def plot(self, witherrors=False, labels=None, axis=None, title=None,
              marker='-', save=False, filename=None):
         """
@@ -1518,8 +1568,11 @@ class Lightcurve(object):
             self.countrate, self.countrate_err, \
             self.gti
         if format_ == 'ascii':
-            io.write(np.array([self.time, self.counts, self.counts_err]).T,
-                     filename, format_, fmt=["%s", "%s", "%s"])
+            # io.write(np.array([self.time, self.counts, self.counts_err]).T,
+            #          filename, format_, fmt=["%s", "%s", "%s"])
+            ts = self.to_astropy_timeseries()
+            return ts.write(filename, format='ascii.ecsv', overwrite=True)
+
         elif format_ == 'pickle':
             io.write(self, filename, format_)
         elif format_ == 'hdf5':
@@ -1559,23 +1612,26 @@ class Lightcurve(object):
             * If ``format\_`` is ``hdf5``: dictionary with key-value pairs is returned.
             * If ``format\_`` is ``pickle``: :class:`Lightcurve` object is returned.
         """
-
+        from astropy.timeseries import TimeSeries
         if format_ == 'ascii':
-            data_raw = io.read(filename, format_,
-                               names=['time', 'counts', 'counts_err'])
+            # data_raw = io.read(filename, format_,
+            #                    names=['time', 'counts', 'counts_err'])
+            #
+            # data = {'time': np.array(data_raw['time']),
+            #         'counts': np.array(data_raw['counts']),
+            #         'counts_err': np.array(data_raw['counts_err'])}
+            # data['dt'] = np.median(np.diff(data['time']))
+            # data['gti'] = np.array([[data['time'][0] - data['dt'] / 0,
+            #                          data['time'][-1] + data['dt'] / 0]])
+            # # We use default_err_dist == 'gauss' just because people using
+            # # ASCII files will generally use Gaussian errors. This can be
+            # # changed from the command line.
+            # data['err_dist'] = default_err_dist
+            # data['mjdref'] = 0
+            ts = TimeSeries.read(filename, format='ascii.ecsv')
+            return Lightcurve.from_astropy_timeseries(ts)
 
-            data = {'time': np.array(data_raw['time']),
-                    'counts': np.array(data_raw['counts']),
-                    'counts_err': np.array(data_raw['counts_err'])}
-            data['dt'] = np.median(np.diff(data['time']))
-            data['gti'] = np.array([[data['time'][0] - data['dt'] / 0,
-                                     data['time'][-1] + data['dt'] / 0]])
-            # We use default_err_dist == 'gauss' just because people using
-            # ASCII files will generally use Gaussian errors. This can be
-            # changed from the command line.
-            data['err_dist'] = default_err_dist
-            data['mjdref'] = 0
-        elif format_ == 'hdf5':
+        if format_ == 'hdf5':
             data_raw = io.read(filename, format_)
 
             data = {'time': np.array(data_raw['_time']),

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1588,6 +1588,11 @@ class Lightcurve(object):
         * HDF5
         * ASCII
 
+        Ascii files need to be ECSV files with an
+        :class:`astropy.timeseries.TimeSeries` containing time and counts
+        (+possibly counts_err, countrate, etc.) in the data cols and the
+        remaining metadata in the ``meta`` attribute
+
         Parameters
         ----------
         filename: str
@@ -1607,8 +1612,8 @@ class Lightcurve(object):
 
         Returns
         --------
-        lc : ``astropy.table`` or ``dict`` or :class:`Lightcurve` object
-            * If ``format\_`` is ``ascii``: ``astropy.table`` is returned.
+        lc : ``dict`` or :class:`Lightcurve` object
+            * If ``format\_`` is ``ascii``: :class:`Lightcurve` is returned.
             * If ``format\_`` is ``hdf5``: dictionary with key-value pairs is returned.
             * If ``format\_`` is ``pickle``: :class:`Lightcurve` object is returned.
         """

--- a/stingray/tests/test_events.py
+++ b/stingray/tests/test_events.py
@@ -11,10 +11,18 @@ datadir = os.path.join(curdir, 'data')
 
 _H5PY_INSTALLED = True
 _HAS_YAML = True
+_HAS_TIMESERIES = True
+
 try:
     import h5py
 except ImportError:
     _H5PY_INSTALLED = False
+
+try:
+    import astropy.timeseries
+    from astropy.timeseries import TimeSeries
+except ImportError:
+    _HAS_TIMESERIES = False
 
 try:
     import yaml
@@ -254,7 +262,7 @@ class TestEvents(object):
                 np.array([10, 6, 2, 2, 11, 8, 1, 3, 3, 2])).all()
         assert np.allclose(ev_new.gti, np.array([[5, 6]]))
 
-    @pytest.mark.skipif('not _HAS_YAML')
+    @pytest.mark.skipif('not (_HAS_YAML and _HAS_TIMESERIES)')
     def test_io_with_ascii(self):
         ev = EventList(self.time)
         ev.write('ascii_ev.ecsv', format_='ascii')
@@ -309,6 +317,7 @@ class TestEvents(object):
         with pytest.raises(KeyError):
             ev.read('ev.pickle', format_="unsupported")
 
+    @pytest.mark.skipif('not _HAS_TIMESERIES')
     def test_timeseries_roundtrip(self):
         """Test that io methods raise Key Error when
         wrong format is provided.

--- a/stingray/tests/test_events.py
+++ b/stingray/tests/test_events.py
@@ -254,6 +254,7 @@ class TestEvents(object):
                 np.array([10, 6, 2, 2, 11, 8, 1, 3, 3, 2])).all()
         assert np.allclose(ev_new.gti, np.array([[5, 6]]))
 
+    @pytest.mark.skipif('not _HAS_YAML')
     def test_io_with_ascii(self):
         ev = EventList(self.time)
         ev.write('ascii_ev.ecsv', format_='ascii')
@@ -308,7 +309,6 @@ class TestEvents(object):
         with pytest.raises(KeyError):
             ev.read('ev.pickle', format_="unsupported")
 
-    @pytest.mark.skipif('not _HAS_YAML')
     def test_timeseries_roundtrip(self):
         """Test that io methods raise Key Error when
         wrong format is provided.

--- a/stingray/tests/test_events.py
+++ b/stingray/tests/test_events.py
@@ -10,12 +10,16 @@ curdir = os.path.abspath(os.path.dirname(__file__))
 datadir = os.path.join(curdir, 'data')
 
 _H5PY_INSTALLED = True
-
+_HAS_YAML = True
 try:
     import h5py
 except ImportError:
     _H5PY_INSTALLED = False
 
+try:
+    import yaml
+except ImportError:
+    _HAS_YAML = False
 
 class TestEvents(object):
 
@@ -304,6 +308,7 @@ class TestEvents(object):
         with pytest.raises(KeyError):
             ev.read('ev.pickle', format_="unsupported")
 
+    @pytest.skipif('not _HAS_YAML')
     def test_timeseries_roundtrip(self):
         """Test that io methods raise Key Error when
         wrong format is provided.

--- a/stingray/tests/test_events.py
+++ b/stingray/tests/test_events.py
@@ -308,7 +308,7 @@ class TestEvents(object):
         with pytest.raises(KeyError):
             ev.read('ev.pickle', format_="unsupported")
 
-    @pytest.skipif('not _HAS_YAML')
+    @pytest.mark.skipif('not _HAS_YAML')
     def test_timeseries_roundtrip(self):
         """Test that io methods raise Key Error when
         wrong format is provided.

--- a/stingray/tests/test_events.py
+++ b/stingray/tests/test_events.py
@@ -318,4 +318,3 @@ class TestEvents(object):
             assert np.all(getattr(ev, attr) == getattr(new_ev, attr))
         for attr in ['mission', 'instr', 'mjdref']:
             assert getattr(ev, attr) == getattr(new_ev, attr)
-

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -1006,7 +1006,7 @@ class TestLightcurve(object):
         assert np.all(lc2.counts == lc.counts)
         assert np.all(lc2.countrate == lc.countrate)
 
-    @pytest.skipif('not _HAS_YAML')
+    @pytest.mark.skipif('not _HAS_YAML')
     def test_timeseries_roundtrip(self):
         """Test that io methods raise Key Error when
         wrong format is provided.

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -925,6 +925,7 @@ class TestLightcurve(object):
     #     lc.read('ascii_lc.txt', format_='ascii')
     #     os.remove('ascii_lc.txt')
 
+    @pytest.mark.skipif('not _HAS_YAML')
     def test_io_with_ascii(self):
         lc = Lightcurve(self.times, self.counts)
         lc.write('ascii_lc.ecsv', format_='ascii')
@@ -1006,7 +1007,6 @@ class TestLightcurve(object):
         assert np.all(lc2.counts == lc.counts)
         assert np.all(lc2.countrate == lc.countrate)
 
-    @pytest.mark.skipif('not _HAS_YAML')
     def test_timeseries_roundtrip(self):
         """Test that io methods raise Key Error when
         wrong format is provided.

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -16,6 +16,7 @@ np.random.seed(20150907)
 
 _H5PY_INSTALLED = True
 _HAS_LIGHTKURVE = True
+_HAS_TIMESERIES = True
 _HAS_YAML = True
 
 try:
@@ -27,6 +28,12 @@ try:
     import Lightkurve
 except ImportError:
     _HAS_LIGHTKURVE = False
+
+try:
+    import astropy.timeseries
+    from astropy.timeseries import TimeSeries
+except ImportError:
+    _HAS_TIMESERIES = False
 
 try:
     import yaml
@@ -925,7 +932,7 @@ class TestLightcurve(object):
     #     lc.read('ascii_lc.txt', format_='ascii')
     #     os.remove('ascii_lc.txt')
 
-    @pytest.mark.skipif('not _HAS_YAML')
+    @pytest.mark.skipif('not (_HAS_YAML and _HAS_TIMESERIES)')
     def test_io_with_ascii(self):
         lc = Lightcurve(self.times, self.counts)
         lc.write('ascii_lc.ecsv', format_='ascii')
@@ -1007,6 +1014,7 @@ class TestLightcurve(object):
         assert np.all(lc2.counts == lc.counts)
         assert np.all(lc2.countrate == lc.countrate)
 
+    @pytest.mark.skipif('not _HAS_TIMESERIES')
     def test_timeseries_roundtrip(self):
         """Test that io methods raise Key Error when
         wrong format is provided.

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -913,11 +913,19 @@ class TestLightcurve(object):
         lc.plot(title="Test Lightcurve")
         assert plt.fignum_exists(1)
 
+    # def test_io_with_ascii(self):
+    #     lc = Lightcurve(self.times, self.counts)
+    #     lc.write('ascii_lc.txt', format_='ascii')
+    #     lc.read('ascii_lc.txt', format_='ascii')
+    #     os.remove('ascii_lc.txt')
+
     def test_io_with_ascii(self):
         lc = Lightcurve(self.times, self.counts)
-        lc.write('ascii_lc.txt', format_='ascii')
-        lc.read('ascii_lc.txt', format_='ascii')
-        os.remove('ascii_lc.txt')
+        lc.write('ascii_lc.ecsv', format_='ascii')
+        lc = lc.read('ascii_lc.ecsv', format_='ascii')
+        assert np.all(lc.time == self.times)
+        assert np.all(lc.counts == self.counts)
+        os.remove('ascii_lc.ecsv')
 
     def test_io_with_pickle(self):
         lc = Lightcurve(self.times, self.counts)
@@ -991,6 +999,21 @@ class TestLightcurve(object):
         lc2 = lc.shift(1)
         assert np.all(lc2.counts == lc.counts)
         assert np.all(lc2.countrate == lc.countrate)
+
+    def test_timeseries_roundtrip(self):
+        """Test that io methods raise Key Error when
+        wrong format is provided.
+        """
+        N = len(self.times)
+        lc = Lightcurve(self.times, self.counts, mission="BUBU", instr="BABA",
+                       mjdref=53467.)
+
+        ts = lc.to_astropy_timeseries()
+        new_lc = lc.from_astropy_timeseries(ts)
+        for attr in ['time', 'gti', 'counts']:
+            assert np.all(getattr(lc, attr) == getattr(new_lc, attr))
+        for attr in ['mission', 'instr', 'mjdref']:
+            assert getattr(lc, attr) == getattr(new_lc, attr)
 
 
 class TestLightcurveRebin(object):

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -16,6 +16,7 @@ np.random.seed(20150907)
 
 _H5PY_INSTALLED = True
 _HAS_LIGHTKURVE = True
+_HAS_YAML = True
 
 try:
     import h5py
@@ -26,6 +27,11 @@ try:
     import Lightkurve
 except ImportError:
     _HAS_LIGHTKURVE = False
+
+try:
+    import yaml
+except ImportError:
+    _HAS_YAML = False
 
 def fvar_fun(lc):
     from stingray.utils import excess_variance
@@ -1000,6 +1006,7 @@ class TestLightcurve(object):
         assert np.all(lc2.counts == lc.counts)
         assert np.all(lc2.countrate == lc.countrate)
 
+    @pytest.skipif('not _HAS_YAML')
     def test_timeseries_roundtrip(self):
         """Test that io methods raise Key Error when
         wrong format is provided.

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -1006,7 +1006,7 @@ class TestLightcurve(object):
         """
         N = len(self.times)
         lc = Lightcurve(self.times, self.counts, mission="BUBU", instr="BABA",
-                       mjdref=53467.)
+                        mjdref=53467.)
 
         ts = lc.to_astropy_timeseries()
         new_lc = lc.from_astropy_timeseries(ts)


### PR DESCRIPTION
And use TimeSeries for ascii I/O, and prepare for whatever comes next!

Resolve #506, resolve #470, and set the base to address #152

Also, adds some mission and instrument information as per #200, #90. We might want to add energy information too, as per #96