### PR TITLE
Added oops plots and resolved errors

### DIFF
--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1248,7 +1248,9 @@ class Crossspectrum(StingrayObject):
         else:
             raise AttributeError("Object has no attribute named 'time_lag' !")
 
-    def plot(self, labels=None, axis=None, title=None, marker="-", save=False, filename=None):
+    def plot(
+        self, labels=None, axis=None, title=None, marker="-", save=False, filename=None, axes=None
+    ):
         """
         Plot the amplitude of the cross spectrum vs. the frequency using ``matplotlib``.
 
@@ -1275,39 +1277,51 @@ class Crossspectrum(StingrayObject):
 
         filename : str
             File name of the image to save. Depends on the boolean ``save``.
+
+        ax : ``matplotlib.Axes`` object
+            An axes object to fill with the cross correlation plot.
         """
 
-        plt.figure("crossspectrum")
-        plt.plot(self.freq, np.abs(self.power), marker, color="b", label="Amplitude")
-        plt.plot(
+        axes_present = True
+        if axes is None:
+            axes_present = False
+            fig = plt.figure("crossspectrum")
+            axes = fig.add_subplot(1, 1, 1)
+
+        axes.plot(self.freq, np.abs(self.power), marker, color="b", label="Amplitude")
+        axes.plot(
             self.freq, np.abs(self.power.real), marker, color="r", alpha=0.5, label="Real Part"
         )
-        plt.plot(
+        axes.plot(
             self.freq, np.abs(self.power.imag), marker, color="g", alpha=0.5, label="Imaginary Part"
         )
 
         if labels is not None:
             try:
-                plt.xlabel(labels[0])
-                plt.ylabel(labels[1])
+                axes.set_xlabel(labels[0])
+                axes.set_ylabel(labels[1])
             except IndexError:
                 simon("``labels`` must have two labels for x and y axes.")
                 # Not raising here because in case of len(labels)==1, only
                 # x-axis will be labelled.
-        plt.legend(loc="best")
+        axes.legend(loc="best")
+
         if axis is not None:
-            plt.axis(axis)
+            axes.set_xlim(axis[0:2])
+            axes.set_ylim(axis[2:4])
 
         if title is not None:
-            plt.title(title)
+            axes.set_title(title)
 
         if save:
-            if filename is None:
-                plt.savefig("spec.png")
+            if axes_present:
+                warnings.warn("Plot saving is not supported for axes objects")
+            elif filename is None:
+                fig.savefig("spec.png")
             else:
-                plt.savefig(filename)
-        else:
-            plt.show(block=False)
+                fig.savefig(filename)
+
+        return axes
 
     def classical_significances(self, threshold=1, trial_correction=False):
         """

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1249,7 +1249,7 @@ class Crossspectrum(StingrayObject):
             raise AttributeError("Object has no attribute named 'time_lag' !")
 
     def plot(
-        self, labels=None, axis=None, title=None, marker="-", save=False, filename=None, axes=None
+        self, labels=None, axis=None, title=None, marker="-", save=False, filename=None, ax=None
     ):
         """
         Plot the amplitude of the cross spectrum vs. the frequency using ``matplotlib``.
@@ -1282,46 +1282,40 @@ class Crossspectrum(StingrayObject):
             An axes object to fill with the cross correlation plot.
         """
 
-        axes_present = True
-        if axes is None:
-            axes_present = False
+        if ax is None:
             fig = plt.figure("crossspectrum")
-            axes = fig.add_subplot(1, 1, 1)
+            ax = fig.add_subplot(1, 1, 1)
 
-        axes.plot(self.freq, np.abs(self.power), marker, color="b", label="Amplitude")
-        axes.plot(
-            self.freq, np.abs(self.power.real), marker, color="r", alpha=0.5, label="Real Part"
-        )
-        axes.plot(
+        ax.plot(self.freq, np.abs(self.power), marker, color="b", label="Amplitude")
+        ax.plot(self.freq, np.abs(self.power.real), marker, color="r", alpha=0.5, label="Real Part")
+        ax.plot(
             self.freq, np.abs(self.power.imag), marker, color="g", alpha=0.5, label="Imaginary Part"
         )
 
         if labels is not None:
             try:
-                axes.set_xlabel(labels[0])
-                axes.set_ylabel(labels[1])
+                ax.set_xlabel(labels[0])
+                ax.set_ylabel(labels[1])
             except IndexError:
                 simon("``labels`` must have two labels for x and y axes.")
                 # Not raising here because in case of len(labels)==1, only
                 # x-axis will be labelled.
-        axes.legend(loc="best")
+        ax.legend(loc="best")
 
         if axis is not None:
-            axes.set_xlim(axis[0:2])
-            axes.set_ylim(axis[2:4])
+            ax.set_xlim(axis[0:2])
+            ax.set_ylim(axis[2:4])
 
         if title is not None:
-            axes.set_title(title)
+            ax.set_title(title)
 
         if save:
-            if axes_present:
-                warnings.warn("Plot saving is not supported for axes objects")
-            elif filename is None:
-                fig.savefig("spec.png")
+            if filename is None:
+                plt.gcf().savefig("spec.png")
             else:
-                fig.savefig(filename)
+                plt.gcf().savefig(filename)
 
-        return axes
+        return ax
 
     def classical_significances(self, threshold=1, trial_correction=False):
         """

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -815,6 +815,14 @@ class TestCrossspectrum(object):
             self.cs.plot(labels=["x"])
         assert np.any(["must have two labels" in r.message.args[0] for r in record])
 
+    def test_plot_axes(self):
+        plt.subplot(211)
+        plot2 = self.cs.plot(
+            axes=plt.subplot(212), labels=("frequency", "amplitude"), title="Crossspectrum_leahy"
+        )
+        assert plt.fignum_exists(1)
+        plt.close(1)
+
     def test_rebin_error(self):
         cs = Crossspectrum()
         with pytest.raises(ValueError):

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -818,10 +818,41 @@ class TestCrossspectrum(object):
     def test_plot_axes(self):
         plt.subplot(211)
         plot2 = self.cs.plot(
-            axes=plt.subplot(212), labels=("frequency", "amplitude"), title="Crossspectrum_leahy"
+            ax=plt.subplot(212), labels=("frequency", "amplitude"), title="Crossspectrum_leahy"
         )
         assert plt.fignum_exists(1)
         plt.close(1)
+
+    def test_plot_labels_and_fname_for_axes(self):
+        outfname = "blabla.png"
+        if os.path.exists(outfname):
+            os.unlink(outfname)
+
+        plt.subplot(211)
+        plot2 = self.cs.plot(
+            ax=plt.subplot(212),
+            labels=("frequency", "amplitude"),
+            title="Crossspectrum_leahy",
+            filename=outfname,
+            save=True,
+        )
+        assert os.path.exists(outfname)
+        os.unlink(outfname)
+
+    def test_plot_labels_and_fname_for_axes_default(self):
+        outfname = "spec.png"
+        if os.path.exists(outfname):
+            os.unlink(outfname)
+
+        plt.subplot(211)
+        plot2 = self.cs.plot(
+            ax=plt.subplot(212),
+            labels=("frequency", "amplitude"),
+            title="Crossspectrum_leahy",
+            save=True,
+        )
+        assert os.path.exists(outfname)
+        os.unlink(outfname)
 
     def test_rebin_error(self):
         cs = Crossspectrum()


### PR DESCRIPTION
### Added Object Oriented Interface to Crossspectrum.plot
Addressing #612 , this Pr makes changes to the `crossspectrum.plot` feature, by adding object oriented matplotlib interface, which returns a `matplotlib.pyplot.axes` object when `axes` is not None and, plots a direct plot (retaining its original features) when called without giving an axes object.
I have created a test which checks that a new figure has been made. I have also tested the code with black and flake8.