### PR TITLE
Fix test suite documentation to match with readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,9 @@ not be easily accessible. Once installed, you can also run the tests using::
 
    $ python -c 'import stingray; stingray.test()'
 
-or from within a python interpreter::
+or from within a python interpreter:
+
+.. doctest-skip::
 
    >>> import stingray
    >>> stingray.test()

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -93,7 +93,9 @@ not be easily accessible. Once installed, you can also run the tests using::
 
    $ python -c 'import stingray; stingray.test()'
 
-or from within a python interpreter::
+or from within a python interpreter:
+
+.. doctest-skip::
 
    >>> import stingray
    >>> stingray.test()

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -79,19 +79,21 @@ Test Suite
 Please be sure to run the test suite before you use the package, and please report anything
 you think might be bugs on our GitHub `Issues page <https://github.com/StingraySoftware/stingray/issues>`_.
 
-Stingray uses `py.test <https://doc.pytest.org/en/latest/>`_ for testing. To run the tests, go into
-the ``stingray`` root directory and execute ::
+Stingray uses `py.test <https://pytest.org>`_ and `tox
+<https://tox.readthedocs.io>`_ for testing. To run the tests, try::
 
-    $ python setup.py test
+   $ tox -e test
+
+You may need to install tox first::
+
+   $ pip install tox
 
 If you have installed Stingray via pip or conda, the source directory might
 not be easily accessible. Once installed, you can also run the tests using::
 
    $ python -c 'import stingray; stingray.test()'
 
-or from within a python interpreter:
-
-.. doctest-skip::
+or from within a python interpreter::
 
    >>> import stingray
    >>> stingray.test()


### PR DESCRIPTION
Reading through the documentation I realized that the documentation for running tests is inconsistent. The corrent way to run the tests is in the Readme, so this PR fixes the documentation.

Also fixed the readme to add `doctest-skip` step based on this comment: https://github.com/StingraySoftware/stingray/pull/553#discussion_r611552714