### PR TITLE
Pin docutils to 0.16

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ test =
     pytest<6
     pytest-astropy
 docs =
+    docutils==0.16
     sphinx-astropy
     nbsphinx
     pandoc


### PR DESCRIPTION
Work-around for https://github.com/spatialaudio/nbsphinx/issues/549.