### PR TITLE
Minor change to make warning more descriptive

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -25,7 +25,7 @@ except ImportError:
 try:
     from pyfftw.interfaces.scipy_fftpack import fft, fftfreq
 except ImportError:
-    warnings.warn("Using standard scipy fft")
+    warnings.warn("pyfftw not installed. Using standard scipy fft")
     from scipy.fftpack import fft, fftfreq
 
 __all__ = [


### PR DESCRIPTION
This is a one-line change, because I thought the warning about `pyfftw` wasn't very helpful to the user (I had to look up in the code why that warning happened), so I added the additional piece of information.