### PR TITLE
Better treatment of array-like attributes in eventlists

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ all =
     zarr
     numcodecs
     pyyaml
+    xarray
+    pandas
 test =
     pytest
     pytest-astropy

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -764,6 +764,12 @@ class EventList(object):
         return meta_dict
 
     def to_astropy_timeseries(self):
+        """Save the event list to an Astropy timeseries.
+
+        Array attributes (time, pi, energy, etc.) are converted
+        into columns, while meta attributes (mjdref, gti, etc.)
+        are saved into the ``meta`` dictionary.
+        """
         from astropy.timeseries import TimeSeries
         from astropy.time import TimeDelta
         from astropy import units as u
@@ -790,9 +796,17 @@ class EventList(object):
 
     @staticmethod
     def from_astropy_timeseries(ts):
-        from astropy.timeseries import TimeSeries
-        from astropy import units as u
+        """Read the event list from an Astropy TimeSeries.
 
+        The timeseries has to define at least a column called time,
+        the rest of columns will form the array attributes of the
+        new event list, while the attributes in table.meta will
+        form the new meta attributes of the event list.
+
+        It is strongly advisable to define such attributes and columns
+        using the standard attributes of EventList: time, pi, energy, gti etc.
+
+        """
         kwargs = dict([(key.lower(), val) for (key, val) in ts.meta.items()])
         ev = EventList(time=ts.time, **kwargs)
         array_attrs = ts.colnames
@@ -805,6 +819,12 @@ class EventList(object):
         return ev
 
     def to_astropy_table(self):
+        """Save the event list to an Astropy Table.
+
+        Array attributes (time, pi, energy, etc.) are converted
+        into columns, while meta attributes (mjdref, gti, etc.)
+        are saved into the ``meta`` dictionary.
+        """
         data = {}
         array_attrs = self.array_attrs()
 
@@ -819,6 +839,17 @@ class EventList(object):
 
     @staticmethod
     def from_astropy_table(ts):
+        """Read the event list from an Astropy Table.
+
+        The table has to define at least a column called time,
+        the rest of columns will form the array attributes of the
+        new event list, while the attributes in table.meta will
+        form the new meta attributes of the event list.
+
+        It is strongly advisable to define such attributes and columns
+        using the standard attributes of EventList: time, pi, energy, gti etc.
+
+        """
         kwargs = dict([(key.lower(), val) for (key, val) in ts.meta.items()])
         ev = EventList(time=ts["time"], **kwargs)
         array_attrs = ts.colnames
@@ -831,6 +862,12 @@ class EventList(object):
         return ev
 
     def to_xarray(self):
+        """Save the event list to an xarray Dataset.
+
+        Array attributes (time, pi, energy, etc.) are converted
+        into columns, while meta attributes (mjdref, gti, etc.)
+        are saved into the ``ds.attrs`` dictionary.
+        """
         from xarray import Dataset
         data = {}
         array_attrs = self.array_attrs()
@@ -846,6 +883,17 @@ class EventList(object):
 
     @staticmethod
     def from_xarray(ts):
+        """Read the event list from a xarray Dataset.
+
+        The dataset has to define at least a column called time,
+        the rest of columns will form the array attributes of the
+        new event list, while the attributes in ds.attrs will
+        form the new meta attributes of the event list.
+
+        It is strongly advisable to define such attributes and columns
+        using the standard attributes of EventList: time, pi, energy, gti etc.
+
+        """
         array_attrs = ts.coords
 
         kwargs = dict([(key.lower(), val)
@@ -860,6 +908,12 @@ class EventList(object):
         return ev
 
     def to_pandas(self):
+        """Save the event list to a pandas DataFrame.
+
+        Array attributes (time, pi, energy, etc.) are converted
+        into columns, while meta attributes (mjdref, gti, etc.)
+        are saved into the ``ds.attrs`` dictionary.
+        """
         from pandas import DataFrame
         data = {}
         array_attrs = self.array_attrs()
@@ -875,6 +929,17 @@ class EventList(object):
 
     @staticmethod
     def from_pandas(ts):
+        """Read the event list from a pandas DataFrame.
+
+        The dataframe has to define at least a column called time,
+        the rest of columns will form the array attributes of the
+        new event list, while the attributes in ds.attrs will
+        form the new meta attributes of the event list.
+
+        It is strongly advisable to define such attributes and columns
+        using the standard attributes of EventList: time, pi, energy, gti etc.
+
+        """
         array_attrs = ts.columns
 
         kwargs = dict([(key.lower(), val)

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -616,7 +616,18 @@ class EventList(object):
         return self.apply_mask(mask, inplace=inplace)
 
     def apply_mask(self, mask, inplace=False):
-        """For compatibility with old stingray version.
+        """Apply a mask to all array attributes of the event list
+
+        Parameters
+        ----------
+        mask : array of ``bool``
+            The mask. Has to be of the same length as ``self.time``
+
+        Other parameters
+        ----------------
+        inplace : bool
+            If True, overwrite the current event list. Otherwise, return a new one.
+
         Examples
         --------
         >>> evt = EventList(time=[0, 1, 2], mission="nustar")

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -166,6 +166,24 @@ class EventList(object):
                 raise ValueError('Lengths of time and energy must be equal.')
 
     def array_attrs(self):
+        """List the names of the array attributes of the event list.
+
+        By array attributes, we mean the ones with the same size and shape as
+        ``self.time``
+
+        Examples
+        --------
+        >>> ev = EventList(time=np.arange(5), pi=np.zeros(5), gti=[[45, 4]])
+        >>> attrs = ev.array_attrs()
+        >>> len(attrs)
+        2
+        >>> "pi" in attrs and "time" in attrs
+        True
+        >>> hasattr(ev, "gti") #  The gti attribute is set, however...
+        True
+        >>> "gti" in attrs #  The shape of self.gti is not equal to time! Not an array attr
+        False
+        """
         return [
             attr for attr in dir(self)
             if (

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -479,7 +479,7 @@ class EventList(object):
 
     @staticmethod
     def read(filename, format_="pickle", **kwargs):
-        r"""Read a :class:`Lightcurve` object from file.
+        r"""Read a :class:`EventList` object from file.
 
         Currently supported formats are
 
@@ -807,7 +807,7 @@ class EventList(object):
 
     @staticmethod
     def from_astropy_timeseries(ts):
-        """Read the event list from an Astropy TimeSeries.
+        """Create an `EventList` object from data in an Astropy TimeSeries
 
         The timeseries has to define at least a column called time,
         the rest of columns will form the array attributes of the
@@ -850,7 +850,7 @@ class EventList(object):
 
     @staticmethod
     def from_astropy_table(ts):
-        """Read the event list from an Astropy Table.
+        """Create an `EventList` object from data in an Astropy Table.
 
         The table has to define at least a column called time,
         the rest of columns will form the array attributes of the
@@ -894,7 +894,7 @@ class EventList(object):
 
     @staticmethod
     def from_xarray(ts):
-        """Read the event list from a xarray Dataset.
+        """Create an `EventList` object from data in an xarray Dataset.
 
         The dataset has to define at least a column called time,
         the rest of columns will form the array attributes of the
@@ -940,7 +940,7 @@ class EventList(object):
 
     @staticmethod
     def from_pandas(ts):
-        """Read the event list from a pandas DataFrame.
+        """Create an `EventList` object from data in a pandas DataFrame.
 
         The dataframe has to define at least a column called time,
         the rest of columns will form the array attributes of the

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -782,3 +782,67 @@ class EventList(object):
             setattr(ev, attr, ts[attr])
 
         return ev
+
+    def to_xarray(self):
+        from xarray import Dataset
+        data = {}
+        array_attrs = self.array_attrs()
+
+        for attr in array_attrs:
+            data[attr] = np.asarray(getattr(self, attr))
+
+        ts = Dataset(data)
+
+        ts.attrs['gti'] = self.gti
+        ts.attrs['mjdref'] = self.mjdref
+        ts.attrs['instr'] = self.instr
+        ts.attrs['mission'] = self.mission
+        ts.attrs['header'] = self.header
+        return ts
+
+    @staticmethod
+    def from_xarray(ts):
+        array_attrs = ts.coords
+
+        kwargs = dict([(key.lower(), val)
+                      for (key, val) in ts.attrs.items() if key not in array_attrs])
+        ev = EventList(time=ts["time"].values, **kwargs)
+
+        for attr in array_attrs:
+            if attr == "time":
+                continue
+            setattr(ev, attr, ts[attr].values)
+
+        return ev
+
+    def to_pandas(self):
+        from pandas import DataFrame
+        data = {}
+        array_attrs = self.array_attrs()
+
+        for attr in array_attrs:
+            data[attr] = np.asarray(getattr(self, attr))
+
+        ts = DataFrame(data)
+
+        ts.attrs['gti'] = self.gti
+        ts.attrs['mjdref'] = self.mjdref
+        ts.attrs['instr'] = self.instr
+        ts.attrs['mission'] = self.mission
+        ts.attrs['header'] = self.header
+        return ts
+
+    @staticmethod
+    def from_pandas(ts):
+        array_attrs = ts.columns
+
+        kwargs = dict([(key.lower(), val)
+                      for (key, val) in ts.attrs.items() if key not in array_attrs])
+        ev = EventList(time=ts["time"].to_numpy(), **kwargs)
+
+        for attr in array_attrs:
+            if attr == "time":
+                continue
+            setattr(ev, attr, ts[attr].to_numpy())
+
+        return ev


### PR DESCRIPTION
Modifies `EventList.apply_mask` so that we don't need to hard-code a list of attributes (e.g., `time`, `energy`, `pi`).
This is done by the method `EventList.array_attrs()` that lists the attributes with the same shape as `time`.
This way, the user can create new mission-dependent attributes (e.g. `detector_id`) and they will be filtered by `apply_mask` automagically.

Also, this PR extends this to the roundtrip to `Table` and `Timeseries`, encoding the array attributes into table columns and vice-versa.

Finally, I add a new function to filter event lists by energy, which is very handy.