### PR TITLE
Reduced memory usage of EventList.from_lc()

### DIFF
--- a/docs/changes/756.bugfix.rst
+++ b/docs/changes/756.bugfix.rst
@@ -1,0 +1,1 @@
+Changed list comprehension to generator expression to reduce memory usage.

--- a/stingray/events.py
+++ b/stingray/events.py
@@ -290,9 +290,9 @@ class EventList(StingrayTimeseries):
         """
 
         # Multiply times by number of counts
-        times = [[i] * int(j) for i, j in zip(lc.time, lc.counts)]
+        times = ([i] * int(j) for i, j in zip(lc.time, lc.counts))
         # Concatenate all lists
-        times = [i for j in times for i in j]
+        times = list(i for j in times for i in j)
 
         return EventList(time=times, gti=lc.gti)
 


### PR DESCRIPTION
Reduced memory usage of `from_lc` method of EventList by changing list comprehension to a generator comprehension expression