### PR TITLE
Added try to import statement for newly public astropy fitter functions

### DIFF
--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -38,8 +38,20 @@ try:
 except ImportError:
     comp_hessian = False
 
-from astropy.modeling.fitting import _fitter_to_model_params, \
-    _model_to_fit_params, _validate_model, _convert_input
+# in astropy v5.1, the below methods are made public, 
+# private methods throw DeprecationWarning
+# remove when old versions of astropy are no longer supported
+
+try:
+    from astropy.modeling.fitting import fitter_to_model_params, \
+         model_to_fit_params
+except ImportError:
+    from astropy.modeling.fitting import _fitter_to_model_params \
+         as fitter_to_model_params
+    from astropy.modeling.fitting import _model_to_fit_params \
+         as model_to_fit_params
+
+from astropy.modeling.fitting import _validate_model, _convert_input
 
 from stingray.modeling.posterior import Posterior, PSDPosterior, \
     LogLikelihood, PSDLogLikelihood, logmin
@@ -196,7 +208,7 @@ class OptimizationResults(object):
             The object containing the function that is being optimized
             in the regression
         """
-        _fitter_to_model_params(lpost.model, self.p_opt)
+        fitter_to_model_params(lpost.model, self.p_opt)
 
         self.mfit = lpost.model(lpost.x)
 
@@ -707,7 +719,7 @@ class ParameterEstimation(object):
         m = lpost.model
 
         # reset the parameters
-        _fitter_to_model_params(m, pars)
+        fitter_to_model_params(m, pars)
 
         # make a model spectrum
         model_data = lpost.model(lpost.x)

--- a/stingray/modeling/posterior.py
+++ b/stingray/modeling/posterior.py
@@ -10,7 +10,16 @@ np.seterr('warn')
 
 from scipy.special import gamma as scipy_gamma
 from scipy.special import gammaln as scipy_gammaln
-from astropy.modeling.fitting import _fitter_to_model_params
+
+# as of astropy v5.1, the below are public methods, and 
+# the private ones throw deprecation warnings
+# remove statement when astropy <5.1 is no longer supported
+try:
+    from astropy.modeling.fitting import fitter_to_model_params
+except ImportError:
+    from astropy.modeling.fitting import _fitter_to_model_params \
+         as fitter_to_model_params
+
 from astropy.modeling import models
 
 from stingray import Lightcurve, Powerspectrum
@@ -277,7 +286,7 @@ class GaussianLogLikelihood(LogLikelihood):
             raise IncorrectParameterError("Input parameters must" +
                                           " match model parameters!")
 
-        _fitter_to_model_params(self.model, pars)
+        fitter_to_model_params(self.model, pars)
 
         mean_model = self.model(self.x)
 
@@ -363,7 +372,7 @@ class PoissonLogLikelihood(LogLikelihood):
             raise IncorrectParameterError("Input parameters must" +
                                           " match model parameters!")
 
-        _fitter_to_model_params(self.model, pars)
+        fitter_to_model_params(self.model, pars)
 
         mean_model = self.model(self.x)
 
@@ -456,7 +465,7 @@ class PSDLogLikelihood(LogLikelihood):
             raise IncorrectParameterError("Input parameters must" +
                                           " match model parameters!")
 
-        _fitter_to_model_params(self.model, pars)
+        fitter_to_model_params(self.model, pars)
 
 
         mean_model = self.model(self.x)
@@ -553,7 +562,7 @@ class LaplaceLogLikelihood(LogLikelihood):
             raise IncorrectParameterError("Input parameters must" +
                                           " match model parameters!")
 
-        _fitter_to_model_params(self.model, pars)
+        fitter_to_model_params(self.model, pars)
 
         mean_model = self.model(self.x)
 

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -6,7 +6,15 @@ import logging
 
 from astropy.tests.helper import pytest, catch_warnings
 from astropy.modeling import models
-from astropy.modeling.fitting import _fitter_to_model_params
+
+# as of astropy v5.1, the below are public methods, and 
+# the private ones throw deprecation warnings
+# remove statement when astropy <5.1 is no longer supported
+try:
+    from astropy.modeling.fitting import fitter_to_model_params
+except ImportError:
+    from astropy.modeling.fitting import _fitter_to_model_params \
+         as fitter_to_model_params
 
 from stingray import Powerspectrum, AveragedPowerspectrum
 from stingray.modeling import ParameterEstimation, PSDParEst, \
@@ -304,7 +312,7 @@ class TestOptimizationResults(object):
                        "mfit"), "OptimizationResult object should have mfit " \
                                 "attribute at this point!"
 
-        _fitter_to_model_params(self.model, self.opt.x)
+        fitter_to_model_params(self.model, self.opt.x)
         mfit_test = self.model(self.lpost.x)
 
         assert np.allclose(self.optres.mfit, mfit_test)
@@ -754,7 +762,7 @@ class TestPSDParEst(object):
         pe = PSDParEst(self.ps)
 
         m = self.model
-        _fitter_to_model_params(m, self.t0)
+        fitter_to_model_params(m, self.t0)
 
         model = m(self.ps.freq)
 


### PR DESCRIPTION
Using functionality in the stingray.modeling interface throws *lots* of `AstropyDeprecationWarning`s, due to an interface change in astropy v5.1, which exposes some previously private methods as public. This PR adds a try/else statement for the imports of those functions so that the correct version gets imported depending on the astropy version installed. Those should be removed once support for astropy <5.1 is dropped in stingray.