### PR TITLE
Added events.py to top-level imports

### DIFF
--- a/stingray/__init__.py
+++ b/stingray/__init__.py
@@ -8,6 +8,7 @@ from ._astropy_init import *
 
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
+    from stingray.events import *
     from stingray.lightcurve import *
     from stingray.utils import *
     from stingray.powerspectrum import *


### PR DESCRIPTION
I was sad that `EventList` is the only top-level stingray class that can't be important with `from stingray import EventList` but rather with `from stingray.events import EventList`, so I added `events` to the `__init__`. :) 