### PR TITLE
Updates FFT calls from legacy scipy.fftpack

### DIFF
--- a/stingray/bispectrum.py
+++ b/stingray/bispectrum.py
@@ -2,7 +2,13 @@
 
 import numpy as np
 from scipy.linalg import toeplitz
-from scipy.fftpack import fftshift, fft2, ifftshift, fft
+
+try:
+    from pyfftw.interfaces.scipy_fft import fftshift, fft2, ifftshift, fft
+except ImportError:
+    warnings.warn("pyfftw not installed. Using standard scipy fft")
+    from scipy.fft import fftshift, fft2, ifftshift, fft
+
 from  scipy.linalg import hankel
 
 from stingray import lightcurve

--- a/stingray/bispectrum.py
+++ b/stingray/bispectrum.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from scipy.linalg import toeplitz
+import warnings
 
 try:
     from pyfftw.interfaces.scipy_fft import fftshift, fft2, ifftshift, fft

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -23,10 +23,10 @@ except ImportError:
     from scipy.special import factorial
 
 try:
-    from pyfftw.interfaces.scipy_fftpack import fft, fftfreq
+    from pyfftw.interfaces.scipy_fft import fft, fftfreq
 except ImportError:
     warnings.warn("pyfftw not installed. Using standard scipy fft")
-    from scipy.fftpack import fft, fftfreq
+    from scipy.fft import fft, fftfreq
 
 __all__ = [
     "Crossspectrum", "AveragedCrossspectrum", "coherence", "time_lag",

--- a/stingray/spectroscopy.py
+++ b/stingray/spectroscopy.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.stats import binned_statistic
-from scipy.fftpack import fft, ifft
+from scipy.fft import fft, ifft
 from scipy.optimize import brent
 
 


### PR DESCRIPTION
to scipy.fft and the pyfftw equivalent. I checked the documentation, and thee relevant functions seem to be closely equivalent except for a new `norm` parameter that allows one to move the 1/n factor around. Given that nothing blew up in the tests, I'm thinking that the defaults are sensible for our purposes. :)

Resolves #535 and *might* address #310, but I haven't looked at that yet.