### PR TITLE
Fix crossspectrum all default

### DIFF
--- a/docs/changes/762.bugfix.rst
+++ b/docs/changes/762.bugfix.rst
@@ -1,0 +1,1 @@
+Crossspectrum had "real" as default value. This meant that, for example, lags could not be calculated. Now the default value is "all", as it should be.

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -547,7 +547,7 @@ class Crossspectrum(StingrayObject):
         gti=None,
         lc1=None,
         lc2=None,
-        power_type="real",
+        power_type="all",
         dt=None,
         fullspec=False,
         skip_checks=False,

--- a/stingray/modeling/gpmodeling.py
+++ b/stingray/modeling/gpmodeling.py
@@ -37,8 +37,7 @@ except ImportError:
     tfp_available = False
 
 
-__all__ = ["get_kernel", "get_mean", "get_prior", 
-           "get_log_likelihood", "GPResult", "get_gp_params"]
+__all__ = ["get_kernel", "get_mean", "get_prior", "get_log_likelihood", "GPResult", "get_gp_params"]
 
 
 def get_kernel(kernel_type, kernel_params):
@@ -575,8 +574,7 @@ class GPResult:
         self.counts = lc.counts
         self.result = None
 
-    def sample(self, prior_model=None, likelihood_model=None, max_samples=1e4,
-               num_live_points=500):
+    def sample(self, prior_model=None, likelihood_model=None, max_samples=1e4, num_live_points=500):
         """
         Makes a Jaxns nested sampler over the Gaussian Process, given the
         prior and likelihood model
@@ -619,7 +617,9 @@ class GPResult:
         nsmodel = Model(prior_model=self.prior_model, log_likelihood=self.log_likelihood_model)
         nsmodel.sanity_check(random.PRNGKey(10), S=100)
 
-        self.exact_ns = ExactNestedSampler(nsmodel, num_live_points=num_live_points, max_samples=max_samples)
+        self.exact_ns = ExactNestedSampler(
+            nsmodel, num_live_points=num_live_points, max_samples=max_samples
+        )
 
         termination_reason, state = self.exact_ns(
             random.PRNGKey(42), term_cond=TerminationCondition(live_evidence_frac=1e-4)

--- a/stingray/simulator/tests/test_simulator.py
+++ b/stingray/simulator/tests/test_simulator.py
@@ -39,7 +39,7 @@ class TestSimulator(object):
 
         lc1 = Lightcurve(time, s)
         lc2 = Lightcurve(time, output)
-        cross = Crossspectrum(lc1, lc2)
+        cross = Crossspectrum(lc2, lc1)
         cross = cross.rebin(0.0075)
 
         return np.angle(cross.power) / (2 * np.pi * cross.freq)
@@ -559,7 +559,7 @@ class TestSimulator(object):
             outputs.append(lc2)
 
         with pytest.warns(UserWarning, match="Your lightcurves have different statistics"):
-            cross = [Crossspectrum(lc, lc2).rebin(0.0075) for lc2 in outputs]
+            cross = [Crossspectrum(lc2, lc).rebin(0.0075) for lc2 in outputs]
         lags = [np.angle(c.power) / (2 * np.pi * c.freq) for c in cross]
 
         v_cutoffs = [1.0 / (2.0 * 5), 1.0 / (2.0 * 10)]
@@ -588,7 +588,7 @@ class TestSimulator(object):
             outputs.append(lc2)
 
         with pytest.warns(UserWarning, match="Your lightcurves have different statistics"):
-            cross = [Crossspectrum(lc, lc2).rebin(0.0075) for lc2 in outputs]
+            cross = [Crossspectrum(lc2, lc).rebin(0.0075) for lc2 in outputs]
         lags = [np.angle(c.power) / (2 * np.pi * c.freq) for c in cross]
 
         v_cutoff = 1.0 / (2.0 * 5)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -869,7 +869,7 @@ class TestCrossspectrum(object):
     @pytest.mark.slow
     def test_classical_significances_threshold(self):
         with pytest.warns(UserWarning) as record:
-            cs = Crossspectrum(self.lc1, self.lc2, norm="leahy")
+            cs = Crossspectrum(self.lc1, self.lc2, norm="leahy", power_type="real")
 
         # change the powers so that just one exceeds the threshold
         cs.power = np.zeros_like(cs.power) + 2.0
@@ -886,7 +886,7 @@ class TestCrossspectrum(object):
     @pytest.mark.slow
     def test_classical_significances_trial_correction(self):
         with pytest.warns(UserWarning) as record:
-            cs = Crossspectrum(self.lc1, self.lc2, norm="leahy")
+            cs = Crossspectrum(self.lc1, self.lc2, norm="leahy", power_type="real")
         # change the powers so that just one exceeds the threshold
         cs.power = np.zeros_like(cs.power) + 2.0
         index = 1
@@ -897,7 +897,7 @@ class TestCrossspectrum(object):
 
     def test_classical_significances_with_logbinned_psd(self):
         with pytest.warns(UserWarning) as record:
-            cs = Crossspectrum(self.lc1, self.lc2, norm="leahy")
+            cs = Crossspectrum(self.lc1, self.lc2, norm="leahy", power_type="real")
         cs_log = cs.rebin_log()
         pval = cs_log.classical_significances(threshold=1.1, trial_correction=False)
 
@@ -905,7 +905,7 @@ class TestCrossspectrum(object):
 
     @pytest.mark.slow
     def test_pvals_is_numpy_array(self):
-        cs = Crossspectrum(self.lc1, self.lc2, norm="leahy")
+        cs = Crossspectrum(self.lc1, self.lc2, norm="leahy", power_type="real")
         # change the powers so that just one exceeds the threshold
         cs.power = np.zeros_like(cs.power) + 2.0
 


### PR DESCRIPTION
For some reason, in `Crossspectrum` the power type remained "real", which also meant that, by default, the lags measured by `Crossspectrum` were all wrong.