### PR TITLE
Added typehints to spectroscopy.py

### DIFF
--- a/docs/changes/713.trivial.rst
+++ b/docs/changes/713.trivial.rst
@@ -1,0 +1,1 @@
+Added typehints to spectroscopy.py

--- a/stingray/spectroscopy.py
+++ b/stingray/spectroscopy.py
@@ -9,8 +9,15 @@ from stingray import Lightcurve, Crossspectrum
 from stingray.utils import standard_error, find_nearest, fft, ifft
 from stingray.filters import Optimal1D, Window1D
 
+from typing import Union, Tuple, Dict, Optional, Any, TYPE_CHECKING
 
-def load_lc_fits(file, counts_type=True):
+if TYPE_CHECKING:
+    from numpy import typing as npt
+
+
+def load_lc_fits(
+    file: str, counts_type: Optional[bool] = True
+) -> Tuple(npt.NDArray, npt.NDArray, Dict[str, Any]):
     """
     Function to load FITS file having reference band and channel of interest
     bands.
@@ -50,7 +57,9 @@ def load_lc_fits(file, counts_type=True):
     return ref, ci, meta
 
 
-def get_new_df(spectrum, n_bins):
+def get_new_df(
+    spectrum: Union[Powerspectrum, Crossspectrum], n_bins: int
+) -> float:
     """
     Return the new df used to re-bin the spectrum.
 
@@ -73,7 +82,7 @@ def get_new_df(spectrum, n_bins):
     return new_df
 
 
-def ccf(cs_power, ps_rms, n_bins):
+def ccf(cs_power: npt.NDArray, ps_rms: npt.NDArray, n_bins: int) -> npt.NDArray:
     """
     Return the normalised cross-correlation function of the cross spectrum. It
     is normalised using the average RMS of power spectrum.
@@ -101,7 +110,9 @@ def ccf(cs_power, ps_rms, n_bins):
 
 
 def ccf_error(
-    ref_counts, ci_counts_0, cs_res_model, rebin_log_factor, meta, ps_rms, filter_type="optimal"
+    ref_counts: npt.NDArray, ci_counts_0: npt.NDArray, cs_res_model: Any,
+    rebin_log_factor: float, meta: Dict[str, Any], ps_rms: npt.NDArray,
+    filter_type: Optional[str] = "optimal"
 ):
     n_seg = meta["N_SEG"]
     n_seconds = meta["NSECONDS"]
@@ -155,7 +166,9 @@ def ccf_error(
     return error, avg_seg_ccf
 
 
-def get_parameters(counts, dt, model):
+def get_parameters(
+    counts: npt.NDArray, dt: float, model: Any
+) -> Tuple[float, float, float, float]:
     """
     Function to calculate mean count rate, phase offset and phase difference
     between the harmonics.
@@ -218,7 +231,10 @@ def get_parameters(counts, dt, model):
     return mu, cap_phi_1, cap_phi_2, small_psi
 
 
-def waveform(x, mu, avg_sigma_1, avg_sigma_2, cap_phi_1, cap_phi_2):
+def waveform(
+    x: npt.NDArray, mu: float, avg_sigma_1: float,
+    avg_sigma_2: float, cap_phi_1: float, cap_phi_2: float
+) -> npt.NDArray:
     """
     Return the QPO waveform (periodic function of QPO phase).
 
@@ -256,7 +272,7 @@ def waveform(x, mu, avg_sigma_1, avg_sigma_2, cap_phi_1, cap_phi_2):
     return y
 
 
-def psi_distance(avg_psi, psi):
+def psi_distance(avg_psi: float, psi: npt.NDArray) -> npt.NDArray:
     """
     Return the distance between array of phase differences of the segments
     and the mean phase difference.
@@ -279,7 +295,7 @@ def psi_distance(avg_psi, psi):
     return dm
 
 
-def x_2_function(x, *args):
+def x_2_function(x: float, *args) -> float:
     """
     Function to minimise to find the average phase difference of the segments.
     """
@@ -288,7 +304,7 @@ def x_2_function(x, *args):
     return X_2
 
 
-def get_mean_phase_difference(cs, model):
+def get_mean_phase_difference(cs: Crossspectrum, model: Any) -> Tuple[float, float]:
     """
     Return the mean phase difference between the first and second harmonics.
 
@@ -331,7 +347,7 @@ def get_mean_phase_difference(cs, model):
     return avg_psi, stddev
 
 
-def get_phase_lag(cs, model):
+def get_phase_lag(cs: Crossspectrum, model: Any) -> Tuple[float, float, float]:
     """
     Return the phase offset of the waveform.
 
@@ -378,7 +394,9 @@ def get_phase_lag(cs, model):
     return cap_phi_1, cap_phi_2, avg_psi
 
 
-def compute_rms(spectrum, model, criteria="all"):
+def compute_rms(
+    spectrum: Union[Powerspectrum, Crossspectrum], model: Any, criteria: Optional[str]="all"
+) -> float:
     """
     Return the average RMS based of the fitting model used and frequency
     selection criteria.

--- a/stingray/spectroscopy.py
+++ b/stingray/spectroscopy.py
@@ -5,6 +5,7 @@ from scipy.optimize import brent
 
 from astropy.table import Table
 from astropy.modeling.models import Lorentz1D
+from astropy.modeling.core import Model as AstropyModel
 from stingray import Lightcurve, Crossspectrum
 from stingray.utils import standard_error, find_nearest, fft, ifft
 from stingray.filters import Optimal1D, Window1D
@@ -14,7 +15,8 @@ from typing import Union, Tuple, Dict, Optional, Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from numpy import typing as npt
 
-AstropyModel = astropy.modeling.core.Model
+#AstropyModel = astropy.modeling.core.Model
+
 
 def load_lc_fits(
     file: str, counts_type: Optional[bool] = True
@@ -58,9 +60,7 @@ def load_lc_fits(
     return ref, ci, meta
 
 
-def get_new_df(
-    spectrum: Union[Powerspectrum, Crossspectrum], n_bins: int
-) -> float:
+def get_new_df(spectrum: Union[Powerspectrum, Crossspectrum], n_bins: int) -> float:
     """
     Return the new df used to re-bin the spectrum.
 
@@ -113,9 +113,13 @@ def ccf(
 
 
 def ccf_error(
-    ref_counts: npt.ArrayLike[float], ci_counts_0: npt.ArrayLike[float], cs_res_model: AstropyModel,
-    rebin_log_factor: float, meta: Dict[str, Any], ps_rms: npt.ArrayLike[float],
-    filter_type: Optional[str] = "optimal"
+    ref_counts: npt.ArrayLike[float],
+    ci_counts_0: npt.ArrayLike[float],
+    cs_res_model: AstropyModel,
+    rebin_log_factor: float,
+    meta: Dict[str, Any],
+    ps_rms: npt.ArrayLike[float],
+    filter_type: Optional[str] = "optimal",
 ) -> Tuple[npt.ArrayLike[float], npt.ArrayLike[float]]:
     # Need documentation here
 
@@ -133,7 +137,9 @@ def ccf_error(
     for i in range(n_seg):  # for each segment
         # Creating cross spectrum
         seg_ci_lc = Lightcurve(seg_times, seg_ci_counts[i], dt=dt)  # CoI light curve
-        seg_ref_lc = Lightcurve(seg_times, seg_ref_counts[i], dt=dt)  # reference band light curve
+        seg_ref_lc = Lightcurve(
+            seg_times, seg_ref_counts[i], dt=dt
+        )  # reference band light curve
         seg_cs = Crossspectrum(
             lc2=seg_ci_lc, lc1=seg_ref_lc, norm="leahy", power_type="absolute"
         )  # cross spectrum
@@ -172,7 +178,9 @@ def ccf_error(
 
 
 def get_parameters(
-    counts: Union[npt.ArrayLike[int], npt.ArrayLike[float]], dt: float, model: AstropyModel
+    counts: Union[npt.ArrayLike[int], npt.ArrayLike[float]],
+    dt: float,
+    model: AstropyModel,
 ) -> Tuple[float, float, float, float]:
     """
     Function to calculate mean count rate, phase offset and phase difference
@@ -237,8 +245,12 @@ def get_parameters(
 
 
 def waveform(
-    x: npt.ArrayLike, mu: float, avg_sigma_1: float,
-    avg_sigma_2: float, cap_phi_1: float, cap_phi_2: float
+    x: npt.ArrayLike,
+    mu: float,
+    avg_sigma_1: float,
+    avg_sigma_2: float,
+    cap_phi_1: float,
+    cap_phi_2: float,
 ) -> npt.ArrayLike:
     """
     Return the QPO waveform (periodic function of QPO phase).
@@ -272,7 +284,10 @@ def waveform(
     y = mu * (
         1
         + np.sqrt(2)
-        * (avg_sigma_1 * np.cos(x - cap_phi_1) + avg_sigma_2 * np.cos(2 * x - cap_phi_2))
+        * (
+            avg_sigma_1 * np.cos(x - cap_phi_1)
+            + avg_sigma_2 * np.cos(2 * x - cap_phi_2)
+        )
     )
     return y
 
@@ -296,7 +311,9 @@ def psi_distance(avg_psi: float, psi: npt.ArrayLike[List[float]]) -> npt.ArrayLi
 
     """
     delta = np.abs(psi - avg_psi)
-    dm = np.array([delta_i if avg_psi < np.pi / 2 else np.pi - delta for delta_i in delta])
+    dm = np.array(
+        [delta_i if avg_psi < np.pi / 2 else np.pi - delta for delta_i in delta]
+    )
     return dm
 
 
@@ -309,7 +326,9 @@ def x_2_function(x: float, *args) -> float:
     return X_2
 
 
-def get_mean_phase_difference(cs: Crossspectrum, model: AstropyModel) -> Tuple[float, float]:
+def get_mean_phase_difference(
+    cs: Crossspectrum, model: AstropyModel
+) -> Tuple[float, float]:
     """
     Return the mean phase difference between the first and second harmonics.
 
@@ -400,7 +419,9 @@ def get_phase_lag(cs: Crossspectrum, model: AstropyModel) -> Tuple[float, float,
 
 
 def compute_rms(
-    spectrum: Union[Powerspectrum, Crossspectrum], model: AstropyModel, criteria: Optional[str]="all"
+    spectrum: Union[Powerspectrum, Crossspectrum],
+    model: AstropyModel,
+    criteria: Optional[str] = "all",
 ) -> float:
     """
     Return the average RMS based of the fitting model used and frequency

--- a/stingray/spectroscopy.py
+++ b/stingray/spectroscopy.py
@@ -14,6 +14,7 @@ from typing import Union, Tuple, Dict, Optional, Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from numpy import typing as npt
 
+AstropyModel = astropy.modeling.core.Model
 
 def load_lc_fits(
     file: str, counts_type: Optional[bool] = True
@@ -112,7 +113,7 @@ def ccf(
 
 
 def ccf_error(
-    ref_counts: npt.ArrayLike[float], ci_counts_0: npt.ArrayLike[float], cs_res_model: Any,
+    ref_counts: npt.ArrayLike[float], ci_counts_0: npt.ArrayLike[float], cs_res_model: AstropyModel,
     rebin_log_factor: float, meta: Dict[str, Any], ps_rms: npt.ArrayLike[float],
     filter_type: Optional[str] = "optimal"
 ) -> Tuple[npt.ArrayLike[float], npt.ArrayLike[float]]:
@@ -171,7 +172,7 @@ def ccf_error(
 
 
 def get_parameters(
-    counts: npt.ArrayLike, dt: float, model: Any
+    counts: Union[npt.ArrayLike[int], npt.ArrayLike[float]], dt: float, model: AstropyModel
 ) -> Tuple[float, float, float, float]:
     """
     Function to calculate mean count rate, phase offset and phase difference
@@ -276,7 +277,7 @@ def waveform(
     return y
 
 
-def psi_distance(avg_psi: float, psi: npt.ArrayLike) -> npt.ArrayLike:
+def psi_distance(avg_psi: float, psi: npt.ArrayLike[List[float]]) -> npt.ArrayLike:
     """
     Return the distance between array of phase differences of the segments
     and the mean phase difference.
@@ -308,7 +309,7 @@ def x_2_function(x: float, *args) -> float:
     return X_2
 
 
-def get_mean_phase_difference(cs: Crossspectrum, model: Any) -> Tuple[float, float]:
+def get_mean_phase_difference(cs: Crossspectrum, model: AstropyModel) -> Tuple[float, float]:
     """
     Return the mean phase difference between the first and second harmonics.
 
@@ -351,7 +352,7 @@ def get_mean_phase_difference(cs: Crossspectrum, model: Any) -> Tuple[float, flo
     return avg_psi, stddev
 
 
-def get_phase_lag(cs: Crossspectrum, model: Any) -> Tuple[float, float, float]:
+def get_phase_lag(cs: Crossspectrum, model: AstropyModel) -> Tuple[float, float, float]:
     """
     Return the phase offset of the waveform.
 
@@ -399,7 +400,7 @@ def get_phase_lag(cs: Crossspectrum, model: Any) -> Tuple[float, float, float]:
 
 
 def compute_rms(
-    spectrum: Union[Powerspectrum, Crossspectrum], model: Any, criteria: Optional[str]="all"
+    spectrum: Union[Powerspectrum, Crossspectrum], model: AstropyModel, criteria: Optional[str]="all"
 ) -> float:
     """
     Return the average RMS based of the fitting model used and frequency

--- a/stingray/spectroscopy.py
+++ b/stingray/spectroscopy.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 def load_lc_fits(
     file: str, counts_type: Optional[bool] = True
-) -> Tuple(npt.NDArray, npt.NDArray, Dict[str, Any]):
+) -> Tuple(npt.ArrayLike[float], npt.ArrayLike[float], Dict[str, Any]):
     """
     Function to load FITS file having reference band and channel of interest
     bands.
@@ -82,7 +82,9 @@ def get_new_df(
     return new_df
 
 
-def ccf(cs_power: npt.NDArray, ps_rms: npt.NDArray, n_bins: int) -> npt.NDArray:
+def ccf(
+    cs_power: npt.ArrayLike[float], ps_rms: npt.ArrayLike[float], n_bins: int
+) -> npt.ArrayLike[float]:
     """
     Return the normalised cross-correlation function of the cross spectrum. It
     is normalised using the average RMS of power spectrum.
@@ -110,10 +112,12 @@ def ccf(cs_power: npt.NDArray, ps_rms: npt.NDArray, n_bins: int) -> npt.NDArray:
 
 
 def ccf_error(
-    ref_counts: npt.NDArray, ci_counts_0: npt.NDArray, cs_res_model: Any,
-    rebin_log_factor: float, meta: Dict[str, Any], ps_rms: npt.NDArray,
+    ref_counts: npt.ArrayLike[float], ci_counts_0: npt.ArrayLike[float], cs_res_model: Any,
+    rebin_log_factor: float, meta: Dict[str, Any], ps_rms: npt.ArrayLike[float],
     filter_type: Optional[str] = "optimal"
-):
+) -> Tuple[npt.ArrayLike[float], npt.ArrayLike[float]]:
+    # Need documentation here
+
     n_seg = meta["N_SEG"]
     n_seconds = meta["NSECONDS"]
     dt = meta["DT"]
@@ -167,7 +171,7 @@ def ccf_error(
 
 
 def get_parameters(
-    counts: npt.NDArray, dt: float, model: Any
+    counts: npt.ArrayLike, dt: float, model: Any
 ) -> Tuple[float, float, float, float]:
     """
     Function to calculate mean count rate, phase offset and phase difference
@@ -232,9 +236,9 @@ def get_parameters(
 
 
 def waveform(
-    x: npt.NDArray, mu: float, avg_sigma_1: float,
+    x: npt.ArrayLike, mu: float, avg_sigma_1: float,
     avg_sigma_2: float, cap_phi_1: float, cap_phi_2: float
-) -> npt.NDArray:
+) -> npt.ArrayLike:
     """
     Return the QPO waveform (periodic function of QPO phase).
 
@@ -272,7 +276,7 @@ def waveform(
     return y
 
 
-def psi_distance(avg_psi: float, psi: npt.NDArray) -> npt.NDArray:
+def psi_distance(avg_psi: float, psi: npt.ArrayLike) -> npt.ArrayLike:
     """
     Return the distance between array of phase differences of the segments
     and the mean phase difference.

--- a/stingray/spectroscopy.py
+++ b/stingray/spectroscopy.py
@@ -11,11 +11,7 @@ from stingray.utils import standard_error, find_nearest, fft, ifft
 from stingray.filters import Optimal1D, Window1D
 
 from typing import Union, Tuple, Dict, Optional, Any, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from numpy import typing as npt
-
-#AstropyModel = astropy.modeling.core.Model
+from numpy import typing as npt
 
 
 def load_lc_fits(


### PR DESCRIPTION
This commit adds typehints to spectroscopy.py.
Things to be noted:

- I have added the type `Dict[str, Any]` for `meta` (meta data after reading from astropy table) after reading the Astropy documentation [here](https://docs.astropy.org/en/stable/table/construct_table.html#meta)
- I have added the `Any` type wherever a `model` is passed

Please let me know if there are any changes I can make. Any suggestions are appreciated