### PR TITLE
Upper limits on pulsations in periodograms

### DIFF
--- a/stingray/io.py
+++ b/stingray/io.py
@@ -584,6 +584,7 @@ def load_events_and_gtis(
     if mission_key not in probe_header:
         mission_key = "TELESCOP"
     mission = probe_header[mission_key].lower()
+
     db = read_mission_info(mission)
     instkey = get_key_from_mission_info(db, "instkey", "INSTRUME")
     instr = mode = None

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -354,6 +354,9 @@ class Powerspectrum(Crossspectrum):
 
         maximum_val = np.argmax(power)
         nyq_ratio = freq[maximum_val] / fnyq
+
+        # I multiply by M because the formulas from Vaughan+94 treat summed powers, while here
+        # we have averaged powers.
         return amplitude_upper_limit(
             power[maximum_val] * self.m, self.nphots, n=self.m, c=c, nyq_ratio=nyq_ratio, fft_corr=True)
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -298,6 +298,7 @@ class Powerspectrum(Crossspectrum):
         a is equivalent to :math:`\sqrt(\sum_l a_l^2)`.
 
         See `stingray.stats.power_upper_limit`, `stingray.stats.amplitude_upper_limit`
+        for more information.
 
         Parameters
         ----------
@@ -305,7 +306,7 @@ class Powerspectrum(Crossspectrum):
             The minimum frequency to search (defaults to the first nonzero bin)
 
         fmax: float
-            The minimum frequency to search (defaults to the Nyquist frequency)
+            The maximum frequency to search (defaults to the Nyquist frequency)
 
         Other Parameters
         ----------------
@@ -321,14 +322,13 @@ class Powerspectrum(Crossspectrum):
         --------
         >>> pds = Powerspectrum()
         >>> pds.norm = "leahy"
-        >>> pds.freq = np.arange(0, 5)
-        >>> pds.power = np.array([100000, 5, 2, 40, 1])
+        >>> pds.freq = np.arange(0., 5.)
+        >>> # Note: this pds has 40 as maximum value between 2 and 5 Hz
+        >>> pds.power = np.array([100000, 1, 1, 40, 1])
         >>> pds.m = 1
         >>> pds.nphots = 30000
-        >>> aup = pds.modulation_upper_limit(2, 5, 0.99)
-        >>> aup_corr = amplitude_upper_limit(40, 30000, 1, 0.99, nyq_ratio=3/4, fft_corr=True)
-        >>> np.isclose(aup, aup_corr)
-        True
+        >>> pds.modulation_upper_limit(fmin=2, fmax=5, c=0.99)
+        0.1016...
         >>> pds.norm = "frac"
         >>> pds.modulation_upper_limit(2, 5, 0.99)
         Traceback (most recent call last):

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -888,12 +888,22 @@ def power_upper_limit(pmeas, n=1, c=0.95):
 
 
 def amplitude_upper_limit(pmeas, counts, n=1, c=0.95, fft_corr=False, nyq_ratio=0):
-    """Upper limit on pulsed fraction, given a measured power in the PDS/Z search.
+    """Upper limit on a sinusoidal modulation, given a measured power in the PDS/Z search.
 
     Eq. 10 in Vaughan+94 and `a_from_ssig`: they are equivalent but Vaughan+94
     corrects further for the response inside an FFT bin and at frequencies close
     to Nyquist. These two corrections are added by using fft_corr=True and
-    nyq_ratio to the correct f / f_Nyq of the FFT peak
+    nyq_ratio to the correct :math:`f / f_{Nyq}` of the FFT peak
+
+    To understand the meaning of this amplitude: if the modulation is described by:
+
+    ..math:: p = \overline{p} (1 + a * \sin(x))
+
+    this function returns a.
+
+    If it is a sum of sinusoidal harmonics instead
+    ..math:: p = \overline{p} (1 + \sum_l a_l * \sin(lx))
+    a is equivalent to :math:`\sqrt(\sum_l a_l^2)`.
 
     See `power_upper_limit`
 
@@ -925,8 +935,8 @@ def amplitude_upper_limit(pmeas, counts, n=1, c=0.95, fft_corr=False, nyq_ratio=
 
     Results
     -------
-    pf: float
-        The pulsed fraction that could produce P>pmeas with 1 - c probability
+    a: float
+        The modulation amplitude that could produce P>pmeas with 1 - c probability
 
     Examples
     --------

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -776,3 +776,219 @@ def _pavnosigfun(power, nspec):
         m -= 1
 
     return sum
+
+
+def confidence_limits(preal, n=1, alpha=0.16):
+    """Confidence limits on power, given a signal power in the PDS/Z search.
+
+    Adapted from Vaughan et al. 1994, noting that, after appropriate
+    normalization of the spectral stats, the distribution of powers in the PDS
+    and the Z^2_n searches is always described by a noncentral chi squared
+    distribution.
+
+    Parameters
+    ----------
+    preal: float
+        The underlying, signal-generated value of power
+
+    Other Parameters
+    ----------------
+    n: int
+        The number of summed powers to obtain pmeas. It can be multiple
+        harmonics of the PDS, adjacent bins in a PDS summed to collect all the
+        power in a QPO, or the n in Z^2_n
+    alpha: float
+        The p-value (e.g. 0.16 = 16% for 1-sigma)
+
+    Results
+    -------
+    pmeas: [float, float]
+        The upper and lower confidence interval on the measured power
+    """
+    rv = stats.ncx2(2 * n, preal)
+    return rv.isf([alpha, 1 - alpha])
+
+
+def power_upper_limit(pmeas, n=1, c=0.95):
+    """Upper limit on signal power, given a measured power in the PDS/Z search.
+
+    Adapted from Vaughan et al. 1994, noting that, after appropriate
+    normalization of the spectral stats, the distribution of powers in the PDS
+    and the Z^2_n searches is always described by a noncentral chi squared
+    distribution.
+
+    Parameters
+    ----------
+    pmeas: float
+        The measured value of power
+
+    Other Parameters
+    ----------------
+    n: int
+        The number of summed powers to obtain pmeas. It can be multiple
+        harmonics of the PDS, adjacent bins in a PDS summed to collect all the
+        power in a QPO, or the n in Z^2_n
+    c: float
+        The confidence value for the probability (e.g. 0.95 = 95%)
+
+    Results
+    -------
+    psig: float
+        The signal power that could produce P>pmeas with 1 - c probability
+    """
+    def ppf(x):
+        rv = stats.ncx2(2 * n, x)
+        return rv.ppf(1-c)
+
+    def isf(x):
+        rv = stats.ncx2(2 * n, x)
+        return rv.ppf(c)
+
+    def func_to_minimize(x, xmeas):
+        print(x, xmeas, ppf(x), ppf(x) - xmeas)
+        return np.abs(ppf(x) - xmeas)
+
+    from scipy.optimize import minimize
+    initial = isf(pmeas)
+
+    res = minimize(func_to_minimize, [initial], pmeas, bounds=[(0, initial * 2)])
+
+    print(res)
+    return res.x[0]
+
+
+def pf_upper_limit(pmeas, counts, n=1, alpha=0.05):
+    """Upper limit on pulsed fraction, given a measured power in the PDS/Z search.
+
+    See `power_upper_limit` and `pf_from_ssig`.
+
+    Parameters
+    ----------
+    pmeas: float
+        The measured value of power
+
+    Other Parameters
+    ----------------
+    n: int
+        The number of summed powers to obtain pmeas. It can be multiple
+        harmonics of the PDS, adjacent bins in a PDS summed to collect all the
+        power in a QPO, or the n in Z^2_n
+    c: float
+        The confidence value for the probability (e.g. 0.95 = 95%)
+
+    Results
+    -------
+    pf: float
+        The pulsed fraction that could produce P>pmeas with 1 - c probability
+    """
+
+    uplim = power_upper_limit(pmeas, n, alpha)
+    return pf_from_ssig(uplim, counts)
+
+
+def pf_from_a(a):
+    """Pulsed fraction from fractional amplitude of modulation.
+
+    If the pulsed profile is defined as
+    p = mean * (1 + a * sin(phase)),
+
+    we define "pulsed fraction" as 2a/b, where b = mean + a is the maximum and
+    a is the amplitude of the modulation.
+
+    Hence, pulsed fraction = 2a/(1+a)
+
+    Examples
+    --------
+    >>> pf_from_a(1)
+    1.0
+    >>> pf_from_a(0)
+    0.0
+    """
+    return 2 * a / (1 + a)
+
+
+def a_from_pf(p):
+    """Fractional amplitude of modulation from pulsed fraction
+
+    If the pulsed profile is defined as
+    p = mean * (1 + a * sin(phase)),
+
+    we define "pulsed fraction" as 2a/b, where b = mean + a is the maximum and
+    a is the amplitude of the modulation.
+
+    Hence, a = pf / (2 - pf)
+
+    Examples
+    --------
+    >>> a_from_pf(1)
+    1.0
+    >>> a_from_pf(0)
+    0.0
+    """
+    return p / (2 - p)
+
+
+def ssig_from_a(a, ncounts):
+    """Theoretical power in the Z or PDS search for a sinusoid of amplitude a.
+
+    From Leahy et al. 1983, given a pulse profile
+    p = lambda * (1 + a * sin(phase)),
+    The theoretical value of Z^2_n is Ncounts / 2 * a^2
+
+    Note that if there are multiple sinusoidal components, one can use
+    a = sqrt(sum(a_l))
+    (Bachetti+2021b)
+
+    Examples
+    --------
+    >>> round(ssig_from_a(0.1, 30000), 1)
+    150.0
+    """
+    return ncounts / 2 * a ** 2
+
+
+def a_from_ssig(ssig, ncounts):
+    """Amplitude of a sinusoid corresponding to a given Z/PDS value
+
+    From Leahy et al. 1983, given a pulse profile
+    p = lambda * (1 + a * sin(phase)),
+    The theoretical value of Z^2_n is Ncounts / 2 * a^2
+
+    Note that if there are multiple sinusoidal components, one can use
+    a = sqrt(sum(a_l))
+    (Bachetti+2021b)
+
+    Examples
+    --------
+    >>> a_from_ssig(150, 30000)
+    0.1
+    """
+    return np.sqrt(2 * ssig / ncounts)
+
+
+def ssig_from_pf(pf, ncounts):
+    """Theoretical power in the Z or PDS for a sinusoid of pulsed fraction pf.
+
+    See `ssig_from_a` and `a_from_pf` for more details
+
+    Examples
+    --------
+    >>> round(ssig_from_pf(pf_from_a(0.1), 30000), 1)
+    150.0
+    """
+    a = a_from_pf(pf)
+    return ncounts / 2 * a ** 2
+
+
+def pf_from_ssig(ssig, ncounts):
+    """Estimate pulsed fraction for a sinusoid from a given Z or PDS power.
+
+    See `a_from_ssig` and `pf_from_a` for more details
+
+    Examples
+    --------
+    >>> round(a_from_pf(pf_from_ssig(150, 30000)), 1)
+    0.1
+    """
+    a = a_from_ssig(ssig, ncounts)
+    return pf_from_a(a)

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -807,7 +807,7 @@ def power_confidence_limits(preal, n=1, c=0.95):
     Other Parameters
     ----------------
     n: int
-        The number of summed powers to obtain pmeas. It can be multiple
+        The number of summed powers to obtain the result. It can be multiple
         harmonics of the PDS, adjacent bins in a PDS summed to collect all the
         power in a QPO, or the n in Z^2_n
     c: float

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -788,9 +788,12 @@ def _pavnosigfun(power, nspec):
     return sum
 
 
-def power_confidence_limits(preal, n=1, alpha=0.16):
-    """Confidence limits on power, given a signal power in the PDS/Z search.
+def power_confidence_limits(preal, n=1, c=0.95):
+    """Confidence limits on power, given a (theoretical) signal power.
 
+    This is to be used when we *expect* a given power (e.g. from the pulsed
+    fraction measured in previous observations) and we want to know the
+    range of values the measured power could take to a given confidence level.
     Adapted from Vaughan et al. 1994, noting that, after appropriate
     normalization of the spectral stats, the distribution of powers in the PDS
     and the Z^2_n searches is always described by a noncentral chi squared
@@ -799,7 +802,7 @@ def power_confidence_limits(preal, n=1, alpha=0.16):
     Parameters
     ----------
     preal: float
-        The underlying, signal-generated value of power
+        The theoretical signal-generated value of power
 
     Other Parameters
     ----------------
@@ -807,8 +810,8 @@ def power_confidence_limits(preal, n=1, alpha=0.16):
         The number of summed powers to obtain pmeas. It can be multiple
         harmonics of the PDS, adjacent bins in a PDS summed to collect all the
         power in a QPO, or the n in Z^2_n
-    alpha: float
-        The p-value (e.g. 0.16 = 16% for 1-sigma)
+    c: float
+        The confidence level (e.g. 0.95=95%)
 
     Results
     -------
@@ -817,12 +820,12 @@ def power_confidence_limits(preal, n=1, alpha=0.16):
 
     Examples
     --------
-    >>> cl = power_confidence_limits(150)
+    >>> cl = power_confidence_limits(150, c=0.84)
     >>> np.allclose(cl, [127, 176], atol=1)
     True
     """
     rv = stats.ncx2(2 * n, preal)
-    return rv.ppf([alpha, 1 - alpha])
+    return rv.ppf([1 - c, c])
 
 
 def power_upper_limit(pmeas, n=1, c=0.95):

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -887,10 +887,15 @@ def power_upper_limit(pmeas, n=1, c=0.95):
     return res.x[0]
 
 
-def pf_upper_limit(pmeas, counts, n=1, c=0.95):
+def amplitude_upper_limit(pmeas, counts, n=1, c=0.95, fft_corr=False, nyq_ratio=0):
     """Upper limit on pulsed fraction, given a measured power in the PDS/Z search.
 
-    See `power_upper_limit` and `pf_from_ssig`.
+    Eq. 10 in Vaughan+94 and `a_from_ssig`: they are equivalent but Vaughan+94
+    corrects further for the response inside an FFT bin and at frequencies close
+    to Nyquist. These two corrections are added by using fft_corr=True and
+    nyq_ratio to the correct f / f_Nyq of the FFT peak
+
+    See `power_upper_limit`
 
     Parameters
     ----------
@@ -908,6 +913,75 @@ def pf_upper_limit(pmeas, counts, n=1, c=0.95):
         power in a QPO, or the n in Z^2_n
     c: float
         The confidence value for the probability (e.g. 0.95 = 95%)
+    fft_corr: bool
+        Apply a correction for the expected power concentrated in an FFT bin,
+        which is about 0.773 on average (it's 1 at the center of the bin, 2/pi
+        at the bin edge.
+    nyq_ratio: float
+        Ratio of the frequency of this feature with respect to the Nyquist
+        frequency. Important to know when dealing with FFTs, because the FFT
+        response decays between 0 and f_Nyq similarly to the response inside
+        a frequency bin: from 1 at 0 Hz to ~2/pi at f_Nyq
+
+    Results
+    -------
+    pf: float
+        The pulsed fraction that could produce P>pmeas with 1 - c probability
+
+    Examples
+    --------
+    >>> aup = amplitude_upper_limit(40, 30000, 1, 0.99)
+    >>> aup_nyq = amplitude_upper_limit(40, 30000, 1, 0.99, nyq_ratio=1)
+    >>> np.isclose(aup_nyq, aup / (2 / np.pi))
+    True
+    >>> aup_corr = amplitude_upper_limit(40, 30000, 1, 0.99, fft_corr=True)
+    >>> np.isclose(aup_corr, aup / np.sqrt(0.773))
+    True
+    """
+
+    uplim = power_upper_limit(pmeas, n, c)
+    a = a_from_ssig(uplim, counts)
+    if fft_corr:
+        factor = 1 / np.sqrt(0.773)
+        a *= factor
+    if nyq_ratio > 0:
+        factor = np.pi / 2 * nyq_ratio
+        sinc_factor = np.sin(factor) / factor
+        a /= sinc_factor
+    return a
+
+
+def pf_upper_limit(*args, **kwargs):
+    """Upper limit on pulsed fraction, given a measured power in the PDS/Z search.
+
+    See `power_upper_limit` and `pf_from_ssig`.
+    All arguments are the same as `amplitude_upper_limit`
+
+    Parameters
+    ----------
+    pmeas: float
+        The measured value of power
+
+    counts: int
+        The number of counts in the light curve used to calculate the spectrum
+
+    Other Parameters
+    ----------------
+    n: int
+        The number of summed powers to obtain pmeas. It can be multiple
+        harmonics of the PDS, adjacent bins in a PDS summed to collect all the
+        power in a QPO, or the n in Z^2_n
+    c: float
+        The confidence value for the probability (e.g. 0.95 = 95%)
+    fft_corr: bool
+        Apply a correction for the expected power concentrated in an FFT bin,
+        which is about 0.773 on average (it's 1 at the center of the bin, 2/pi
+        at the bin edge.
+    nyq_ratio: float
+        Ratio of the frequency of this feature with respect to the Nyquist
+        frequency. Important to know when dealing with FFTs, because the FFT
+        response decays between 0 and f_Nyq similarly to the response inside
+        a frequency bin: from 1 at 0 Hz to ~2/pi at f_Nyq
 
     Results
     -------
@@ -921,8 +995,7 @@ def pf_upper_limit(pmeas, counts, n=1, c=0.95):
     True
     """
 
-    uplim = power_upper_limit(pmeas, n, c)
-    return pf_from_ssig(uplim, counts)
+    return pf_from_a(amplitude_upper_limit(*args, **kwargs))
 
 
 def pf_from_a(a):

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -779,7 +779,7 @@ def _pavnosigfun(power, nspec):
     return sum
 
 
-def confidence_limits(preal, n=1, alpha=0.16):
+def power_confidence_limits(preal, n=1, alpha=0.16):
     """Confidence limits on power, given a signal power in the PDS/Z search.
 
     Adapted from Vaughan et al. 1994, noting that, after appropriate
@@ -804,10 +804,17 @@ def confidence_limits(preal, n=1, alpha=0.16):
     Results
     -------
     pmeas: [float, float]
-        The upper and lower confidence interval on the measured power
+        The upper and lower confidence interval (a, 1-a) on the measured power
+
+    Examples
+    --------
+    >>> power_confidence_limits(preal, n=1, alpha=0.16)
+    >>> cl = power_confidence_limits(150)
+    >>> np.allclose(cl, [127, 176], atol=1)
+    True
     """
     rv = stats.ncx2(2 * n, preal)
-    return rv.isf([alpha, 1 - alpha])
+    return rv.ppf([alpha, 1 - alpha])
 
 
 def power_upper_limit(pmeas, n=1, c=0.95):

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -21,7 +21,15 @@ __all__ = ['p_multitrial_from_single_trial',
            'chi2_logp',
            'equivalent_gaussian_Nsigma',
            'equivalent_gaussian_Nsigma_from_logp',
-           'power_upper_limit']
+           'power_confidence_limits',
+           'power_upper_limit',
+           'pf_from_ssig',
+           'pf_from_a',
+           'pf_upper_limit',
+           'a_from_pf',
+           'a_from_ssig',
+           'ssig_from_a',
+           'ssig_from_pf']
 
 
 @vectorize([float64(float32),

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -29,7 +29,8 @@ __all__ = ['p_multitrial_from_single_trial',
            'a_from_pf',
            'a_from_ssig',
            'ssig_from_a',
-           'ssig_from_pf']
+           'ssig_from_pf',
+           'amplitude_upper_limit']
 
 
 @vectorize([float64(float32),

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -808,7 +808,6 @@ def power_confidence_limits(preal, n=1, alpha=0.16):
 
     Examples
     --------
-    >>> power_confidence_limits(preal, n=1, alpha=0.16)
     >>> cl = power_confidence_limits(150)
     >>> np.allclose(cl, [127, 176], atol=1)
     True

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -889,6 +889,9 @@ def pf_upper_limit(pmeas, counts, n=1, c=0.95):
     pmeas: float
         The measured value of power
 
+    counts: int
+        The number of counts in the light curve used to calculate the spectrum
+
     Other Parameters
     ----------------
     n: int

--- a/stingray/tests/test_stats.py
+++ b/stingray/tests/test_stats.py
@@ -213,7 +213,6 @@ class TestClassicalSignificances(object):
         p = z2_n_probability(stat, n=n)
         assert np.allclose(logp, np.log(p))
 
-    def test_probability_of_power_implementation(self):
+    def test_power_upper_limit(self):
         # Use example from Vaughan+94
         assert np.isclose(power_upper_limit(40, 1, 0.99), 75, rtol=0.1)
-

--- a/stingray/tests/test_stats.py
+++ b/stingray/tests/test_stats.py
@@ -212,3 +212,8 @@ class TestClassicalSignificances(object):
         logp = z2_n_logprobability(stat, n=n)
         p = z2_n_probability(stat, n=n)
         assert np.allclose(logp, np.log(p))
+
+    def test_probability_of_power_implementation(self):
+        # Use example from Vaughan+94
+        assert np.isclose(power_upper_limit(40, 1, 0.99), 75, rtol=0.1)
+


### PR DESCRIPTION
Resolve #492 

I added a bunch of utility functions in `stingray.stats`, including `amplitude_upper_limit` which calculates the maximum modulation amplitude that would produce the given value of power (in Leahy normalization) at the C confidence level, using material Vaughan+94 and Groth+75. This also works for the Z^2_n search, since the statistic is equivalent (e.g. Brazier+94) and corresponding to the noncentral chi squared distribution with 2n degrees of freedom, where n is either the number of summed power spectral bins (adjacent or harmonics, it's equivalent) or the "n" in Z^2_n.

Upper limits in Powerspectrum and AveragedPowerspectrum now available through
```
pds.modulation_upper_limit(fmin, fmax, confidence_level)
```
