### PR TITLE
Fix integer times in simulator

### DIFF
--- a/stingray/simulator/base.py
+++ b/stingray/simulator/base.py
@@ -157,9 +157,7 @@ def simulate_times_from_count_array(time, counts, gti, dt, use_spline=False):
     tmin = gti[0, 0]
     tmax = gti[-1, 1]
     duration = (tmax - tmin)
-    phase_bins = np.copy(time)
-    phase_bins -= tmin
-    phase_bins /= duration
+    phase_bins = (time - tmin) / duration
     dph = dt / duration
 
     counts = np.concatenate(([0], counts))

--- a/stingray/simulator/base.py
+++ b/stingray/simulator/base.py
@@ -116,6 +116,8 @@ def simulate_times_from_count_array(time, counts, gti, dt, use_spline=False):
     True
     >>> np.any((times > 4.) & (times < 5.))  # No times outside GTIs
     False
+    >>> # test that it works with integer times (former bug)
+    >>> times = simulate_times_from_count_array([0, 1, 2, 3, 5], c, gti, 1, use_spline=True)
     >>> c[0] = -3.
     >>> simulate_times_from_count_array(t, c, gti, 1)  # Test with one negative value in the lc
     Traceback (most recent call last):


### PR DESCRIPTION
From a private report:
```
In [9]: ev = EventList()
   ...: ev.simulate_times(lc)
   ...: ev.time
---------------------------------------------------------------------------
UFuncTypeError                            Traceback (most recent call last)
<ipython-input-9-8e2de76e3da1> in <module>
      1 ev = EventList()
----> 2 ev.simulate_times(lc)
      3 ev.time

/soft/anaconda3/envs/3point8/lib/python3.8/site-packages/stingray/events.py in simulate_times(self, lc, use_spline, bin_time)
    274                           DeprecationWarning)
    275 
--> 276         self.time = simulate_times(lc, use_spline=use_spline)
    277         self.gti = lc.gti
    278         self.ncounts = len(self.time)

/soft/anaconda3/envs/3point8/lib/python3.8/site-packages/stingray/simulator/base.py in simulate_times(lc, use_spline)
     64     ValueError: simulate_times can only work with...
     65     """
---> 66     return simulate_times_from_count_array(
     67         lc.time, lc.counts, lc.gti, lc.dt, use_spline=use_spline)
     68 

/soft/anaconda3/envs/3point8/lib/python3.8/site-packages/stingray/simulator/base.py in simulate_times_from_count_array(time, counts, gti, dt, use_spline)
    159     duration = (tmax - tmin)
    160     phase_bins = np.copy(time)
--> 161     phase_bins -= tmin
    162     phase_bins /= duration
    163     dph = dt / duration

UFuncTypeError: Cannot cast ufunc 'subtract' output from dtype('float
```

This fixes the problem.