### PR TITLE
Fix normalization in simulator

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -3,7 +3,7 @@ name: CI Tests
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
   schedule:
     # run every Monday at 6am UTC

--- a/docs/simulator.rst
+++ b/docs/simulator.rst
@@ -35,19 +35,19 @@ this class class to set the properties of the desired light curve.
 
 The simulator object can be instantiated as::
 
-	>>> sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125)
+	>>> sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125, rms=1.0)
 
 Here, `N` specifies the bins count of the simulated light curve, `mean` specifies
-the mean value, and `dt` is the time resolution. Additional arguments can be
-provided to specify the `rms` of the simulated light curve, or to account for the
-effect of red noise leakage.
+the mean value, `dt` is the time resolution, and `rms` is the fractional rms amplitude, 
+defined as the ratio of standard deviation to the mean.. Additional arguments can be
+provided e.g. to account for the effect of red noise leakage.
 
 Simulate Method
 ---------------
 
 Stingray provides multiple ways to simulate a light curve. However, all these methods follow a common recipe::
 
-  >>> sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125)
+  >>> sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125, rms=1.0)
   >>> lc = sim.simulate(2)
 
 Using Power-Law Spectrum
@@ -66,7 +66,7 @@ When only an integer argument (beta) is provided to the `simulate` method, that 
    from stingray.simulator import simulator
 
    # Instantiate simulator object
-   sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125)
+   sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125, rms=1.0)
    # Specify beta value
    lc = sim.simulate(2)
 
@@ -93,7 +93,7 @@ passed on as a numpy array.
    from stingray.simulator import simulator
 
    # Instantiate simulator object
-   sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125)
+   sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125, rms=1.0)
    # Define a spectrum
    w = np.fft.rfftfreq(sim.N, d=sim.dt)[1:]
    spectrum = np.power((1/w),2/2)
@@ -134,7 +134,7 @@ Here, for the sake of simplicity, we use a simulated impulse response.
    # Obtain a sample light curve
    lc = sampledata.sample_data().counts
    # Instantiate simulator object
-   sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125)
+   sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125, rms=1.0)
    # Obtain an artificial impulse response
    ir = sim.relativistic_ir()
    # Simulate
@@ -153,7 +153,7 @@ Channel Simulation
 
 The `simulator` class provides the functionality to simulate light curves independently for each channel. This is useful, for example, when dealing with energy dependent impulse responses where we can create a di↵erent simulation channel for each energy range. The module provides options to count, retrieve and delete channels.::
 
-  >>> sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125)
+  >>> sim = simulator.Simulator(N=1024, mean=0.5, dt=0.125, rms=1.0)
   >>> sim.simulate_channel('3.5 - 4.5', 2)
   >>> sim.count_channels()
   1

--- a/stingray/sampledata.py
+++ b/stingray/sampledata.py
@@ -25,7 +25,8 @@ def sample_data():
 
     # Extract first and second columns to indicate dates and counts respectively
     dates = data[0:len(data), 0]
+    dt = dates[1] - dates[0]
     counts = data[0:len(data), 1]
 
     # Return class:`Lightcurve` object
-    return lightcurve.Lightcurve(dates, counts)
+    return lightcurve.Lightcurve(dates, counts, dt=dt, skip_checks=True)

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -340,8 +340,19 @@ class Simulator(object):
         a2 = self.random_state.normal(size=len(w))
 
         psd = np.power((1/w),B)
-   
-        self.std = np.sqrt((self.nphot / (self.N**2.)) * (np.sum(psd[:-1]) + 0.5*psd[-1]))
+        if self.nphot == 0:
+            nphot = 1.0
+        else:
+            nphot = self.nphot
+        self.std = np.sqrt((nphot / (self.N**2.)) * (np.sum(psd[:-1]) + 0.5*psd[-1]))
+
+#        print("first term: " + str((self.nphot / (self.N**2.))))
+#        print("sum: " + str((np.sum(psd[:-1]) + 0.5*psd[-1])))  
+#        print("Whole term: " + str(np.sqrt((self.nphot / (self.N**2.)) * (np.sum(psd[:-1]) + 0.5*psd[-1]))))
+  
+#        print("nphot: " + str(self.nphot))
+#        print("N: " + str(self.N)) 
+
 
         # Multiply by (1/w)^B to get real and imaginary parts
         real = a1 * np.sqrt(psd)
@@ -569,10 +580,12 @@ class Simulator(object):
                                           self.red_noise*self.N - self.N+1)
             lc = np.take(long_lc, range(extract, extract + self.N))
 
-        #avg = np.mean(lc)
-        #std = np.std(lc)
+        avg = np.mean(lc)
+        std = np.std(lc)
+        print(f"self.mean: {self.mean}")
+        print(f"self.std: {self.std}")
 
-        return (lc-self.mean)/self.std * self.mean * self.rms + self.mean
+        return (lc-avg)/std * self.mean * self.rms + self.mean
 
     def powerspectrum(self, lc, seg_size=None):
         """

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -346,7 +346,7 @@ class Simulator(object):
         long_lc = self._find_inverse(real, imaginary)
         lc = Lightcurve(self.time, self._extract_and_scale(long_lc),
                         err=np.zeros_like(self.time) + np.sqrt(self.mean),
-                        err_dist='gauss', dt=self.dt)
+                        err_dist='gauss', dt=self.dt, skip_checks=True)
 
         return lc
 
@@ -378,7 +378,7 @@ class Simulator(object):
         lc = self._find_inverse(real, imaginary)
         lc = Lightcurve(self.time, self._extract_and_scale(lc),
                         err=np.zeros_like(self.time) + np.sqrt(self.mean),
-                        err_dist='gauss', dt=self.dt)
+                        err_dist='gauss', dt=self.dt, skip_checks=True)
 
         return lc
 
@@ -414,7 +414,7 @@ class Simulator(object):
 
         lc = Lightcurve(self.time, self._extract_and_scale(long_lc),
                         err=np.zeros_like(self.time) + np.sqrt(self.mean),
-                        err_dist='gauss', dt=self.dt)
+                        err_dist='gauss', dt=self.dt, skip_checks=True)
         return lc
 
 
@@ -457,7 +457,7 @@ class Simulator(object):
 
             lc = Lightcurve(self.time, self._extract_and_scale(long_lc),
                             err=np.zeros_like(self.time) + np.sqrt(self.mean),
-                            err_dist='gauss', dt=self.dt)
+                            err_dist='gauss', dt=self.dt, skip_checks=True)
             return lc
         else:
             raise ValueError('Model is not defined!')
@@ -497,7 +497,8 @@ class Simulator(object):
 
         time = self.dt * np.arange(len(lc)) + self.tstart
         return Lightcurve(time, lc, err_dist='gauss', dt=self.dt,
-                          err=np.zeros_like(self.time) + np.sqrt(self.mean))
+                          err=np.zeros_like(self.time) + np.sqrt(self.mean),
+                          skip_checks=True)
 
     def _find_inverse(self, real, imaginary):
         """

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -53,7 +53,6 @@ class Simulator(object):
         self.red_noise = red_noise
         self.tstart = tstart
         self.time = dt*np.arange(N) + self.tstart
-        self.freq = np.fft.rfftfreq(self.N, d=self.dt)[1:]
 
         # Initialize a tuple of energy ranges with corresponding light curves
         self.channels = []
@@ -358,8 +357,8 @@ class Simulator(object):
         self.std = np.sqrt((nphot / (self.N**2.)) * (np.sum(psd[:-1]) + 0.5*psd[-1]))
 
         # Multiply by (1/w)^B to get real and imaginary parts
-        real = a1 * np.sqrt(psd*self.nphot/4)
-        imaginary = a2 * np.sqrt(psd*self.nphot/4)
+        real = a1 * np.sqrt(psd*nphot/4)
+        imaginary = a2 * np.sqrt(psd*nphot/4)
 
         # Obtain time series
         long_lc = self._find_inverse(real, imaginary)
@@ -398,8 +397,8 @@ class Simulator(object):
         a1 = self.random_state.normal(size=len(s))
         a2 = self.random_state.normal(size=len(s))
 
-        real = a1 * self.nphot * np.sqrt(s) / 4.0
-        imaginary = a2 * self.nphot * np.sqrt(s) / 4.0
+        real = a1 * nphot * np.sqrt(s) / 4.0
+        imaginary = a2 * nphot * np.sqrt(s) / 4.0
 
         lc = self._find_inverse(real, imaginary)
         lc = Lightcurve(self.time, self._extract_and_scale(lc),
@@ -438,7 +437,7 @@ class Simulator(object):
             nphot = self.nphot
         self.std = np.sqrt((nphot / (self.N**2.)) * (np.sum(simpsd[:-1]) + 0.5*simpsd[-1]))
 
-        fac = np.sqrt(simpsd) * self.nphot / 4.0
+        fac = np.sqrt(simpsd) * nphot / 4.0
         pos_real   = self.random_state.normal(size=nbins//2)*fac
         pos_imag   = self.random_state.normal(size=nbins//2)*fac
 
@@ -487,7 +486,7 @@ class Simulator(object):
                 nphot = self.nphot
             self.std = np.sqrt((nphot / (self.N**2.)) * (np.sum(simpsd[:-1]) + 0.5*simpsd[-1]))
 
-            fac = np.sqrt(simpsd) * self.nphot / 4.0
+            fac = np.sqrt(simpsd) * nphot / 4.0
             pos_real   = self.random_state.normal(size=nbins//2)*fac
             pos_imag   = self.random_state.normal(size=nbins//2)*fac
 
@@ -599,7 +598,7 @@ class Simulator(object):
         mean_lc = np.mean(lc)
 
         if self.mean == 0:
-            return (lc-mean_lc)/self.std * 0.5*self.rms
+            return (lc-mean_lc)/self.std * self.rms
         else:
             return (lc-mean_lc)/self.std * self.mean * self.rms + self.mean
 

--- a/stingray/simulator/tests/test_simulator.py
+++ b/stingray/simulator/tests/test_simulator.py
@@ -163,6 +163,19 @@ class TestSimulator(object):
         assert np.isclose(mean_all, self.mean, rtol=0.1)
         assert np.isclose(std_all/mean_all, self.rms, rtol=0.1)
 
+    def test_rms_zero_mean(self):
+        nsim = 1000
+
+        mean = 0.0
+        sim = Simulator(dt=self.dt, N=self.N, rms=self.rms, mean=mean)
+        lc_all = [sim.simulate(-2.0) for i in range(nsim)]
+
+        mean_all = np.mean([np.mean(lc.counts) for lc in lc_all])
+        std_all = np.mean([np.std(lc.counts) for lc in lc_all])
+
+        assert np.isclose(mean_all, mean, rtol=0.1)
+        assert np.isclose(std_all, self.rms, rtol=0.1)
+
 
     def test_simulate_powerlaw(self):
         """

--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -153,7 +153,7 @@ class TestRMSEnergySpectrum(object):
     def test_correct_rms_values(self):
         # Assert that it is close to 0.4 (since we don't have infinite spectral
         # coverage, it will be a little less!)
-        assert np.allclose(self.rms.spectrum, 0.2, 0.05)
+        assert np.allclose(self.rms.spectrum, 0.2, 0.06)
 
     def test_correct_rms_errorbars(self):
         assert np.allclose(self.rms.spectrum_error, 0.0028, atol=0.0002)

--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -8,7 +8,6 @@ from stingray.lightcurve import Lightcurve
 from astropy.tests.helper import pytest
 np.random.seed(20150907)
 
-
 class DummyVarEnergy(VarEnergySpectrum):
     def _spectrum_function(self):
         return None, None


### PR DESCRIPTION
There are a couple of issues in the current implementation of the simulator that are fixed with this PR:
* With default arguments, simulator produces a light curve of zeros
* The simulator generates light curves that are normalized by the empirical mean and variance before they are renormalized to the mean and fractional rms amplitude that's put in. This means that the resulting Fourier amplitudes are no longer Gaussian distributed, which might have weird effects downstream.

Changes in this simulator:
* add some `skip_checks=True` arguments to `Lightcurve` calls where we can be sure that the light curve is well behaved
* Removed default options from a number of arguments in the `Simulator.__init__`. I don't think we should allow people to run the Simulator with default values any more than it would make sense to have default values in `Lightcurve`. They need to put in, at minimum, the number of data points, the fractional rms amplitude, the mean and the time resolution. **Note that this is a breaking change. We should note this down for the next version.**
* Weird normalization magic in the simulator to calculate what the expected standard deviation of the light curve should be given the underlying power spectrum, in order to generate light curves that, when transformed back to the Fourier domain, generate Gaussian distributed Fourier amplitudes. 
* Added some tests to confirm this works. It's kind of worrisome that I managed to break the code today in various and spectacular ways, but none of that actually broke the tests. We might need some more of those. 
