### PR TITLE
Fix failing test configuration

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -17,7 +17,6 @@ jobs:
   ci-tests:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
-    if: ! contains(github.event.head_commit.message, '[docs only]')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In #743, I confused the non-starting of the standard build with the effect of "skip ci". Instead, the configuration file was wrong.
This fixes the issue. Still need to find a way to just start a docs build.