### PR TITLE
Speedup rebin of Averaged Cross/Power spectra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ addopts = --doctest-rst
 filterwarnings =
     ignore:SIMON says. Errorbars on cross spectra are not thoroughly tested.:UserWarning
     ignore:SIMON says. Stingray only uses poisson err_dist at the moment.:UserWarning
+    ignore:SIMON says. Looks like your lightcurve:UserWarning
     ignore:Matplotlib is currently using agg, which is a:UserWarning
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning
     ignore:unclosed file:ResourceWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,9 @@ doctest_plus = enabled
 text_file_format = rst
 addopts = --doctest-rst
 filterwarnings =
+    ignore:SIMON says. Errorbars on cross spectra are not thoroughly tested.:UserWarning
+    ignore:SIMON says. Stingray only uses poisson err_dist at the moment.:UserWarning
+    ignore:Matplotlib is currently using agg, which is a:UserWarning
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning
     ignore:unclosed file:ResourceWarning
     ignore:numpy.ufunc size changed:RuntimeWarning

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1168,7 +1168,6 @@ class AveragedCrossspectrum(Crossspectrum):
 
         """
 
-        # TODO: need to update this for making cross spectra.
         assert isinstance(lc1, Lightcurve)
         assert isinstance(lc2, Lightcurve)
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -994,6 +994,11 @@ class AveragedCrossspectrum(Crossspectrum):
     large_data : bool, default False
         Use only for data larger than 10**7 data points!! Uses zarr and dask for computation.
 
+    save_all : bool, default False
+        Save all intermediate PDSs used for the final average. Use with care.
+        This is likely to fill up your RAM on medium-sized datasets, and to
+        slow down the computation when rebinning.
+
     Attributes
     ----------
     freq: numpy.ndarray
@@ -1147,6 +1152,11 @@ class AveragedCrossspectrum(Crossspectrum):
 
         segment_size : ``numpy.float``
             Size of each light curve segment to use for averaging.
+
+        Other parameters
+        ----------------
+        silent : bool, default False
+            Suppress progress bars
 
         Returns
         -------

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -990,7 +990,7 @@ def _isattribute(data):
         True if the data is a single number, False if it is an iterable.
     """
 
-    if isinstance(data, np.ndarray) or isinstance(data, list):
+    if isinstance(data, Iterable) and not isinstance(data, (str, bytes)):
         return False
     else:
         return True

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -323,6 +323,11 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
     large_data : bool, default False
         Use only for data larger than 10**7 data points!! Uses zarr and dask for computation.
 
+    save_all : bool, default False
+        Save all intermediate PDSs used for the final average. Use with care.
+        This is likely to fill up your RAM on medium-sized datasets, and to
+        slow down the computation when rebinning.
+
     Attributes
     ----------
     norm: {``leahy`` | ``frac`` | ``abs`` | ``none`` }
@@ -428,6 +433,11 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
 
         segment_size : ``numpy.float``
             Size of each light curve segment to use for averaging.
+
+        Other parameters
+        ----------------
+        silent : bool, default False
+            Suppress progress bars
 
         Returns
         -------

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -356,7 +356,8 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
 
     """
     def __init__(self, data=None, segment_size=None, norm="frac", gti=None,
-                 silent=False, dt=None, lc=None, large_data=False):
+                 silent=False, dt=None, lc=None, large_data=False, 
+                 save_all=False):
 
         if lc is not None:
             warnings.warn("The lc keyword is now deprecated. Use data "
@@ -402,6 +403,7 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
 
         self.type = "powerspectrum"
         self.dt = dt
+        self.save_all = save_all
 
         if isinstance(data, EventList):
             lengths = data.gti[:, 1] - data.gti[:, 0]

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -356,7 +356,7 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
 
     """
     def __init__(self, data=None, segment_size=None, norm="frac", gti=None,
-                 silent=False, dt=None, lc=None, large_data=False, 
+                 silent=False, dt=None, lc=None, large_data=False,
                  save_all=False):
 
         if lc is not None:
@@ -416,7 +416,7 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
 
         return
 
-    def _make_segment_spectrum(self, lc, segment_size):
+    def _make_segment_spectrum(self, lc, segment_size, silent=False):
         """
         Split the light curves into segments of size ``segment_size``, and
         calculate a power spectrum for each.
@@ -457,7 +457,7 @@ class AveragedPowerspectrum(AveragedCrossspectrum, Powerspectrum):
         nphots_all = []
 
         local_show_progress = show_progress
-        if not self.show_progress:
+        if not self.show_progress or silent:
             local_show_progress = lambda a: a
 
         for start_ind, end_ind in \

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -166,14 +166,10 @@ class TestAveragedCrossspectrumEvents(object):
                                        segment_size=np.inf, dt=self.dt)
 
     def test_coherence(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
+        with pytest.warns(UserWarning) as w:
             coh = self.acs.coherence()
-
-            assert len(coh[0]) == 4999
-            assert len(coh[1]) == 4999
-            assert issubclass(w[-1].category, UserWarning)
+        assert len(coh[0]) == 4999
+        assert len(coh[1]) == 4999
 
     def test_failure_when_normalization_not_recognized(self):
         with pytest.raises(ValueError):
@@ -623,6 +619,11 @@ class TestAveragedCrossspectrum(object):
         with pytest.warns(UserWarning) as record:
             self.cs = AveragedCrossspectrum(self.lc1, self.lc2, segment_size=1)
 
+    def test_save_all(self):
+        cs = AveragedCrossspectrum(self.lc1, self.lc2, segment_size=1,
+                                   save_all=True)
+        assert hasattr(cs, 'cs_all')
+
     def test_lc_keyword_deprecation(self):
         cs1 = AveragedCrossspectrum(data1=self.lc1, data2=self.lc2,
                                     segment_size=1)
@@ -728,8 +729,12 @@ class TestAveragedCrossspectrum(object):
         lc1 = Lightcurve(x, y1)
         lc2 = Lightcurve(x, y2)
 
-        acs = AveragedCrossspectrum(lc1, lc2, segment_size=5.0, norm="leahy")
+        with pytest.warns(UserWarning) as record:
+            acs = AveragedCrossspectrum(
+                lc1, lc2, segment_size=5.0, norm="leahy")
         assert acs.m == 1
+        assert np.any(["No counts in interval" in r.message.args[0]
+                       for r in record])
 
 
     def test_rebin_with_invalid_type_attribute(self):
@@ -865,14 +870,15 @@ class TestAveragedCrossspectrum(object):
         test_lc1 = simulator.simulate(2)
         test_lc1.counts -= np.min(test_lc1.counts)
 
-        test_lc1 = Lightcurve(test_lc1.time,
-                              test_lc1.counts,
-                              err_dist=test_lc1.err_dist,
-                              dt=dt)
-        test_lc2 = Lightcurve(test_lc1.time,
-                              np.array(np.roll(test_lc1.counts, 2)),
-                              err_dist=test_lc1.err_dist,
-                              dt=dt)
+        with pytest.warns(UserWarning):
+            test_lc1 = Lightcurve(test_lc1.time,
+                                  test_lc1.counts,
+                                  err_dist=test_lc1.err_dist,
+                                  dt=dt)
+            test_lc2 = Lightcurve(test_lc1.time,
+                                  np.array(np.roll(test_lc1.counts, 2)),
+                                  err_dist=test_lc1.err_dist,
+                                  dt=dt)
 
         with warnings.catch_warnings(record=True) as w:
             cs = AveragedCrossspectrum(test_lc1, test_lc2, segment_size=5,

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -280,6 +280,7 @@ class TestLightcurve(object):
                     "the moment")
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always")
             lc = Lightcurve(times, counts, err_dist='gauss')
             assert np.any([warn_str in str(wi.message) for wi in w])
 
@@ -558,7 +559,7 @@ class TestLightcurve(object):
         lc1 = Lightcurve(self.times, self.counts)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
- 
+
             lc2 = Lightcurve(self.times, self.counts, err=self.counts / 2,
                              err_dist="gauss")
         with warnings.catch_warnings(record=True) as w:
@@ -651,7 +652,7 @@ class TestLightcurve(object):
             newlc = lc1.join(lc2)
             # The join operation *averages* the overlapping arrays
             assert np.allclose(newlc.counts, lc1.counts)
-            assert np.any(["MJDref is different in the two light curves" 
+            assert np.any(["MJDref is different in the two light curves"
                            in str(wi.message) for wi in w])
             assert np.any(["The two light curves have overlapping time ranges"
                            in str(wi.message) for wi in w])
@@ -807,7 +808,7 @@ class TestLightcurve(object):
             warnings.simplefilter("ignore", category=UserWarning)
             lc_test = Lightcurve(test_time, test_counts)
         slc = lc_test.split(1.5)
- 
+
         assert len(slc) == 3
 
     def test_threeway_split_has_correct_data_points(self):

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -175,7 +175,7 @@ def rebin_data(x, y, dx_new, yerr=None, method='sum', dx=None):
     >>> y = np.ones(x.size)
     >>> yerr = np.ones(x.size)
     >>> xbin, ybin, ybinerr, step_size = rebin_data(
-    ...     x, y, 4, yerr=yerr, method='sum')
+    ...     x, y, 4, yerr=yerr, method='sum', dx=0.01)
     >>> np.allclose(ybin, 400)
     True
     >>> np.allclose(ybinerr, 20)
@@ -194,9 +194,9 @@ def rebin_data(x, y, dx_new, yerr=None, method='sum', dx=None):
     else:
         yerr = np.asarray(yerr)
 
-    if dx is None or not dx:
+    if not dx:
         dx_old = np.diff(x)
-    elif dx.size == 1:
+    elif np.size(dx) == 1:
         dx_old = np.array([dx])
     else:
         dx_old = dx
@@ -263,7 +263,7 @@ def rebin_data(x, y, dx_new, yerr=None, method='sum', dx=None):
 
     dx_var = np.var(dx_old) / np.mean(dx_old)
 
-    if dx_old.size == 1 or dx_var < 1e-6:
+    if np.size(dx_old) == 1 or dx_var < 1e-6:
         step_size = step_size[0]
 
     new_x0 = (x[0] - (0.5 * dx_old[0])) + (0.5 * dx_new)

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -189,11 +189,14 @@ def rebin_data(x, y, dx_new, yerr=None, method='sum', dx=None):
     """
 
     y = np.asarray(y)
-    yerr = np.asarray(apply_function_if_none(yerr, y, np.zeros_like))
+    if yerr is None:
+        yerr = np.zeros_like(y)
+    else:
+        yerr = np.asarray(yerr)
 
-    if not dx:
+    if dx is None or not dx:
         dx_old = np.diff(x)
-    elif np.size(dx) == 1:
+    elif dx.size == 1:
         dx_old = np.array([dx])
     else:
         dx_old = dx
@@ -214,13 +217,12 @@ def rebin_data(x, y, dx_new, yerr=None, method='sum', dx=None):
     outputerr = np.zeros(xbin.shape[0] - 1, dtype=type(y[0]))
     step_size = np.zeros(xbin.shape[0] - 1)
 
-    for i in range(len(xbin)-1):
-
-        xmin = xbin[i]
-        xmax = xbin[i+1]
-        min_ind = xedges.searchsorted(xmin)
-        max_ind = xedges.searchsorted(xmax)
-
+    all_x = np.searchsorted(xedges, xbin)
+    min_inds = all_x[:-1]
+    max_inds = all_x[1:]
+    xmins = xbin[:-1]
+    xmaxs = xbin[1:]
+    for i, (xmin, xmax, min_ind, max_ind) in enumerate(zip(xmins, xmaxs, min_inds, max_inds)):
         output[i] = np.sum(y[min_ind:max_ind-1])
         outputerr[i] = np.sum(yerr[min_ind:max_ind-1])
         step_size[i] = len(y[min_ind:max_ind-1])
@@ -259,7 +261,7 @@ def rebin_data(x, y, dx_new, yerr=None, method='sum', dx=None):
 
     dx_var = np.var(dx_old) / np.mean(dx_old)
 
-    if np.size(dx_old) == 1 or dx_var < 1e-6:
+    if dx_old.size == 1 or dx_var < 1e-6:
         step_size = step_size[0]
 
     new_x0 = (x[0] - (0.5 * dx_old[0])) + (0.5 * dx_new)

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -223,9 +223,11 @@ def rebin_data(x, y, dx_new, yerr=None, method='sum', dx=None):
     xmins = xbin[:-1]
     xmaxs = xbin[1:]
     for i, (xmin, xmax, min_ind, max_ind) in enumerate(zip(xmins, xmaxs, min_inds, max_inds)):
-        output[i] = np.sum(y[min_ind:max_ind-1])
-        outputerr[i] = np.sum(yerr[min_ind:max_ind-1])
-        step_size[i] = len(y[min_ind:max_ind-1])
+        filtered_y = y[min_ind:max_ind-1]
+        filtered_yerr = yerr[min_ind:max_ind-1]
+        output[i] = np.sum(filtered_y)
+        outputerr[i] = np.sum(filtered_yerr)
+        step_size[i] = max_ind -1 - min_ind
 
         prev_dx = xedges[min_ind] - xedges[min_ind-1]
         prev_frac = (xedges[min_ind] - xmin)/prev_dx
@@ -233,7 +235,7 @@ def rebin_data(x, y, dx_new, yerr=None, method='sum', dx=None):
         outputerr[i] += yerr[min_ind-1]*prev_frac
         step_size[i] += prev_frac
 
-        if not max_ind == len(xedges):
+        if not max_ind == xedges.size:
             dx_post = xedges[max_ind] - xedges[max_ind-1]
             post_frac = (xmax-xedges[max_ind-1])/dx_post
             output[i] += y[max_ind-1]*post_frac


### PR DESCRIPTION
These objects carry an array of spectra calculated in each segment, and when rebinning, these were also rebinned. This took a very long time, needlessly given the cs_all is itself not necessary. So, I added a save_all option to __init__.py that makes the cs_all garbage collected as soon as the calculation is done. The previous behavior is reinstated by using save_all when creating the spectrum.

Also, I silenced some more warnings here and there

Moar:
Close #315, close #313