### PR TITLE
Extending the Multitapering concept to unevenly sampled time-series: Multitaper Lomb-Scargle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     numpy>=1.11.0
     scipy>=0.18.0
     matplotlib>=1.3
+    nfft
 
 [options.entry_points]
 console_scripts =

--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -243,8 +243,16 @@ class Multitaper(Powerspectrum):
             self.freq, self.multitaper_norm_power = \
                 self._multitaper_lomb_scargle(lc, NW=NW, low_bias=low_bias)
 
-            # Same for the timebeing until normalization discrepancy is resolved
-            self.unnorm_power = self.multitaper_norm_power
+            # Unnormalizing the LS PSD
+            self.unnorm_power = \
+                self.multitaper_norm_power / (0.5 * (lc.tseg - lc.dt) / lc.n)
+
+            # log_nphots = np.log(self.nphots)
+            # actual_nphots = np.float64(np.sqrt(np.exp(log_nphots + log_nphots)))
+
+            # # Unnormalized LS seems to Leahy normalized as per Stingray
+            # # Thus unnormalizing
+            # self.unnorm_power *= actual_nphots / 2.0
 
         else:
             self.freq, self.multitaper_norm_power = \

--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -802,5 +802,6 @@ class Multitaper(Powerspectrum):
         freq_ls = np.arange(0, psd_ls.shape[-1])*(1/tseg)
 
         self.jk_var_deg_freedom = None
+        self.eigvals = eigvals
 
         return freq_ls, psd_ls

--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -699,7 +699,7 @@ class Multitaper(Powerspectrum):
             The amplitude/value at each time in times
 
         num_freq: int, optional, default = ``2 * len(times)``
-            The number of frequencies at which to evaluate the result 
+            The number of frequencies at which to evaluate the result
 
         Returns
         -------
@@ -709,7 +709,7 @@ class Multitaper(Powerspectrum):
         """
         series_len = times.shape[-1]
 
-        if num_freq == None:
+        if num_freq is None:
             num_freq = 2 * series_len
 
         tseg = times[-1] - times[0]
@@ -749,7 +749,7 @@ class Multitaper(Powerspectrum):
             The amplitude/value at each time in times
 
         weight: float, optional, default = ``1``
-            The weight to multiply with the NFFT's result 
+            The weight to multiply with the NFFT's result
 
         Returns
         -------

--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -243,7 +243,7 @@ class Multitaper(Powerspectrum):
             self.freq, self.multitaper_norm_power = \
                 self._multitaper_lomb_scargle(lc, NW=NW, low_bias=low_bias)
 
-            # Unnormalizing the LS PSD
+            # Unnormalizing the PSD normalizaed in self.lomb_scargle()
             self.unnorm_power = \
                 self.multitaper_norm_power / (0.5 * (lc.tseg - lc.dt) / lc.n)
 
@@ -253,6 +253,12 @@ class Multitaper(Powerspectrum):
             # # Unnormalized LS seems to Leahy normalized as per Stingray
             # # Thus unnormalizing
             # self.unnorm_power *= actual_nphots / 2.0
+
+            # Unnormalizing from Leahy norm
+            self.unnorm_power = self.unnorm_power * self.var / 2
+
+            # Converting to Stingray's unnorm_power equivalent
+            self.unnorm_power = self.unnorm_power * lc.n / lc.dt
 
         else:
             self.freq, self.multitaper_norm_power = \

--- a/stingray/tests/test_multitaper.py
+++ b/stingray/tests/test_multitaper.py
@@ -131,9 +131,10 @@ class TestMultitaper(object):
             assert np.any(["not poisson" in r.message.args[0]
                            for r in record])
 
-    def test_fourier_multitaper_with_invalid_NW(self):
+    @pytest.mark.parametrize('lombscargle', [False, True])
+    def test_fourier_multitaper_with_invalid_NW(self, lombscargle):
         with pytest.raises(ValueError):
-            mtp = Multitaper(self.lc, NW=0.1)
+            mtp = Multitaper(self.lc, NW=0.1, lombscargle=lombscargle)
 
     @pytest.mark.parametrize("adaptive, jackknife",
                              [(a, j) for a in (True, False) for j in (True, False)])
@@ -244,9 +245,10 @@ class TestMultitaper(object):
                        for r in record])
         assert mtp.multitaper_norm_power is not None
 
-    def test_max_eigval_less_than_threshold(self):
+    @pytest.mark.parametrize('lombscargle', [False, True])
+    def test_max_eigval_less_than_threshold(self, lombscargle):
         with pytest.warns(UserWarning) as record:
-            mtp = Multitaper(lc=self.lc, NW=0.5, low_bias=True)
+            mtp = Multitaper(lc=self.lc, NW=0.5, low_bias=True, lombscargle=lombscargle)
         assert np.any(['not properly use low_bias' in r.message.args[0]
                        for r in record])
         assert len(mtp.eigvals) > 0
@@ -263,3 +265,38 @@ class TestMultitaper(object):
         with pytest.raises(ValueError):
             el = EventList.from_lc(self.lc)
             mtp_el = Multitaper(data=el)
+
+    def test_multitaper_lombscargle(self):
+        rng = np.random.default_rng()
+        N = 1000
+
+        white_noise_irregular = rng.normal(loc=0.0, scale=7, size=N)
+        start = 0.0
+        end = 9.0
+        # Generating uneven sampling times by adding white noise. Do tell a better way
+        time_irregular = np.linspace(start, end, N) + rng.normal(loc=0.0,
+                                                                 scale=(end-start)/(3*N), size=N)
+        time_irregular = np.sort(time_irregular)
+
+        with pytest.warns(UserWarning) as record:
+            lc_nonuni = Lightcurve(time=time_irregular,
+                                   counts=white_noise_irregular, err_dist="gauss")
+        assert np.any(["Bin sizes in input time array" in r.message.args[0]
+                       for r in record])
+
+        mtls_white = Multitaper(lc_nonuni, lombscargle=True, low_bias=True, NW=4)
+        assert mtls_white.norm == "frac"
+        assert mtls_white.fullspec is False
+        assert mtls_white.meancounts == lc_nonuni.meancounts
+        assert mtls_white.nphots == np.float64(np.sum(lc_nonuni.counts))
+        assert mtls_white.err_dist == lc_nonuni.err_dist
+        assert mtls_white.dt == lc_nonuni.dt
+        assert mtls_white.n == lc_nonuni.time.shape[0]
+        assert mtls_white.df == 1.0 / lc_nonuni.tseg
+        assert mtls_white.m == 1
+        assert mtls_white.freq is not None
+        assert mtls_white.multitaper_norm_power is not None
+        assert mtls_white.power is not None
+        assert mtls_white.power_err is not None
+        assert mtls_white.jk_var_deg_freedom is None  # Not supported yet
+        assert len(mtls_white.eigvals) > 0


### PR DESCRIPTION
These additions apply the multitapering concept to signals with uneven temporal sampling in order to estimate their power spectrum density. The Lomb (1976) Scargle (1982) periodogram used to calculate the PSD is rapidly computed using the `[nfft](https://github.com/jakevdp/nfft)` library, as shown by Leroy (2012), using the decomposition of Press & Rybicki (1989).

The normalization and frequency outputs are currently set so as to replicate the result of [Springford, Eadie & Thompson (2020)](https://iopscience.iop.org/article/10.3847/1538-3881/ab7fa1). 

Adds to #361.