### PR TITLE
Extending the Multitapering concept to unevenly sampled time-series: Multitaper Lomb-Scargle

### DIFF
--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -11,7 +11,12 @@ import scipy
 import scipy.optimize
 import scipy.stats
 from scipy import signal, fft, interpolate
-from astropy.timeseries import LombScargle
+
+# location of LombScargle moved between astropy versions
+try:
+    from astropy.timeseries import LombScargle
+except ImportError:
+    from astropy.stats import LombScargle
 
 from .events import EventList
 from .lightcurve import Lightcurve

--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -55,6 +55,12 @@ class Multitaper(Powerspectrum):
         90% spectral concentration within the bandwidth (still using
         a maximum of 2NW tapers)
 
+    lombscargle: boolean, optional, default ``False``
+        Whether to use the Lomb (1976) Scargle (1982) periodogram when
+        calculating the Multitaper spectral estimate. Highly recommended for
+        unevenly sampled time-series. Adaptive weighting and jack-knife
+        estimated variance are yet not supported.
+
     Other Parameters
     ----------------
     gti: 2-d float array

--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -720,7 +720,7 @@ class Multitaper(Powerspectrum):
 
         Notes
         -----
-        Dose not currently support adapative weighting or jack-knife estimates.
+        Does not currently support adapative weighting or jack-knife estimates.
         """
 
         lc.apply_gtis()  # Remove bins with missing data

--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -347,7 +347,8 @@ class Multitaper(Powerspectrum):
         if lc.n % 2 == 0:
             freq_response[..., -1] /= np.sqrt(2.)
 
-        freq_multitaper = scipy.fft.rfftfreq(lc.n, d=lc.dt)
+        freq_response = freq_response[..., 1:-1]
+        freq_multitaper = scipy.fft.rfftfreq(lc.n, d=lc.dt)[1:-1]
 
         if adaptive:
             psd_multitaper, weights_multitaper = \
@@ -780,7 +781,7 @@ class Multitaper(Powerspectrum):
 
         # The frequencies rest of Stingray uses
         freq_multitaper_ls = fft.rfftfreq(
-            n=lc.n, d=lc.dt)[1:]  # Avoiding zero
+            n=lc.n, d=lc.dt)[1:-1]  # Avoiding zero
 
         for values in dpss_data_interpolated:
 

--- a/stingray/tests/test_multitaper.py
+++ b/stingray/tests/test_multitaper.py
@@ -310,5 +310,12 @@ class TestMultitaper(object):
         mtp_ls = Multitaper(self.lc, lombscargle=True, adaptive=False, norm=norm)
 
         # Check if 99% of the points in the PSDs are within the set tolerance
-        assert np.sum(np.isclose(mtp.power[1:], mtp_ls.power,
+        assert np.sum(np.isclose(mtp.power, mtp_ls.power,
                       atol=0.022*np.max(mtp_ls.power))) >= 0.99*mtp_ls.power.size
+
+        # Check if the freq vals are the same
+        ps = Powerspectrum(self.lc, norm=norm)
+
+        assert np.allclose(mtp.freq, mtp_ls.freq)
+        assert np.allclose(mtp.freq, ps.freq)
+        assert mtp.power.shape == ps.power.shape

--- a/stingray/tests/test_multitaper.py
+++ b/stingray/tests/test_multitaper.py
@@ -18,7 +18,7 @@ class TestMultitaper(object):
     @classmethod
     def setup_class(cls):
         tstart = 0.0
-        tend = 1.0
+        tend = 1.484
         dt = 0.0001
 
         time = np.arange(tstart + 0.5*dt, tend + 0.5*dt, dt)


### PR DESCRIPTION
These additions apply the multitapering concept to signals with uneven temporal sampling in order to estimate their power spectrum density. The Lomb (1976) Scargle (1982) periodogram used to calculate the PSD is rapidly computed using Astropy. 

This method is presented in Springford, Eadie & Thompson (2020).

Adds to #361 and #578, and replaces #583.

The newly added functionality is showcased at the end of [this](https://github.com/dhruv9vats/notebooks/blob/multitaper_periodogram/Multitaper/Multitaper_showcase.ipynb) notebook.