### PR TITLE
Fix powerspectrum from lightcurve - wrong size, float casting

### DIFF
--- a/docs/changes/760.bugfix.rst
+++ b/docs/changes/760.bugfix.rst
@@ -1,0 +1,2 @@
++ Fix a bug with segment sizes not exact multiples of dt when dealing with light curves
++ Fix a bug when light curve segments contain complex values

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -1077,6 +1077,10 @@ def get_flux_iterable_from_segments(times, gti, segment_size, n_bin=None, fluxes
     binned = fluxes is not None
     if binned:
         dt = np.median(np.diff(times[:100]))
+        cast_kind = float
+        fluxes = np.asarray(fluxes)
+        if np.iscomplexobj(fluxes):
+            cast_kind = complex
 
     fun = _which_segment_idx_fun(binned, dt)
 
@@ -1093,9 +1097,9 @@ def get_flux_iterable_from_segments(times, gti, segment_size, n_bin=None, fluxes
             ).astype(float)
             cts = np.array(cts)
         else:
-            cts = fluxes[idx0:idx1].astype(float)
+            cts = fluxes[idx0:idx1].astype(cast_kind)
             if errors is not None:
-                cts = cts, errors[idx0:idx1]
+                cts = cts, errors[idx0:idx1].astype(cast_kind)
 
         yield cts
 

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -48,6 +48,23 @@ def test_norm():
     assert np.isclose(pdsfrac[good].mean(), pois_frac, rtol=0.01)
 
 
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+def test_flux_iterables(dtype):
+    times = np.arange(4)
+    fluxes = np.ones(4).astype(dtype)
+    errors = np.ones(4).astype(dtype) * np.sqrt(2)
+    gti = np.asarray([[-0.5, 3.5]])
+    iter = get_flux_iterable_from_segments(times, gti, 2, n_bin=None, fluxes=fluxes, errors=errors)
+    cast_kind = float
+    if np.iscomplexobj(fluxes):
+        cast_kind = complex
+    for it, er in iter:
+        assert np.allclose(it, 1, rtol=0.01)
+        assert np.allclose(er, np.sqrt(2), rtol=0.01)
+        assert isinstance(it[0], cast_kind)
+        assert isinstance(er[0], cast_kind)
+
+
 class TestCoherence(object):
     @classmethod
     def setup_class(cls):

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -65,6 +65,31 @@ def test_flux_iterables(dtype):
         assert isinstance(er[0], cast_kind)
 
 
+def test_avg_pds_imperfect_lc_size():
+    times = np.arange(100)
+    fluxes = np.ones(100).astype(float)
+    gti = np.asarray([[-0.5, 99.5]])
+    segment_size = 5.99
+    dt = 1
+    res = avg_pds_from_events(times, gti, segment_size, dt, fluxes=fluxes)
+    assert res.meta["segment_size"] == 5
+    assert res.meta["dt"] == 1
+
+
+def test_avg_cs_imperfect_lc_size():
+    times1 = times2 = np.arange(100)
+    fluxes1 = np.ones(100).astype(float)
+    fluxes2 = np.ones(100).astype(float)
+    gti = np.asarray([[-0.5, 99.5]])
+    segment_size = 5.99
+    dt = 1
+    res = avg_cs_from_events(
+        times1, times2, gti, segment_size, dt, fluxes1=fluxes1, fluxes2=fluxes2
+    )
+    assert res.meta["segment_size"] == 5
+    assert res.meta["dt"] == 1
+
+
 class TestCoherence(object):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
Resolves two recently reported issues:

+ `avg_*s_from_event` methods not accepting complex fluxes and
+ `avg_*s_from_event` methods throwing errors of "no segment shorter than gti"

The first one comes from our forcing a float casting on input fluxes (to avoid integers - that can lead to casting errors in Numba routines, and quadruple precision, which is overkill), that kills complex numbers.

The second one comes from our re-defining `dt` to accommodate an exact number of bins inside a segment. This works well with actual events, but does damage when you have a light curve that was sampled with a given dt.

