### PR TITLE
Fix failure with external forks

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-# Found this solution at
-# https://monadical.com/posts/filters-github-actions.html#Case-2-Pull-request
+      # Found this solution at
+      # https://monadical.com/posts/filters-github-actions.html#Case-2-Pull-request
       - name: check if message indicates that tests should be skipped
         id: check_commit
         run: |

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -25,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
 # Found this solution at
 # https://monadical.com/posts/filters-github-actions.html#Case-2-Pull-request


### PR DESCRIPTION
This should fix the failures with the check_commit step from forks
(E.g. #737 and #739)