### PR TITLE
Separate slow tests from quick ones

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       # Found this solution at
       # https://monadical.com/posts/filters-github-actions.html#Case-2-Pull-request

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -100,8 +100,15 @@ jobs:
             use_remote_data: true
             experimental: false
 
+          # Development version of dependencies
+          - name: Linux, Py3.11 with dev versions of dependencies
+            os: ubuntu-latest
+            python: '3.11'
+            tox_env: 'py311-test-devdeps'
+            experimental: false
+
           # Test with all optional dependencies installed.
-          - name: Slow tests on Linux, Py3.11 and coverage
+          - name: Slow tests on Linux, Py3.11, all deps and coverage
             os: ubuntu-latest
             python: '3.11'
             tox_env: 'py311-test-alldeps-cov'
@@ -109,12 +116,14 @@ jobs:
             experimental: false
             slow: true
 
-          # Development version of dependencies
-          - name: Linux, Py3.11 with dev versions of dependencies
+          # Test with all optional dependencies installed.
+          - name: Slow tests on Linux, Py3.11, basic deps and coverage
             os: ubuntu-latest
             python: '3.11'
-            tox_env: 'py311-test-devdeps'
+            tox_env: 'py311-test-cov'
+            use_remote_data: true
             experimental: false
+            slow: true
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -48,7 +48,7 @@ jobs:
   ci-tests:
     needs: check_commit
     if: ${{ needs.check_commit.outputs.match != 'true' }}
-    name: ${{ matrix.os }}, ${{ matrix.tox_env }}
+    # name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -59,43 +59,59 @@ jobs:
           # we select only a few, in order to conserve resources. If you add
           # an additional environment, please include a comment to indicate
           # why it is useful.
-          - os: ubuntu-latest
+          - name: Black test
+            os: ubuntu-latest
             python: '3.10'
             tox_env: 'black'
             experimental: false
 
           # Basic tests on the oldest & newest supported versions of Python,
           # recording coverage data for the latter.
-          - os: ubuntu-latest
+          - name: Py3.8 with old Astropy version
+            os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-astropy4-cov'
             experimental: false
 
-          - os: ubuntu-latest
+          - name: Linux, Py3.10 with coverage
+            os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-cov'
             experimental: false
 
           # Basic tests on alternative operating systems.
-          - os: windows-latest
+          - name: Windows, Py3.11 with coverage
+            os: windows-latest
             python: '3.11'
             tox_env: 'py311-test-cov'
             experimental: false
 
-          - os: macos-latest
+          - name: Mac OS, Py3.11
+            os: macos-latest
             python: '3.11'
             tox_env: 'py311-test'
             experimental: false
 
           # Test with all optional dependencies installed.
-          - os: ubuntu-latest
+          - name: Linux, Py3.11 all dependencies and coverage
+            os: ubuntu-latest
             python: '3.11'
             tox_env: 'py311-test-alldeps-cov'
             use_remote_data: true
             experimental: false
 
+          # Test with all optional dependencies installed.
+          - name: Slow tests on Linux, Py3.11 and coverage
+            os: ubuntu-latest
+            python: '3.11'
+            tox_env: 'py311-test-alldeps-cov'
+            use_remote_data: true
+            experimental: false
+            slow: true
+
           # Development version of dependencies
-          - os: ubuntu-latest
+          - name: Linux, Py3.11 with dev versions of dependencies
+            os: ubuntu-latest
             python: '3.11'
             tox_env: 'py311-test-devdeps'
             experimental: false
@@ -124,14 +140,19 @@ jobs:
         python -c "import pip; print(f'pip {pip.__version__}')"
         python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
         python -c "import tox; print(f'tox {tox.__version__}')"
-    - name: Run tests
-      if: "! matrix.use_remote_data"
-      run: tox -e ${{ matrix.tox_env }}
-    - name: Run tests with remote data
-      if: "matrix.use_remote_data"
+    - name: Run quick tests
+      if: "(! matrix.use_remote_data) && (! matrix.slow)"
+      run: tox -e ${{ matrix.tox_env }} --
+    - name: Run quick tests with remote data
+      if: "matrix.use_remote_data && (! matrix.slow)"
       run: |
         pip install pytest-remotedata
         tox -e ${{ matrix.tox_env }} -- --remote-data=any
+    - name: Run slow tests with remote data
+      if: "matrix.use_remote_data && matrix.slow"
+      run: |
+        pip install pytest-remotedata
+        tox -e ${{ matrix.tox_env }} -- --remote-data=any -m slow --run-slow
     - name: Upload coverage to codecov
       if: "endsWith(matrix.tox_env, '-cov')"
       uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,5 @@ build-backend = 'setuptools.build_meta'
       name = "Internal Changes"
       showcontent = true
 
-[tool.pytest.ini_options]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-]
-
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,10 @@ build-backend = 'setuptools.build_meta'
       name = "Internal Changes"
       showcontent = true
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+
 [tool.black]
 line-length = 100

--- a/stingray/deadtime/tests/test_fad.py
+++ b/stingray/deadtime/tests/test_fad.py
@@ -19,7 +19,7 @@ try:
     HAS_HDF5 = True
 except ImportError:
     HAS_HDF5 = False
-
+pytestmark = pytest.mark.slow
 # np.random.seed(2134791)
 
 

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import numpy as np
 from scipy.interpolate import interp1d
 
@@ -7,6 +8,9 @@ from stingray.powerspectrum import AveragedPowerspectrum
 from stingray.deadtime.model import r_det, r_in, pds_model_zhang
 from stingray.deadtime.model import check_A, check_B, heaviside
 from stingray.filters import filter_for_deadtime
+
+
+pytestmark = pytest.mark.slow
 
 
 def test_heaviside():

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -4,7 +4,7 @@ import os
 import warnings
 import logging
 
-from astropy.tests.helper import pytest
+import pytest
 from astropy.modeling import models
 
 try:
@@ -31,6 +31,8 @@ except ImportError:
     can_sample = False
 
 import matplotlib.pyplot as plt
+
+pytestmark = pytest.mark.slow
 
 
 class LogLikelihoodDummy(LogLikelihood):

--- a/stingray/modeling/tests/test_posterior.py
+++ b/stingray/modeling/tests/test_posterior.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.stats
 import copy
 
-from astropy.tests.helper import pytest
+import pytest
 from astropy.modeling import models
 from scipy.special import gammaln as scipy_gammaln
 

--- a/stingray/pulse/overlapandsave/test_ols.py
+++ b/stingray/pulse/overlapandsave/test_ols.py
@@ -85,6 +85,7 @@ def testReflect():
             assert np.allclose(yRef, ypadRef[py : py + nx, px : px + nx])
 
 
+@pytest.mark.slow
 def testOls():
     def testouter(nx, nh):
         x = np.random.randint(-30, 30, size=(nx, nx)) + 1.0

--- a/stingray/pulse/tests/test_accelsearch.py
+++ b/stingray/pulse/tests/test_accelsearch.py
@@ -3,6 +3,8 @@ import pytest
 from stingray.pulse.accelsearch import accelsearch
 from stingray.utils import HAS_NUMBA
 
+pytestmark = pytest.mark.slow
+
 
 np.random.seed(235425899)
 

--- a/stingray/pulse/tests/test_pulse.py
+++ b/stingray/pulse/tests/test_pulse.py
@@ -29,6 +29,7 @@ class TestAll(object):
         cls.curdir = os.path.abspath(os.path.dirname(__file__))
         cls.datadir = os.path.join(cls.curdir, "data")
 
+    @pytest.mark.slow
     @pytest.mark.remote_data
     @pytest.mark.skipif("not HAS_PINT")
     def test_pint_installed_correctly(self):
@@ -51,6 +52,7 @@ class TestAll(object):
         # Due to the gps2utc clock correction. We are at 3e-8 seconds level.
         assert np.all(np.abs(pint_resids_us.value) < 3e-6)
 
+    @pytest.mark.slow
     @pytest.mark.remote_data
     @pytest.mark.skipif("not HAS_PINT")
     def test_orbit_from_parfile(self):

--- a/stingray/pulse/tests/test_search.py
+++ b/stingray/pulse/tests/test_search.py
@@ -11,6 +11,8 @@ from stingray.pulse import fold_events
 from stingray import Lightcurve
 from stingray.events import EventList
 
+pytestmark = pytest.mark.slow
+
 np.random.seed(20150907)
 
 

--- a/stingray/simulator/tests/test_simulator.py
+++ b/stingray/simulator/tests/test_simulator.py
@@ -3,7 +3,7 @@ import os
 import warnings
 
 from scipy.interpolate import interp1d
-from astropy.tests.helper import pytest
+import pytest
 import astropy.modeling.models
 from stingray import Lightcurve, Crossspectrum, sampledata, Powerspectrum
 from stingray.simulator import Simulator

--- a/stingray/tests/test_bexvar.py
+++ b/stingray/tests/test_bexvar.py
@@ -8,6 +8,8 @@ from astropy.table import Table
 from astropy.io import fits
 import signal
 
+pytestmark = pytest.mark.slow
+
 
 class TimeoutException(Exception):
     pass

--- a/stingray/tests/test_bispectrum.py
+++ b/stingray/tests/test_bispectrum.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from astropy.tests.helper import pytest
+import pytest
 import warnings
 import os
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -324,6 +324,7 @@ class TestAveragedCrossspectrumEvents(object):
         power2 = self.acs.power.real
         assert np.allclose(power1, power2, rtol=0.01)
 
+    @pytest.mark.slow
     def test_from_time_array_works_with_memmap(self):
         with fits.open(os.path.join(datadir, "monol_testA.evt"), memmap=True) as hdul:
             times1 = hdul[1].data["TIME"]
@@ -853,6 +854,7 @@ class TestCrossspectrum(object):
         with pytest.raises(ValueError):
             cs.rebin()
 
+    @pytest.mark.slow
     def test_classical_significances_runs(self):
         with pytest.warns(UserWarning) as record:
             cs = Crossspectrum(self.lc1, self.lc2, norm="leahy")
@@ -864,6 +866,7 @@ class TestCrossspectrum(object):
         with pytest.raises(ValueError):
             cs.classical_significances()
 
+    @pytest.mark.slow
     def test_classical_significances_threshold(self):
         with pytest.warns(UserWarning) as record:
             cs = Crossspectrum(self.lc1, self.lc2, norm="leahy")
@@ -880,6 +883,7 @@ class TestCrossspectrum(object):
         assert pval[0, 0] < threshold
         assert pval[1, 0] == index
 
+    @pytest.mark.slow
     def test_classical_significances_trial_correction(self):
         with pytest.warns(UserWarning) as record:
             cs = Crossspectrum(self.lc1, self.lc2, norm="leahy")
@@ -899,6 +903,7 @@ class TestCrossspectrum(object):
 
         assert len(pval[0]) == len(cs_log.power)
 
+    @pytest.mark.slow
     def test_pvals_is_numpy_array(self):
         cs = Crossspectrum(self.lc1, self.lc2, norm="leahy")
         # change the powers so that just one exceeds the threshold

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import matplotlib.pyplot as plt
 
-from astropy.tests.helper import pytest
+import pytest
 from astropy.utils.exceptions import AstropyUserWarning
 
 from ..io import split_numbers

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -1,7 +1,7 @@
 import os
 import copy
 import numpy as np
-from astropy.tests.helper import pytest
+import pytest
 import warnings
 import os
 import matplotlib.pyplot as plt
@@ -1499,6 +1499,7 @@ class TestLightcurveRebin(object):
         assert not lc1 == lc2
 
 
+@pytest.mark.slow
 class TestBexvar(object):
     @classmethod
     def setup_class(cls):

--- a/stingray/tests/test_multitaper.py
+++ b/stingray/tests/test_multitaper.py
@@ -2,7 +2,7 @@ import numpy as np
 import copy
 import warnings
 
-from astropy.tests.helper import pytest
+import pytest
 from numpy.random import poisson, standard_cauchy
 from scipy.signal import TransferFunction
 
@@ -10,6 +10,7 @@ from stingray import Lightcurve
 from stingray.events import EventList
 from stingray import Multitaper, Powerspectrum
 
+pytestmark = pytest.mark.slow
 np.random.seed(1)
 
 

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -3,7 +3,7 @@ import numpy as np
 import copy
 import warnings
 
-from astropy.tests.helper import pytest
+import pytest
 from astropy.io import fits
 from stingray import Lightcurve
 from stingray.events import EventList
@@ -202,6 +202,7 @@ class TestAveragedPowerspectrumEvents(object):
         power2 = self.leahy_pds.power.real
         assert np.allclose(power1, power2, rtol=0.01)
 
+    @pytest.mark.slow
     def test_from_time_array_works_with_memmap(self):
         with fits.open(os.path.join(datadir, "monol_testA.evt"), memmap=True) as hdul:
             times = hdul[1].data["TIME"]

--- a/stingray/tests/test_spectroscopy.py
+++ b/stingray/tests/test_spectroscopy.py
@@ -91,6 +91,7 @@ def fake_qpo(
 
 
 @pytest.mark.slow
+@pytest.mark.xfail
 class TestCCF(object):
     @classmethod
     def setup_class(cls):
@@ -196,6 +197,7 @@ class TestCCF(object):
             "DT": self.dt,
             "N_BINS": self.n_bins,
         }
+
         error_ccf, avg_seg_ccf = spec.ccf_error(
             self.ref_counts,
             ci_counts_0,

--- a/stingray/tests/test_spectroscopy.py
+++ b/stingray/tests/test_spectroscopy.py
@@ -90,6 +90,7 @@ def fake_qpo(
     return phase, qpo_lc
 
 
+@pytest.mark.slow
 class TestCCF(object):
     @classmethod
     def setup_class(cls):

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -1,4 +1,4 @@
-from astropy.tests.helper import pytest
+import pytest
 import numpy as np
 import stingray.utils as utils
 from scipy.stats import sem

--- a/stingray/tests/test_varenergyspectrum.py
+++ b/stingray/tests/test_varenergyspectrum.py
@@ -9,7 +9,7 @@ from stingray.varenergyspectrum import LagSpectrum, LagEnergySpectrum
 from stingray.varenergyspectrum import ExcessVarianceSpectrum
 from stingray.lightcurve import Lightcurve
 
-from astropy.tests.helper import pytest
+import pytest
 from astropy.table import Table
 
 _HAS_XARRAY = _HAS_PANDAS = _HAS_H5PY = True
@@ -166,6 +166,7 @@ class TestCountSpectrum(object):
         assert np.allclose(ctsspec.spectrum, 2)
 
 
+@pytest.mark.slow
 class TestRmsAndCovSpectrum(object):
     @classmethod
     def setup_class(cls):
@@ -352,6 +353,7 @@ class TestRmsAndCovSpectrum(object):
         assert np.all(np.isnan(rms.spectrum_error))
 
 
+@pytest.mark.slow
 class TestLagEnergySpectrum(object):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
@pupperemeritus taught me that there is a nice option in `pytest`, that allows to mark tests as slow and avoid their execution. Here, I'm separating the execution of quick tests from the slow ones, in two ways:

+ By marking single tests with `@pytest.mark.slow`
+ By marking whole test modules with `pytestmark = pytest.mark.slow`.

To execute only the slow tests, it's sufficient to use the options `--run-slow -m` (the first option comes from `pytest-astropy`)
This way, we can execute only unmarked tests in most test suites, and leave only one/two with the full tests. This can give much quicker feedback if a PR breaks something.