### PR TITLE
Request citing DOIs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Stingray
 ========
 
-|Build Status Master| |Docs| |Slack| |joss| |Coverage Status Master| |GitHub release|
+|Build Status Master| |Docs| |Slack| |joss| |doi| |Coverage Status Master| |GitHub release|
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 X-Ray Spectral Timing Made Easy
@@ -81,6 +81,8 @@ The code is distributed under the MIT license; see `LICENSE.rst <LICENSE.rst>`_ 
    :target: https://github.com/StingraySoftware/stingray/releases/latest
 .. |joss| image:: http://joss.theoj.org/papers/10.21105/joss.01393/status.svg
    :target: https://doi.org/10.21105/joss.01393
+.. |doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1490116.svg
+   :target: https://doi.org/10.5281/zenodo.1490116
 .. _Astropy: https://www.github.com/astropy/astropy
 .. _Issues: https://www.github.com/stingraysoftware/stingray/issues
 .. _Issue: https://www.github.com/stingraysoftware/stingray/issues

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+_zenodo.rst

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -2,9 +2,22 @@
 Citing Stingray
 ***************
 
-Citations are still the main currency of the academic world, and pointing to citations is *the* best way to help us ensure that Stingray continues to be supported and we can continue working on it.
+Citations are still the main currency of the academic world, and *the* best way to ensure that Stingray continues to be supported and we can continue to work on it.
+If you use Stingray in data analysis leading to a publication, we ask that you cite *both* a `DOI <https://www.doi.org>`_ which points to the software itself *and* our papers describing the Stingray project.
 
-If you use Stingray in data analysis leading to a publication, please cite both of the following papers:
+DOI
+===
+
+If possible, we ask that you cite a DOI corresponding to the specific version of Stingray that you used to carry out your analysis.
+
+.. include:: _zenodo.rst
+
+If this isn't possible — for example, because you worked with an unreleased version of the code — you can cite Stingray's `concept DOI <https://help.zenodo.org/#versioning>`__, `10.5281/zenodo.1490116 <https://zenodo.org/record/1490116>`__ (`BibTeX <https://zenodo.org/record/1490116/export/hx>`__), which will always resolve to the latest release.
+
+Papers
+======
+
+Please cite both of the following papers:
 
 .. raw:: html
 
@@ -96,5 +109,10 @@ If you use Stingray in data analysis leading to a publication, please cite both 
          [<a onclick="copyJossBib()">Copy BibTeX to clipboard</a>]</li>
    </ul>
 
-   Stingray is also listed in the <a href="https://ascl.net/1608.001">Astrophysics Source Code Library</a>.
+Other Useful References
+=======================
+
+.. raw:: html
+
+   Stingray is listed in the <a href="https://ascl.net/1608.001">Astrophysics Source Code Library</a>.
    <a onclick="copyAsclBib()">Copy the corresponding BibTeX to clipboard</a>.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,7 +228,7 @@ with open("_zenodo.rst", "w") as f:
     if releases:
         f.write(".. list-table::\n")
         f.write("   :header-rows: 1\n\n")
-        f.write("   * - Release\n")
+        f.write("   * - Stingray Release\n")
         f.write("     - DOI\n")
         f.write("     - Citation\n")
         for r in sorted(releases, key=lambda r: r.version, reverse=True):
@@ -236,4 +236,6 @@ with open("_zenodo.rst", "w") as f:
             f.write(f"     - `{r.doi} <{r.zenodo_url}>`__\n")
             f.write(f"     - `[Link to BibTeX] <{r.bibtex_url}>`__\n")
     else:
-        f.write("No additional release details are available.\n")
+        # The file needs to exist, but the text degrades gracefully if it is
+        # empty.
+        pass

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,3 +171,69 @@ github_issues_url = 'https://github.com/{0}/issues/'.format(
 # -- Configuration for nbsphinx -----------------------------------------------
 # disable notebook execution
 nbsphinx_execute = 'never'
+
+# -- Generate DOI listing from Zenodo -----------------------------------------
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+
+ZENODO_API_ENDPOINT = "https://zenodo.org/api/records/"
+
+# The “concept DOI” refers to all versions of Stingray.
+# We'll use it to locate each of the specific versions in turn.
+# See https://help.zenodo.org/#versioning for details.
+CONCEPT_DOI = "10.5281/zenodo.1490116"
+
+
+@dataclass
+class Release(object):
+    version: str
+    doi: str
+
+    @property
+    def zenodo_url(self):
+        return f"https://zenodo.org/record/{self.doi.split('.')[-1]}"
+
+    @property
+    def github_url(self):
+        return (
+            f"https://github.com/StingraySoftware/stingray/releases/tag/{self.version}"
+        )
+
+    @property
+    def bibtex_url(self):
+        return self.zenodo_url + "/export/hx"
+
+
+params = urllib.parse.urlencode(
+    {"q": f'conceptdoi: "{CONCEPT_DOI}"', "all_versions": 1}
+)
+try:
+    with urllib.request.urlopen(ZENODO_API_ENDPOINT + "?" + params) as url:
+        data = json.loads(url.read().decode("utf-8"))
+except urllib.error.URLError:
+    data = {"hits": {"hits": []}}
+
+releases = []
+for rec in data["hits"]["hits"]:
+    version = rec["metadata"]["version"]
+    if version[0] != "v":
+        continue
+    doi = rec["metadata"]["doi"]
+    releases.append(Release(version, doi))
+
+with open("_zenodo.rst", "w") as f:
+    if releases:
+        f.write(".. list-table::\n")
+        f.write("   :header-rows: 1\n\n")
+        f.write("   * - Release\n")
+        f.write("     - DOI\n")
+        f.write("     - Citation\n")
+        for r in sorted(releases, key=lambda r: r.version, reverse=True):
+            f.write(f"   * - `{r.version} <{r.github_url}>`__\n")
+            f.write(f"     - `{r.doi} <{r.zenodo_url}>`__\n")
+            f.write(f"     - `[Link to BibTeX] <{r.bibtex_url}>`__\n")
+    else:
+        f.write("No additional release details are available.\n")


### PR DESCRIPTION
This updates citation guidance to request that folks cite a DOI.

It also queries Zenodo to pull a list of appropriate DOIs to cite, depending of the version of Stingray in use, and embeds that in the docs.

Why not hard-code that list? Primarily, because then docs for a given release wouldn't (easily) include its own DOI; you'd have to come back and edit it in after the release was made, thus changing the code to something subtly different from what the DOI is pointing to.

(It should also be possible to work around that issue by pre-reserving a DOI on Zenodo before the release, but doing things this way involves fewer manual steps to forget!)