### PR TITLE
Adjust codecov settings with new yaml file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+    notify: false
+    # do not notify (default notification is email)
+
+comment:
+    after_n_builds: 7
+    # will leave a comment on the pull request after 7 (out of 9) 
+    # continuous integration tests have completed
+
+coverage:
+  round: nearest
+  # rounds the coverage percentage to the nearest value, 
+  # instead of always rounding down (former default behaviour)


### PR DESCRIPTION
Adjusts codecov settings, following up on issue https://github.com/StingraySoftware/stingray/issues/573. This should make it less aggressive, though still thoroughly checking the code and reporting back in a useful way. Now, codecov will NOT email you ever, and it will comment on the pull request after 7 (out of 9) continuous integration (CI) tests have completed. This should stop it from quickly emailing a contributor saying their code contribution has decreased coverage by 50%, as it was erroneously doing pretty often.
Resolve #573 