### PR TITLE
Improve performance of existing GTI operations; add new GTI operations

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -49,6 +49,12 @@ Other future additions we are currently implementing are:
 * pulsar searches with :math:`H`-test
 * binary pulsar searches
 
+Platform-specific issues
+------------------------
+
+Windows uses an internal 32-bit representation for ``int``. This might create numerical errors when using large integer numbers (e.g. when calculating the sum of a light curve, if the ``lc.counts`` array is an integer).
+Windows users are encouraged to always avoid the use integer arrays in ``Lightcurve`` objects.
+
 Presentations
 =============
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -53,7 +53,7 @@ Platform-specific issues
 ------------------------
 
 Windows uses an internal 32-bit representation for ``int``. This might create numerical errors when using large integer numbers (e.g. when calculating the sum of a light curve, if the ``lc.counts`` array is an integer).
-Windows users are encouraged to always avoid the use integer arrays in ``Lightcurve`` objects.
+On Windows, we automatically convert the ``counts`` array to float. The small numerical errors should be a relatively small issue compare to the above.
 
 Presentations
 =============

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ all =
     emcee>=3.0.0
     statsmodels
     corner
-    lightcurve
+    lightkurve
     pyfftw
     h5py
     pint-pulsar

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -13,7 +13,7 @@ import numpy.random as ra
 from astropy.table import Table
 
 from .filters import get_deadtime_mask
-from .gti import append_gtis, check_separate, cross_gtis, generate_indices_of_segment_boundaries_unbinned, generate_indices_of_gti_boundaries
+from .gti import append_gtis, check_separate, cross_gtis, generate_indices_of_boundaries
 from .io import load_events_and_gtis
 from .lightcurve import Lightcurve
 from .utils import assign_value_if_none, simon, interpret_times
@@ -213,11 +213,8 @@ class EventList(object):
             Generates one :class:`stingray.Lightcurve` object for each GTI or segment
         """
 
-        if segment_size is not None:
-            segment_iter = generate_indices_of_segment_boundaries_unbinned(
-                self.time, self.gti, segment_size)
-        else:
-            segment_iter = generate_indices_of_gti_boundaries(self.time, self.gti, dt=0)
+        segment_iter = generate_indices_of_boundaries(
+            self.time, self.gti, segment_size=segment_size, dt=0)
 
         for st, end, idx_st, idx_end in segment_iter:
             tseg = end - st

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -13,7 +13,7 @@ import numpy.random as ra
 from astropy.table import Table
 
 from .filters import get_deadtime_mask
-from .gti import append_gtis, check_separate, cross_gtis, get_segment_events_idx, get_gti_events_idx
+from .gti import append_gtis, check_separate, cross_gtis, generate_indices_of_segment_boundaries_unbinned, generate_indices_of_gti_boundaries
 from .io import load_events_and_gtis
 from .lightcurve import Lightcurve
 from .utils import assign_value_if_none, simon, interpret_times
@@ -214,9 +214,10 @@ class EventList(object):
         """
 
         if segment_size is not None:
-            segment_iter = get_segment_events_idx(self.time, self.gti, segment_size)
+            segment_iter = generate_indices_of_segment_boundaries_unbinned(
+                self.time, self.gti, segment_size)
         else:
-            segment_iter = get_gti_events_idx(self.time, self.gti, dt=0)
+            segment_iter = generate_indices_of_gti_boundaries(self.time, self.gti, dt=0)
 
         for st, end, idx_st, idx_end in segment_iter:
             tseg = end - st

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -233,6 +233,9 @@ class EventList(object):
         ----------
         dt: float
             Binning time of the light curves
+
+        Other parameters
+        ----------------
         segment_size : float, default None
             Optional segment size. If None, use the GTI boundaries
 

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -26,8 +26,7 @@ def gti_len(gti):
     """Deprecated. Use get_total_gti_length."""
     warnings.warn("This function is deprecated. Use get_total_gti_length instead",
                   DeprecationWarning)
-    gti = np.array(gti)
-    return np.sum(gti[:, 1] - gti[:, 0])
+    return get_total_gti_length(gti, minlen=0)
 
 
 def get_gti_lengths(gti):

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -1079,7 +1079,14 @@ def time_intervals_from_gtis(gtis, chunk_length, fraction_step=1,
 
 
 def get_segment_bin_start(startbin, stopbin, nbin, fraction_step=1):
-    """Get start of intervals of equal length, given bin number range
+    """Get the starting indices of intervals of equal length.
+
+    A bit like `np.arange`, but checks that the last number is
+    at least ``nbin`` less than ``stopbin``. Useful when getting
+    starting intervals of equal chunks of a binned light curve.
+
+    It is possible to make these intervals sliding, through the
+    ``fraction_step`` parameter.
 
     Parameters
     ----------
@@ -1095,9 +1102,9 @@ def get_segment_bin_start(startbin, stopbin, nbin, fraction_step=1):
     Other Parameters
     ----------------
     fraction_step : float
-        If the step is not a full ``chunk_length`` but less (e.g. a moving window),
-        this indicates the ratio between step step and ``chunk_length`` (e.g.
-        ``0.5`` means that the window shifts of half ``chunk_length``)
+        If the step is not a full ``nbin`` but less (e.g. a moving window),
+        this indicates the ratio between the step and ``nbin`` (e.g.
+        ``0.5`` means that the window shifts of half ``nbin``)
 
     Returns
     -------

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -1080,7 +1080,7 @@ def time_intervals_from_gtis(gtis, chunk_length, fraction_step=1,
     return spectrum_start_times, spectrum_start_times + chunk_length
 
 
-def get_segment_bin_start(startbin, stopbin, nbin, fraction_step=1):
+def calculate_segment_bin_start(startbin, stopbin, nbin, fraction_step=1):
     """Get the starting indices of intervals of equal length.
 
     A bit like `np.arange`, but checks that the last number is
@@ -1116,13 +1116,13 @@ def get_segment_bin_start(startbin, stopbin, nbin, fraction_step=1):
 
     Examples
     --------
-    >>> st = get_segment_bin_start(0, 10000, 10000)
+    >>> st = calculate_segment_bin_start(0, 10000, 10000)
     >>> st[-1]
     0
-    >>> st = get_segment_bin_start(0, 5, 2)
+    >>> st = calculate_segment_bin_start(0, 5, 2)
     >>> st[-1]
     2
-    >>> st = get_segment_bin_start(0, 6, 2)
+    >>> st = calculate_segment_bin_start(0, 6, 2)
     >>> st[-1]
     4
     """
@@ -1226,7 +1226,8 @@ def bin_intervals_from_gtis(gtis, chunk_length, time, dt=None, fraction_step=1,
         if time[stopbin - 1] > g1:
             stopbin -= 1
 
-        newbins = get_segment_bin_start(startbin, stopbin, nbin, fraction_step=fraction_step)
+        newbins = calculate_segment_bin_start(
+            startbin, stopbin, nbin, fraction_step=fraction_step)
         spectrum_start_bins = \
             np.append(spectrum_start_bins,
                       newbins)
@@ -1323,8 +1324,6 @@ def gti_border_bins(gtis, time, dt=None, epsilon=0.001):
         spectrum_start_bins.append(startbin)
         spectrum_stop_bins.append(stopbin)
 
-    assert len(spectrum_start_bins) > 0, \
-        ("No GTIs are equal to or longer than chunk_length.")
     return np.array(spectrum_start_bins), np.array(spectrum_stop_bins)
 
 

--- a/stingray/gti.py
+++ b/stingray/gti.py
@@ -17,9 +17,9 @@ __all__ = ['load_gtis', 'check_gtis',
            'cross_two_gtis', 'cross_gtis', 'get_btis',
            'get_gti_extensions_from_pattern', 'get_gti_from_all_extensions',
            'get_gti_from_hdu', 'get_gti_lengths', 'get_total_gti_length',
-           'check_separate', 'append_gtis', 'join_gtis', 'get_gti_events_idx',
+           'check_separate', 'append_gtis', 'join_gtis', 'generate_indices_of_gti_boundaries',
            'time_intervals_from_gtis', 'bin_intervals_from_gtis',
-           'gti_border_bins', 'get_segment_events_idx', 'get_segment_binned_array_idx']
+           'gti_border_bins', 'generate_indices_of_segment_boundaries_unbinned', 'generate_indices_of_segment_boundaries_binned']
 
 
 def gti_len(gti):
@@ -1320,7 +1320,7 @@ def gti_border_bins(gtis, time, dt=None, epsilon=0.001):
     return np.array(spectrum_start_bins), np.array(spectrum_stop_bins)
 
 
-def get_gti_events_idx(times, gti, dt=0):
+def generate_indices_of_gti_boundaries(times, gti, dt=0):
     """Get the indices of events from different GTIs of the observation.
 
     This is a generator, yielding the boundaries of each GTI and the
@@ -1355,7 +1355,7 @@ def get_gti_events_idx(times, gti, dt=0):
     --------
     >>> times = [0.1, 0.2, 0.5, 0.8, 1.1]
     >>> gtis = [[0, 0.55], [0.6, 2.1]]
-    >>> vals = get_gti_events_idx(times, gtis)
+    >>> vals = generate_indices_of_gti_boundaries(times, gtis)
     >>> v0 = next(vals)
     >>> np.allclose(v0[:2], gtis[0])
     True
@@ -1370,7 +1370,7 @@ def get_gti_events_idx(times, gti, dt=0):
         yield s, e, idx0, idx1
 
 
-def get_segment_events_idx(times, gti, segment_size):
+def generate_indices_of_segment_boundaries_unbinned(times, gti, segment_size):
     """Get the indices of events from different segments of the observation.
 
     This is a generator, yielding the boundaries of each segment and the
@@ -1402,7 +1402,7 @@ def get_segment_events_idx(times, gti, segment_size):
     --------
     >>> times = [0.1, 0.2, 0.5, 0.8, 1.1]
     >>> gtis = [[0, 0.55], [0.6, 2.1]]
-    >>> vals = get_segment_events_idx(times, gtis, 0.5)
+    >>> vals = generate_indices_of_segment_boundaries_unbinned(times, gtis, 0.5)
     >>> v0 = next(vals)
     >>> np.allclose(v0[:2], [0, 0.5])
     True
@@ -1428,7 +1428,7 @@ def get_segment_events_idx(times, gti, segment_size):
         yield s, e, idx0, idx1
 
 
-def get_segment_binned_array_idx(times, gti, segment_size, dt=None):
+def generate_indices_of_segment_boundaries_binned(times, gti, segment_size, dt=None):
     """Get the indices of binned times from different segments of the observation.
 
     This is a generator, yielding the boundaries of each segment and the
@@ -1460,7 +1460,7 @@ def get_segment_binned_array_idx(times, gti, segment_size, dt=None):
     --------
     >>> times = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]
     >>> gtis = [[0.05, 0.55]]
-    >>> vals = get_segment_binned_array_idx(times, gtis, 0.5, dt=0.1)
+    >>> vals = generate_indices_of_segment_boundaries_binned(times, gtis, 0.5, dt=0.1)
     >>> v0 = next(vals)
     >>> np.allclose(v0[:2], [0.1, 0.6])
     True

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -176,7 +176,7 @@ class Lightcurve(object):
 
         time = np.asarray(time)
         counts = np.asarray(counts)
-        if os.name == 'nt':
+        if os.name == 'nt':  # pragma: no cover
             warnings.warn(
                 "On Windows, the size of an integer is 32 bits. "
                 "To avoid integer overflow, I'm converting the input array to float")

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -177,11 +177,6 @@ class Lightcurve(object):
 
         time = np.asarray(time)
         counts = np.asarray(counts)
-        if os.name == 'nt':  # pragma: no cover
-            warnings.warn(
-                "On Windows, the size of an integer is 32 bits. "
-                "To avoid integer overflow, I'm converting the input array to float")
-            counts = counts.astype(float)
 
         if err is not None:
             err = np.asarray(err)
@@ -258,6 +253,11 @@ class Lightcurve(object):
 
         if not skip_checks:
             self.check_lightcurve()
+        if os.name == 'nt':
+            warnings.warn(
+                "On Windows, the size of an integer is 32 bits. "
+                "To avoid integer overflow, I'm converting the input array to float")
+            counts = counts.astype(float)
 
     @property
     def time(self):
@@ -603,8 +603,8 @@ class Lightcurve(object):
         >>> lc1 = Lightcurve(time, count1, gti=gti1, dt=5)
         >>> lc2 = Lightcurve(time, count2, gti=gti2, dt=5)
         >>> lc = lc1 + lc2
-        >>> lc.counts
-        array([ 900, 1300, 1200])
+        >>> np.allclose(lc.counts, [ 900, 1300, 1200])
+        True
         """
 
         return self._operation_with_other_lc(other, np.add)
@@ -632,8 +632,8 @@ class Lightcurve(object):
         >>> lc1 = Lightcurve(time, count1, gti=gti1, dt=10)
         >>> lc2 = Lightcurve(time, count2, gti=gti2, dt=10)
         >>> lc = lc1 - lc2
-        >>> lc.counts
-        array([ 300, 1100,  400])
+        >>> np.allclose(lc.counts, [ 300, 1100,  400])
+        True
         """
 
         return self._operation_with_other_lc(other, np.subtract)
@@ -653,8 +653,8 @@ class Lightcurve(object):
         >>> lc1 = Lightcurve(time, count1)
         >>> lc2 = Lightcurve(time, count2)
         >>> lc_new = -lc1 + lc2
-        >>> lc_new.counts
-        array([100, 100, 100])
+        >>> np.allclose(lc_new.counts, [100, 100, 100])
+        True
         """
         lc_new = Lightcurve(self.time, -1 * self.counts,
                             err=self.counts_err, gti=self.gti,
@@ -704,10 +704,10 @@ class Lightcurve(object):
         >>> time = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         >>> count = [11, 22, 33, 44, 55, 66, 77, 88, 99]
         >>> lc = Lightcurve(time, count, dt=1)
-        >>> lc[2]
-        33
-        >>> lc[:2].counts
-        array([11, 22])
+        >>> np.isclose(lc[2], 33)
+        True
+        >>> np.allclose(lc[:2].counts, [11, 22])
+        True
         """
         if isinstance(index, (int, np.integer)):
             return self.counts[index]
@@ -985,8 +985,8 @@ class Lightcurve(object):
         >>> lc = lc1.join(lc2)
         >>> lc.time
         array([ 5, 10, 15, 20, 25, 30])
-        >>> lc.counts
-        array([ 300,  100,  400,  600, 1200,  800])
+        >>> np.allclose(lc.counts, [ 300,  100,  400,  600, 1200,  800])
+        True
         """
         if self.mjdref != other.mjdref:
             warnings.warn("MJDref is different in the two light curves")
@@ -1107,17 +1107,16 @@ class Lightcurve(object):
         >>> count = [10, 20, 30, 40, 50, 60, 70, 80, 90]
         >>> lc = Lightcurve(time, count, dt=1)
         >>> lc_new = lc.truncate(start=2, stop=8)
-        >>> lc_new.counts
-        array([30, 40, 50, 60, 70, 80])
+        >>> np.allclose(lc_new.counts, [30, 40, 50, 60, 70, 80])
+        True
         >>> lc_new.time
         array([3, 4, 5, 6, 7, 8])
         >>> # Truncation can also be done by time values
         >>> lc_new = lc.truncate(start=6, method='time')
         >>> lc_new.time
         array([6, 7, 8, 9])
-        >>> lc_new.counts
-        array([60, 70, 80, 90])
-
+        >>> np.allclose(lc_new.counts, [60, 70, 80, 90])
+        True
         """
 
         if not isinstance(method, str):
@@ -1249,8 +1248,8 @@ class Lightcurve(object):
         >>> lc_new = lc.sort()
         >>> lc_new.time
         array([1, 2, 3])
-        >>> lc_new.counts
-        array([100, 200, 300])
+        >>> np.allclose(lc_new.counts, [100, 200, 300])
+        True
 
         Returns
         -------
@@ -1298,8 +1297,8 @@ class Lightcurve(object):
         >>> lc_new = lc.sort_counts()
         >>> lc_new.time
         array([2, 1, 3])
-        >>> lc_new.counts
-        array([100, 200, 300])
+        >>> np.allclose(lc_new.counts, [100, 200, 300])
+        True
         """
 
         new_counts, new_time, new_counts_err = \

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -12,7 +12,7 @@ import pickle
 import numpy as np
 
 from astropy.table import Table
-from astropy.time import TimeDelta
+from astropy.time import TimeDelta, Time
 from astropy import units as u
 
 import stingray.utils as utils
@@ -164,6 +164,7 @@ class Lightcurve(object):
         The full header of the original FITS file, if relevant
 
     """
+
     def __init__(self, time, counts, err=None, input_counts=True,
                  gti=None, err_dist='poisson', mjdref=0, dt=None,
                  skip_checks=False, low_memory=False, mission=None,
@@ -795,7 +796,6 @@ class Lightcurve(object):
     @staticmethod
     def make_lightcurve(toa, dt, tseg=None, tstart=None, gti=None, mjdref=0,
                         use_hist=False):
-
         """
         Make a light curve out of photon arrival times, with a given time resolution ``dt``.
         Note that ``dt`` should be larger than the native time resolution of the instrument
@@ -1462,7 +1462,8 @@ class Lightcurve(object):
         except ImportError:
             raise ImportError("You need to install Lightkurve to use "
                               "the Lightcurve.to_lightkurve() method.")
-        return lk(time=self.time, flux=self.counts, flux_err=self.counts_err)
+        time = Time(self.time / 86400 + self.mjdref, format="mjd", scale="utc")
+        return lk(time=time, flux=self.counts, flux_err=self.counts_err)
 
     @staticmethod
     def from_lightkurve(lk, skip_checks=True):
@@ -1477,6 +1478,7 @@ class Lightcurve(object):
             If True, the user specifies that data are already sorted and contain no
             infinite or nan points. Use at your own risk.
         """
+
         return Lightcurve(time=lk.time, counts=lk.flux,
                           err=lk.flux_err, input_counts=False,
                           skip_checks=skip_checks)
@@ -1723,7 +1725,6 @@ class Lightcurve(object):
         ts = Table.read(filename, format=format_)
         return Lightcurve.from_astropy_table(
             ts, err_dist=err_dist, skip_checks=skip_checks)
-
 
     def split_by_gti(self, gti=None, min_points=2):
         """

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1312,8 +1312,10 @@ class Lightcurve(object):
         return new_lc
 
     def estimate_chunk_length(self, *args, **kwargs):
+        """Deprecated alias of estimate_segment_size.
+        """
         warnings.warn("This function was renamed to estimate_segment_size", DeprecationWarning)
-        self.estimate_segment_size(*args, **kwargs)
+        return self.estimate_segment_size(*args, **kwargs)
 
     def estimate_segment_size(self, min_total_counts=100, min_time_bins=100):
         """Estimate a reasonable segment length for chunk-by-chunk analysis.

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -849,7 +849,11 @@ class Lightcurve(object):
 
         logging.info("make_lightcurve: tseg: " + str(tseg))
 
-        timebin = np.int64(tseg / dt)
+        timebin = int(tseg / dt)
+        # If we are missing the next bin by just 1%, let's round up:
+        if tseg / dt - timebin >= 0.99:
+            timebin += 1
+
         logging.info("make_lightcurve: timebin:  " + str(timebin))
 
         tend = tstart + timebin * dt

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -4,6 +4,7 @@ Definition of :class::class:`Lightcurve`.
 :class::class:`Lightcurve` is used to create light curves out of photon counting data
 or to save existing light curves in a class that's easy to use.
 """
+import os
 import logging
 import warnings
 import pickle
@@ -175,6 +176,12 @@ class Lightcurve(object):
 
         time = np.asarray(time)
         counts = np.asarray(counts)
+        if os.name == 'nt':
+            warnings.warn(
+                "On Windows, the size of an integer is 32 bits. "
+                "To avoid integer overflow, I'm converting the input array to float")
+            counts = counts.astype(float)
+
         if err is not None:
             err = np.asarray(err)
 

--- a/stingray/simulator/base.py
+++ b/stingray/simulator/base.py
@@ -153,7 +153,7 @@ def simulate_times_from_count_array(time, counts, gti, dt, use_spline=False):
         dt = dt
         t0 = time[0] - dt / 2
         t1 = time[0] + dt / 2
-        N = counts[0]
+        N = int(np.rint(counts[0]))
         return np.sort(np.random.uniform(t0, t1, N))
 
     tmin = gti[0, 0]

--- a/stingray/simulator/base.py
+++ b/stingray/simulator/base.py
@@ -100,21 +100,21 @@ def simulate_times_from_count_array(time, counts, gti, dt, use_spline=False):
 
     Examples
     --------
-    >>> t = [0.5, 1.5, 2.5, 3.5, 5.5]
+    >>> t = [0., 1., 2., 3., 5.]
     >>> c = [100] * 5
-    >>> gti = [[0, 4], [5, 6]]
+    >>> gti = [[-0.5, 3.5], [4.5, 5.5]]
     >>> times = simulate_times_from_count_array(t, c, gti, 1, use_spline=True)
     >>> np.all(np.diff(times) > 0)  # Output array is sorted
     True
-    >>> np.all(times >= 0.)  # All times inside GTIs
+    >>> np.all(times >= -0.5)  # All times inside GTIs
     True
-    >>> np.all(times <= 6.)
+    >>> np.all(times <= 5.5)
     True
-    >>> np.any(times > 5.)
+    >>> np.any(times > 4.5)
     True
-    >>> np.any(times < 4.)
+    >>> np.any(times < 3.5)
     True
-    >>> np.any((times > 4.) & (times < 5.))  # No times outside GTIs
+    >>> np.any((times > 3.5) & (times < 4.5))  # No times outside GTIs
     False
     >>> # test that it works with integer times (former bug)
     >>> times = simulate_times_from_count_array([0, 1, 2, 3, 5], c, gti, 1, use_spline=True)

--- a/stingray/tests/test_events.py
+++ b/stingray/tests/test_events.py
@@ -30,6 +30,7 @@ try:
 except ImportError:
     _HAS_YAML = False
 
+
 class TestEvents(object):
 
     @classmethod
@@ -207,8 +208,8 @@ class TestEvents(object):
         assert np.allclose(ev_new.time, [1, 2, 3])
 
     def test_join_different_dt(self):
-        ev = EventList(time=[10, 20, 30], dt = 1)
-        ev_other = EventList(time=[40, 50, 60], dt = 3)
+        ev = EventList(time=[10, 20, 30], dt=1)
+        ev_other = EventList(time=[40, 50, 60], dt=3)
         with pytest.warns(UserWarning):
             ev_new = ev.join(ev_other)
 
@@ -254,9 +255,9 @@ class TestEvents(object):
         """Join two overlapping event lists.
         """
         ev = EventList(time=[1, 1, 2, 3, 4],
-                        energy=[3, 4, 7, 4, 3], gti=[[1, 2],[3, 4]])
+                       energy=[3, 4, 7, 4, 3], gti=[[1, 2], [3, 4]])
         ev_other = EventList(time=[5, 6, 6, 7, 10],
-                            energy=[4, 3, 8, 1, 2], gti=[[6, 7]])
+                             energy=[4, 3, 8, 1, 2], gti=[[6, 7]])
         with pytest.warns(UserWarning) as record:
             ev_new = ev.join(ev_other)
 
@@ -268,15 +269,15 @@ class TestEvents(object):
         assert (ev_new.energy ==
                 np.array([3, 4, 7, 4, 3, 4, 3, 8, 1, 2])).all()
         assert (ev_new.gti ==
-                np.array([[1, 2],[3, 4],[6, 7]])).all()
+                np.array([[1, 2], [3, 4], [6, 7]])).all()
 
     def test_overlapping_join(self):
         """Join two non-overlapping event lists.
         """
         ev = EventList(time=[1, 1, 10, 6, 5],
-                        energy=[10, 6, 3, 11, 2], gti=[[1, 3],[5, 6]])
+                       energy=[10, 6, 3, 11, 2], gti=[[1, 3], [5, 6]])
         ev_other = EventList(time=[5, 7, 6, 6, 10],
-                            energy=[2, 3, 8, 1, 2], gti=[[5, 7],[8, 10]])
+                             energy=[2, 3, 8, 1, 2], gti=[[5, 7], [8, 10]])
         ev_new = ev.join(ev_other)
 
         assert (ev_new.time ==
@@ -383,4 +384,3 @@ class TestEvents(object):
             assert np.allclose(getattr(ev, attr), getattr(new_ev, attr))
         for attr in ['mission', 'instr', 'mjdref']:
             assert getattr(ev, attr) == getattr(new_ev, attr)
-

--- a/stingray/tests/test_gti.py
+++ b/stingray/tests/test_gti.py
@@ -14,6 +14,7 @@ from stingray import StingrayError
 curdir = os.path.abspath(os.path.dirname(__file__))
 datadir = os.path.join(curdir, 'data')
 
+
 class TestGTI(object):
 
     """Real unit tests."""
@@ -123,7 +124,7 @@ class TestGTI(object):
         assert np.allclose(mask, np.array([0, 1, 0, 0, 0, 0, 0], dtype=bool))
 
     def test_gti_mask_compare(self):
-        arr = np.array([ 0.5, 1.5, 2.5, 3.5])
+        arr = np.array([0.5, 1.5, 2.5, 3.5])
         gti = np.array([[0, 4]])
         mask_c, new_gtis_c = \
             create_gti_mask_complete(arr, gti, return_new_gtis=True,
@@ -134,7 +135,7 @@ class TestGTI(object):
         assert np.allclose(new_gtis, new_gtis_c)
 
     def test_gti_mask_compare2(self):
-        arr = np.array([ 0.5, 1.5, 2.5, 3.5])
+        arr = np.array([0.5, 1.5, 2.5, 3.5])
         gti = np.array([[0, 4]])
         mask_c, new_gtis_c = \
             create_gti_mask_complete(arr, gti, return_new_gtis=True,
@@ -213,7 +214,6 @@ class TestGTI(object):
         assert np.all(join_gtis(gti0, gti1) == np.array([[0, 1], [2, 3], [4, 8],
                                                          [10, 11], [12, 13]]))
 
-
     def test_time_intervals_from_gtis(self):
         """Test the division of start and end times to calculate spectra."""
         start_times, stop_times = \
@@ -238,6 +238,19 @@ class TestGTI(object):
 
         assert np.allclose(start_bins, np.array([0, 2, 6]))
         assert np.allclose(stop_bins, np.array([2, 4, 8]))
+
+    def test_bin_intervals_from_gtis_2(self):
+        dt = 0.1
+        tstart = 0
+        tstop = 100
+        times = np.arange(tstart, tstop, dt)
+        gti = np.array([[tstart - dt/2, tstop - dt/2]])
+        # Simulate something *clearly* non-constant
+        counts = np.random.poisson(
+            10000 + 2000 * np.sin(2 * np.pi * times))
+
+        start_bins, stop_bins = bin_intervals_from_gtis(gti, 20, times)
+        assert np.allclose(start_bins, [0, 200, 400, 600, 800])
 
     def test_bin_intervals_from_gtis_frac(self):
         """Test the division of start and end times to calculate spectra."""
@@ -305,4 +318,3 @@ class TestGTI(object):
                         [1.16703482e+08, 1.16703514e+08]])
         newg = join_equal_gti_boundaries(gti)
         assert np.allclose(newg, np.array([[1.16703354e+08, 1.16703514e+08]]))
-

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -96,6 +96,15 @@ class TestProperties(object):
         assert np.any(["Unrecognized keywords:" in r.message.args[0]
                        for r in record])
 
+    def test_warn_estimate_chunk_length(self):
+        times = np.arange(0, 1000, 1)
+        lc = Lightcurve(times, counts=np.ones(times.size) + 200, dt=1, skip_checks=True)
+        with pytest.warns(DeprecationWarning) as record:
+            lc.estimate_chunk_length()
+
+        assert np.any(["This function was renamed to estimate_segment_size" in r.message.args[0]
+                       for r in record])
+
     def test_time(self):
         lc = copy.deepcopy(self.lc)
         assert lc._bin_lo is None

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -27,7 +27,7 @@ except ImportError:
     _H5PY_INSTALLED = False
 
 try:
-    import Lightkurve
+    import lightkurve
 except ImportError:
     _HAS_LIGHTKURVE = False
 
@@ -931,13 +931,13 @@ class TestLightcurve(object):
         assert_allclose(lk.flux, counts)
         assert_allclose(lk.flux_err, counts_err)
 
-    @pytest.mark.skipif(not _HAS_LIGHTKURVE,
+    @pytest.mark.skipif('not _HAS_LIGHTKURVE',
                         reason='Lightkurve not installed')
     def test_from_lightkurve(self):
-        from Lightkurve import LightCurve
+        from lightkurve import LightCurve
         time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
-        lk = LightCurve(time, flux, flux_err)
-        sr = Lightcurve.from_lightkurve(lk)
+        lc = LightCurve(time, flux, flux_err)
+        sr = Lightcurve.from_lightkurve(lc)
         assert_allclose(sr.time, lc.time)
         assert_allclose(sr.counts, lc.flux)
         assert_allclose(sr.counts_err, lc.flux_err)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -1,3 +1,4 @@
+import os
 import copy
 import numpy as np
 from astropy.tests.helper import pytest
@@ -18,6 +19,7 @@ _H5PY_INSTALLED = True
 _HAS_LIGHTKURVE = True
 _HAS_TIMESERIES = True
 _HAS_YAML = True
+_IS_WINDOWS = os.name == "nt"
 
 try:
     import h5py
@@ -70,6 +72,14 @@ class TestProperties(object):
 
         cls.lc = Lightcurve(times, counts, gti=cls.gti)
         cls.lc_lowmem = Lightcurve(times, counts, gti=cls.gti, low_memory=True)
+
+    @pytest.mark.skipif("not _IS_WINDOWS")
+    def test_warn_on_windows(self):
+        with pytest.warns(UserWarning) as record:
+            _ = Lightcurve(self.lc.time, self.lc.counts, gti=self.lc.gti)
+        assert np.any(["On Windows, the size of an integer" in r.message.args[0]
+                       for r in record])
+
 
     def test_warn_wrong_keywords(self):
         lc = copy.deepcopy(self.lc)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -763,7 +763,7 @@ class TestDynamicalPowerspectrum(object):
     def test_rebin_time_default_method(self):
         segment_size = 3
         dt_new = 4.0
-        rebin_time = np.array([ 2.,  6., 10.])
+        rebin_time = np.array([2.,  6., 10.])
         rebin_dps = np.array([[0.7962963, 1.16402116, 0.28571429]])
         dps = DynamicalPowerspectrum(self.lc_test, segment_size=segment_size)
         new_dps = dps.rebin_time(dt_new=dt_new)
@@ -786,13 +786,13 @@ class TestDynamicalPowerspectrum(object):
             dps = DynamicalPowerspectrum(self.lc, segment_size=segment_size)
         new_dps = dps.rebin_frequency(df_new=df_new)
         assert np.allclose(new_dps.freq, rebin_freq)
-        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.01)
         assert np.isclose(new_dps.df, df_new)
 
     def test_rebin_time_mean_method(self):
         segment_size = 3
         dt_new = 4.0
-        rebin_time = np.array([ 2.,  6., 10.])
+        rebin_time = np.array([2.,  6., 10.])
         rebin_dps = np.array([[0.59722222, 0.87301587, 0.21428571]])
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
@@ -817,13 +817,13 @@ class TestDynamicalPowerspectrum(object):
             dps = DynamicalPowerspectrum(self.lc, segment_size=segment_size)
         new_dps = dps.rebin_frequency(df_new=df_new, method="mean")
         assert np.allclose(new_dps.freq, rebin_freq)
-        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.00001)
         assert np.isclose(new_dps.df, df_new)
 
     def test_rebin_time_average_method(self):
         segment_size = 3
         dt_new = 4.0
-        rebin_time = np.array([ 2.,  6., 10.])
+        rebin_time = np.array([2.,  6., 10.])
         rebin_dps = np.array([[0.59722222, 0.87301587, 0.21428571]])
 
         with warnings.catch_warnings():
@@ -849,5 +849,5 @@ class TestDynamicalPowerspectrum(object):
             dps = DynamicalPowerspectrum(self.lc, segment_size=segment_size)
         new_dps = dps.rebin_frequency(df_new=df_new, method="average")
         assert np.allclose(new_dps.freq, rebin_freq)
-        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.00001)
         assert np.isclose(new_dps.df, df_new)

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -1149,6 +1149,20 @@ def check_iterables_close(iter0, iter1, **kwargs):
     ----------
     iter0 : iterable
     iter1 : iterable
+
+    Examples
+    --------
+    >>> iter0 = [0, 1]
+    >>> iter1 = [0, 2]
+    >>> check_iterables_close(iter0, iter1)
+    False
+    >>> iter0 = [(0, 0), (0, 1)]
+    >>> iter1 = [(0, 0.), (0, 1.)]
+    >>> check_iterables_close(iter0, iter1)
+    True
+    >>> iter1 = [(0, 0.), (0, 3.)]
+    >>> check_iterables_close(iter0, iter1)
+    False
     """
     for i0, i1 in zip(iter0, iter1):
         if isinstance(i0, Iterable):

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -1139,3 +1139,27 @@ def interpret_times(time, mjdref=0):
             pass
 
     raise ValueError(f"Unknown time format: {type(time)}")
+
+
+def check_iterables_close(iter0, iter1, **kwargs):
+    """Check that the values produced by iterables are equal.
+
+    Uses `np.isclose` if the iterables produce single values per iteration,
+    `np.allclose` otherwise.
+
+    Additional keyword arguments are passed to `np.allclose`
+    and `np.isclose`.
+
+    Parameters
+    ----------
+    iter0 : iterable
+    iter1 : iterable
+    """
+    for i0, i1 in zip(iter0, iter1):
+        if isinstance(i0, Iterable):
+            if not np.allclose(i0, i1):
+                return False
+            continue
+        if not np.isclose(i0, i1):
+            return False
+    return True

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -457,7 +457,7 @@ def look_for_array_in_array(array1, array2):
     return next((i for i in array1 if i in array2), None)
 
 
-def is_string(s):  # pragma : no cover
+def is_string(s):
     """
     Portable function to answer whether a variable is a string.
 
@@ -471,12 +471,7 @@ def is_string(s):  # pragma : no cover
     isstring : bool
         A boolean decision on whether ``s`` is a string or not
     """
-
-    PY2 = sys.version_info[0] == 2
-    if PY2:
-        return isinstance(s, basestring)  # NOQA
-    else:
-        return isinstance(s, str)  # NOQA
+    return isinstance(s, str)
 
 
 def is_iterable(var):


### PR DESCRIPTION
This PR improves by a lot the performance with the following GTI operations, by avoiding operations on the full time array:
+ `gti_border_bins`
+ `bin_intervals_from_gtis`

Also in this PR, new GTI operations:
+ `get_gti_lengths`: list the length of each GTI
+ `get_total_gti_length`: get the total observing time
+ `get_gti_events_idx`: get the first and the last bin of the `time` array in each GTI

Moreover:
+ Fix `Lightcurve.make_lightcurve` when the number of bins is close to the next integer (>=N + 0.99)
+ Add the new GTI machinery to EventList when creating light curve iterables; give both an iterator (`EventList.to_lc_iter`) and a list (`EventList.to_lc_list`)