### PR TITLE
Fix issue with fracexp >~ 1

### DIFF
--- a/stingray/io.py
+++ b/stingray/io.py
@@ -466,7 +466,7 @@ def lcurve_from_fits(
         fracexp = np.ones_like(rate)
 
     good_intervals = (
-        (rate == rate) * (fracexp >= fracexp_limit) * (fracexp <= 1)
+        (rate == rate) * (fracexp >= fracexp_limit)
     )
 
     rate[good_intervals] /= fracexp[good_intervals]


### PR DESCRIPTION
Some NICER light curves have fractional exposure $\gtrsim$1, by a very small amount. An overly restrictive filter in the light curve reading made all these points invalid. Eliminating the filter