### PR TITLE
Run the publish_docs workflow on release

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  release:
 
 jobs:
   build-docs:


### PR DESCRIPTION
So that we pick up any new version numbers, etc, in the published docs.