### PR TITLE
Bugfix for issue- CrossCorrelation Gives Strange Results (#592)

### DIFF
--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -194,15 +194,9 @@ class CrossCorrelation(object):
         # Calculates cross-correlation of two lightcurves
         self.corr = \
             signal.correlate(lc1_counts, lc2_counts, self.mode)
-        # Obtains correlation lags 
-        # signal.correlation_lags() method uses SciPy versions >= 1.6.1
-        x_lags = \
-            signal.correlation_lags(lc1_counts.size, lc2_counts.size, self.mode)
 
         self.n = np.size(self.corr)
-        self.time_lags = x_lags * self.dt
-        # time_shift is the time lag for max. correlation
-        self.time_shift = self.time_lags[np.argmax(self.corr)]
+        self.time_shift, self.time_lags, self.n = self.cal_timeshift(dt=self.dt)
 
         # Normalization that makes the maximum correlation equal to 1, and
         # maximum anticorrelation -1.
@@ -251,9 +245,20 @@ class CrossCorrelation(object):
                     self._make_corr(self.lc1, self.lc2)
 
         self.n = len(self.corr)
-        dur = int(self.n / 2)
-        # Correlation against all possible lags, positive as well as negative lags are stored
-        x_lags = np.linspace(-dur, dur, self.n)
+        
+        if self.cross is not None:
+          # Obtains correlation lags if a cross spectrum object is given
+          # Correlation against all possible lags, positive as well as negative lags are stored
+          # signal.correlation_lags() method uses SciPy versions >= 1.6.1
+          x_lags = signal.correlation_lags(self.n, self.n, self.mode)
+          
+        else:
+          # Obtains correlation lags if two light curves are porvided
+          # Correlation against all possible lags, positive as well as negative lags are stored
+          # signal.correlation_lags() method uses SciPy versions >= 1.6.1
+          x_lags = \
+              signal.correlation_lags(np.size(self.lc1.counts), np.size(self.lc2.counts), self.mode)
+        
         self.time_lags = x_lags * self.dt
         # time_shift is the time lag for max. correlation
         self.time_shift = self.time_lags[np.argmax(self.corr)]

--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -76,7 +76,6 @@ class CrossCorrelation(object):
     References
     ----------
     .. [scipy-docs] https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.signal.correlate.html
-    .. [scipy-docs] https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.correlation_lags.html
     """
 
     def __init__(self, lc1=None, lc2=None, cross=None, mode='same', norm="none"):
@@ -156,7 +155,6 @@ class CrossCorrelation(object):
         """
         Do some checks on the light curves supplied to the method, and then calculate the time
         shifts, time lags and cross correlation.
-        The method signal.correlation_lags() uses SciPy versions >= 1.6.1
 
         Parameters
         ----------
@@ -212,6 +210,12 @@ class CrossCorrelation(object):
         """
         Calculate the cross correlation against all possible time lags, both positive and negative.
 
+        The method signal.correlation_lags() uses SciPy versions >= 1.6.1 ([scipy-docs-lag]_)
+        
+        References
+        ----------
+        .. [scipy-docs-lag] https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.correlation_lags.html
+        
         Parameters
         ----------
         dt: float, optional, default ``1.0``

--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -76,7 +76,7 @@ class CrossCorrelation(object):
     References
     ----------
     .. [scipy-docs] https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.signal.correlate.html
-
+    .. [scipy-docs] https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.correlation_lags.html
     """
 
     def __init__(self, lc1=None, lc2=None, cross=None, mode='same', norm="none"):
@@ -156,6 +156,7 @@ class CrossCorrelation(object):
         """
         Do some checks on the light curves supplied to the method, and then calculate the time
         shifts, time lags and cross correlation.
+        The method signal.correlation_lags() uses SciPy versions >= 1.6.1
 
         Parameters
         ----------
@@ -194,6 +195,7 @@ class CrossCorrelation(object):
         self.corr = \
             signal.correlate(lc1_counts, lc2_counts, self.mode)
         # Obtains correlation lags 
+        # signal.correlation_lags() method uses SciPy versions >= 1.6.1
         x_lags = \
             signal.correlation_lags(lc1_counts.size, lc2_counts.size, self.mode)
 

--- a/stingray/crosscorrelation.py
+++ b/stingray/crosscorrelation.py
@@ -193,9 +193,14 @@ class CrossCorrelation(object):
         # Calculates cross-correlation of two lightcurves
         self.corr = \
             signal.correlate(lc1_counts, lc2_counts, self.mode)
+        # Obtains correlation lags 
+        x_lags = \
+            signal.correlation_lags(lc1_counts.size, lc2_counts.size, self.mode)
 
         self.n = np.size(self.corr)
-        self.time_shift, self.time_lags, self.n = self.cal_timeshift(dt=self.dt)
+        self.time_lags = x_lags * self.dt
+        # time_shift is the time lag for max. correlation
+        self.time_shift = self.time_lags[np.argmax(self.corr)]
 
         # Normalization that makes the maximum correlation equal to 1, and
         # maximum anticorrelation -1.

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -252,3 +252,29 @@ class TestCrossCorrelation(object):
         assert np.isclose(ac.time_shift, 0.0)
         assert ac.mode == 'full'
         assert ac.auto is True
+        
+    def test_cross_correlation_with_identical_lc_oddlength(self):
+        result =  np.array([ 1.68, -3.36, 5.2, -3.36, 1.68])
+        lags_result = np.array([-2, -1, 0, 1, 2])
+        cr = CrossCorrelation(self.lc_odd,self.lc_odd)
+        assert np.allclose(cr.lc1, cr.lc2)
+        assert np.allclose(cr.corr, result)
+        assert np.isclose(cr.dt, lc_odd.dt)
+        assert cr.n == 5
+        assert np.allclose(cr.time_lags, lags_result)
+        assert np.isclose(cr.time_shift,0.0)
+        assert cr.mode == 'same'
+        assert cr.auto is False
+   
+    def test_cross_correlation_with_identical_lc_evenlength(self):
+        result =  np.array([-1.75, 2.5, -4.25, 5.5, -4.25, 2.5])
+        lags_result = np.array([-3, -2, -1, 0, 1, 2])
+        cr = CrossCorrelation(self.lc_even,self.lc_even)
+        assert np.allclose(cr.lc1, cr.lc2)
+        assert np.allclose(cr.corr, result)
+        assert np.isclose(cr.dt, lc_even.dt)
+        assert cr.n == 6
+        assert np.allclose(cr.time_lags, lags_result)
+        assert np.isclose(cr.time_shift,0.0)
+        assert cr.mode == 'same'
+        assert cr.auto is False

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -263,7 +263,7 @@ class TestCrossCorrelation(object):
         cr = CrossCorrelation(self.lc_odd,self.lc_odd)
         assert np.allclose(cr.lc1, cr.lc2)
         assert np.allclose(cr.corr, result)
-        assert np.isclose(cr.dt, lc_odd.dt)
+        assert np.isclose(cr.dt, self.lc_odd.dt)
         assert cr.n == 5
         assert np.allclose(cr.time_lags, lags_result)
         assert np.isclose(cr.time_shift,0.0)
@@ -276,7 +276,7 @@ class TestCrossCorrelation(object):
         cr = CrossCorrelation(self.lc_even,self.lc_even)
         assert np.allclose(cr.lc1, cr.lc2)
         assert np.allclose(cr.corr, result)
-        assert np.isclose(cr.dt, lc_even.dt)
+        assert np.isclose(cr.dt, self.lc_even.dt)
         assert cr.n == 6
         assert np.allclose(cr.time_lags, lags_result)
         assert np.isclose(cr.time_shift,0.0)

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -47,6 +47,10 @@ class TestCrossCorrelation(object):
         cls.lc_s = Lightcurve([1, 2, 3], [5, 3, 2])
         # lc with different time resolution
         cls.lc_u = Lightcurve([1, 3, 5, 7, 9], [4, 8, 1, 9, 11])
+        # Light curve with odd number of data points
+        cls.lc_odd = Lightcurve([1, 2, 3, 4, 5], [2, 3, 2, 4, 1])
+        # Light curve with even number of data points
+        cls.lc_even = Lightcurve([1, 2, 3, 4, 5, 6], [2, 3, 2, 4, 1, 3])
 
     def test_empty_cross_correlation(self):
         cr = CrossCorrelation()

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -128,8 +128,8 @@ class TestCrossCorrelation(object):
         assert np.allclose(cr.corr, result)
         assert np.isclose(cr.dt, self.lc1.dt)
         assert cr.n == 5
+        assert np.isclose(cr.time_shift, 3.0)
         assert np.allclose(cr.time_lags, lags_result)
-        assert np.isclose(cr.time_shift, 2.0)
         assert cr.mode == 'same'
         assert cr.auto is False
 

--- a/stingray/tests/test_crosscorrelation.py
+++ b/stingray/tests/test_crosscorrelation.py
@@ -121,7 +121,7 @@ class TestCrossCorrelation(object):
 
     def test_cross_correlation_with_unequal_lc(self):
         result = np.array([-0.66666667, -0.33333333, -1., 0.66666667, 3.13333333])
-        lags_result = np.array([-2, -1, 0, 1, 2])
+        lags_result = np.array([-1.,  0.,  1.,  2.,  3.])
         cr = CrossCorrelation(self.lc1, self.lc_s)
         assert np.allclose(cr.lc1, self.lc1)
         assert np.allclose(cr.lc2, self.lc_s)


### PR DESCRIPTION
The reason why the previous code did not provide zero time_shift for cross-correlation between two identical light curves of even length is as follows:

The correlation lags (x_legs) required to calculate time_shift was obtained by creating a linear space in cal_timeshift method.
The following line stores possible correlation lags in x_lags. 
`x_lags = np.linspace(-dur, dur, self.n)`  
The correlation lags obtained using this method depend on the evenness/oddity of self.n (i.e. number of time bins in the light curve).  For an odd number of time bins, np.linspace,  will provide an ndarray of integers centered at 0, but for an even number of time bins, it will generate an ndarray of floats which will not include 0. As a result, the time_shift will never be 0.



The correlation lags (x_legs) required to calculate time_shift can be obtained using [signal.correlation_lags](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.correlation_lags.html#scipy.signal.correlation_lags).

` 

        x_lags = signal.correlation_lags(lc1_counts.size, lc2_counts.size, self.mode)
        self.n = np.size(self.corr)
        self.time_lags = x_lags * self.dt
        # time_shift is the time lag for max. correlation
        self.time_shift = self.time_lags[np.argmax(self.corr)]
`
The  [signal.correlation_lags](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.correlation_lags.html#scipy.signal.correlation_lags) takes care of evenness/oddity of input light curves for all possible correlation modes (i.e 'same', 'valid' or 'full') . This method was introduced in SciPy version 1.6.1.

closes #592 







