### PR TITLE
Weighted histograms

### DIFF
--- a/docs/changes/764.feature.rst
+++ b/docs/changes/764.feature.rst
@@ -1,0 +1,1 @@
+Our fast implementation of histograms is now safer (failing safely to the equivalent numpy histogram functions), more consistent (ranges moved to range, for consistency with numpy), and accept complex weights as well!

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -460,7 +460,7 @@ def test_histogram_numba_fail_safely():
 
 
 @pytest.mark.skipif("not HAS_NUMBA")
-def test_histogramnd_accept_complex():
+def test_histogramnd_accept_complex_warns_with_numba():
     x = np.random.uniform(0.0, 1.0, 100)
     y = np.random.uniform(2.0, 3.0, 100)
     z = np.random.uniform(4.0, 5.0, 100)
@@ -472,7 +472,9 @@ def test_histogramnd_accept_complex():
     )
 
     # This implementation does not support weights
-    with pytest.warns(UserWarning, match="Cannot calculate the histogram with the numba"):
+    with pytest.warns(
+        UserWarning, match="Cannot calculate the histogram with the numba implementation"
+    ):
         Hn = utils.histogramnd(
             (x, y, z, w),
             bins=np.array((5, 6, 7, 8)),
@@ -483,7 +485,28 @@ def test_histogramnd_accept_complex():
     assert np.all(H == Hn.imag)
 
 
-@pytest.mark.skipif("not HAS_NUMBA")
+@pytest.mark.skipif("HAS_NUMBA")
+def test_histogramnd_accept_complex():
+    x = np.random.uniform(0.0, 1.0, 100)
+    y = np.random.uniform(2.0, 3.0, 100)
+    z = np.random.uniform(4.0, 5.0, 100)
+    w = np.random.uniform(6.0, 8.0, 100)
+    H, _ = np.histogramdd(
+        (x, y, z, w),
+        bins=np.array((5, 6, 7, 8)),
+        range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5), (6.0, 8)],
+    )
+
+    Hn = utils.histogramnd(
+        (x, y, z, w),
+        bins=np.array((5, 6, 7, 8)),
+        range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5), (6.0, 8)],
+        weights=np.ones_like(x) + 1.0j,
+    )
+    assert np.all(H == Hn.real)
+    assert np.all(H == Hn.imag)
+
+
 def test_histogram3d_accept_complex():
     x = np.random.uniform(0.0, 1.0, 100)
     y = np.random.uniform(2.0, 3.0, 100)
@@ -502,7 +525,6 @@ def test_histogram3d_accept_complex():
     assert np.all(H == Hn.imag)
 
 
-@pytest.mark.skipif("not HAS_NUMBA")
 def test_histogram2d_accept_complex():
     x = np.random.uniform(0.0, 1.0, 100)
     y = np.random.uniform(2.0, 3.0, 100)
@@ -519,7 +541,6 @@ def test_histogram2d_accept_complex():
     assert np.all(H == Hn.imag)
 
 
-@pytest.mark.skipif("not HAS_NUMBA")
 def test_histogram_accept_complex():
     x = np.random.uniform(0.0, 1.0, 100)
     (H, _) = np.histogram(x, bins=5, range=(0.0, 1.0))

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import stingray.utils as utils
+from stingray.utils import HAS_NUMBA
 from scipy.stats import sem
 
 np.random.seed(20150907)
@@ -368,10 +369,7 @@ def test_equal_count_energy_ranges():
 
 def test_histogram_equiv_numpy():
     x = np.random.uniform(0.0, 1.0, 100)
-    (
-        H,
-        _,
-    ) = np.histogram(x, bins=5, range=(0.0, 1.0))
+    (H, _) = np.histogram(x, bins=5, range=(0.0, 1.0))
 
     Hn = utils.histogram(x, bins=5, range=np.array([0.0, 1.0]))
     assert np.all(H == Hn)
@@ -384,6 +382,150 @@ def test_histogram2d_equiv_numpy():
 
     Hn = utils.histogram2d(x, y, bins=np.array([5, 5]), range=np.array([[0.0, 1.0], [2.0, 3.0]]))
     assert np.all(H == Hn)
+
+
+@pytest.mark.skipif("not HAS_NUMBA")
+def test_histogramnd_numba_fail_safely():
+    x = np.random.uniform(0.0, 1.0, 100)
+    y = np.random.uniform(2.0, 3.0, 100)
+    z = np.random.uniform(4.0, 5.0, 100)
+    w = np.random.uniform(6.0, 8.0, 100)
+    H, _ = np.histogramdd(
+        (x, y, z, w),
+        bins=np.array((5, 6, 7, 8)),
+        range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5), (6.0, 8)],
+        density=True,
+    )
+
+    with pytest.warns(UserWarning, match="Cannot calculate the histogram with the numba"):
+        Hn = utils.histogramnd(
+            (x, y, z, w),
+            bins=np.array((5, 6, 7, 8)),
+            range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5), (6.0, 8)],
+            density=True,
+        )
+    assert np.all(H == Hn)
+
+
+@pytest.mark.skipif("not HAS_NUMBA")
+def test_histogram3d_numba_fail_safely():
+    x = np.random.uniform(0.0, 1.0, 100)
+    y = np.random.uniform(2.0, 3.0, 100)
+    z = np.random.uniform(4.0, 5.0, 100)
+    H, _ = np.histogramdd(
+        (x, y, z), bins=np.array((5, 6, 7)), range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5)], density=True
+    )
+
+    with pytest.warns(UserWarning, match="Cannot calculate the histogram with the numba"):
+        Hn = utils.histogram3d(
+            (x, y, z),
+            bins=np.array((5, 6, 7)),
+            range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5)],
+            density=True,
+        )
+    assert np.all(H == Hn)
+
+
+@pytest.mark.skipif("not HAS_NUMBA")
+def test_histogram2d_numba_fail_safely():
+    x = np.random.uniform(0.0, 1.0, 100)
+    y = np.random.uniform(2.0, 3.0, 100)
+    H, _, _ = np.histogram2d(
+        x, y, bins=np.array((5, 5)), range=[(0.0, 1.0), (2.0, 3.0)], density=True
+    )
+
+    with pytest.warns(UserWarning, match="Cannot calculate the histogram with the numba"):
+        Hn = utils.histogram2d(
+            x,
+            y,
+            bins=np.array([5, 5]),
+            range=np.array([[0.0, 1.0], [2.0, 3.0]]),
+            density=True,
+        )
+    assert np.all(H == Hn)
+
+
+@pytest.mark.skipif("not HAS_NUMBA")
+def test_histogram_numba_fail_safely():
+    x = np.random.uniform(0.0, 1.0, 100)
+    (H, _) = np.histogram(x, bins=5, range=(0.0, 1.0), density=True)
+    with pytest.warns(UserWarning, match="Cannot calculate the histogram with the numba"):
+        Hn = utils.histogram(
+            x,
+            bins=5,
+            range=np.array([0.0, 1.0]),
+            density=True,
+        )
+    assert np.all(H == Hn)
+
+
+@pytest.mark.skipif("not HAS_NUMBA")
+def test_histogramnd_accept_complex():
+    x = np.random.uniform(0.0, 1.0, 100)
+    y = np.random.uniform(2.0, 3.0, 100)
+    z = np.random.uniform(4.0, 5.0, 100)
+    w = np.random.uniform(6.0, 8.0, 100)
+    H, _ = np.histogramdd(
+        (x, y, z, w),
+        bins=np.array((5, 6, 7, 8)),
+        range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5), (6.0, 8)],
+    )
+
+    # This implementation does not support weights
+    with pytest.warns(UserWarning, match="Cannot calculate the histogram with the numba"):
+        Hn = utils.histogramnd(
+            (x, y, z, w),
+            bins=np.array((5, 6, 7, 8)),
+            range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5), (6.0, 8)],
+            weights=np.ones_like(x) + 1.0j,
+        )
+    assert np.all(H == Hn.real)
+    assert np.all(H == Hn.imag)
+
+
+@pytest.mark.skipif("not HAS_NUMBA")
+def test_histogram3d_accept_complex():
+    x = np.random.uniform(0.0, 1.0, 100)
+    y = np.random.uniform(2.0, 3.0, 100)
+    z = np.random.uniform(4.0, 5.0, 100)
+    H, _ = np.histogramdd(
+        (x, y, z), bins=np.array((5, 6, 7)), range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5)]
+    )
+
+    Hn = utils.histogram3d(
+        (x, y, z),
+        bins=np.array((5, 6, 7)),
+        range=[(0.0, 1.0), (2.0, 3.0), (4.0, 5)],
+        weights=np.ones_like(x) + 1.0j,
+    )
+    assert np.all(H == Hn.real)
+    assert np.all(H == Hn.imag)
+
+
+@pytest.mark.skipif("not HAS_NUMBA")
+def test_histogram2d_accept_complex():
+    x = np.random.uniform(0.0, 1.0, 100)
+    y = np.random.uniform(2.0, 3.0, 100)
+    H, _, _ = np.histogram2d(x, y, bins=np.array((5, 5)), range=[(0.0, 1.0), (2.0, 3.0)])
+
+    Hn = utils.histogram2d(
+        x,
+        y,
+        bins=np.array([5, 5]),
+        range=np.array([[0.0, 1.0], [2.0, 3.0]]),
+        weights=np.ones_like(x) + 1.0j,
+    )
+    assert np.all(H == Hn.real)
+    assert np.all(H == Hn.imag)
+
+
+@pytest.mark.skipif("not HAS_NUMBA")
+def test_histogram_accept_complex():
+    x = np.random.uniform(0.0, 1.0, 100)
+    (H, _) = np.histogram(x, bins=5, range=(0.0, 1.0))
+    Hn = utils.histogram(x, bins=5, range=np.array([0.0, 1.0]), weights=np.ones_like(x) + 1.0j)
+    assert np.all(H == Hn.real)
+    assert np.all(H == Hn.imag)
 
 
 def test_compute_bin():

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -1540,6 +1540,51 @@ def hist3d_numba_seq(tracks, bins, ranges, use_memmap=False, tmp=None):
 
 
 @njit(nogil=True, parallel=False)
+def _hist1d_numba_seq_weight(H, tracks, weights, bins, ranges):
+    delta = 1 / ((ranges[1] - ranges[0]) / bins)
+
+    for t in range(tracks.size):
+        i = (tracks[t] - ranges[0]) * delta
+        if 0 <= i < bins:
+            H[int(i)] += weights[t]
+
+    return H
+
+
+def hist1d_numba_seq_weight(a, weights, bins, ranges, use_memmap=False, tmp=None):
+    """
+    Examples
+    --------
+    >>> if os.path.exists('out.npy'): os.unlink('out.npy')
+    >>> x = np.random.uniform(0., 1., 100)
+    >>> weights = np.random.uniform(0, 1, 100)
+    >>> H, xedges = np.histogram(x, bins=5, range=[0., 1.], weights=weights)
+    >>> Hn = hist1d_numba_seq_weight(x, weights, bins=5, ranges=[0., 1.], tmp='out.npy',
+    ...                              use_memmap=True)
+    >>> assert np.all(H == Hn)
+    >>> # The number of bins is small, memory map was not used!
+    >>> assert not os.path.exists('out.npy')
+    >>> H, xedges = np.histogram(x, bins=10**8, range=[0., 1.], weights=weights)
+    >>> Hn = hist1d_numba_seq_weight(x, weights, bins=10**8, ranges=[0., 1.], tmp='out.npy',
+    ...                              use_memmap=True)
+    >>> assert np.all(H == Hn)
+    >>> assert os.path.exists('out.npy')
+    >>> # Now use memmap but do not specify a tmp file
+    >>> Hn = hist1d_numba_seq_weight(x, weights, bins=10**8, ranges=[0., 1.],
+    ...                              use_memmap=True)
+    >>> assert np.all(H == Hn)
+    """
+    if bins > 10**7 and use_memmap:
+        if tmp is None:
+            tmp = tempfile.NamedTemporaryFile("w+").name
+        hist_arr = np.lib.format.open_memmap(tmp, mode="w+", dtype=a.dtype, shape=(bins,))
+    else:
+        hist_arr = np.zeros((bins,), dtype=a.dtype)
+
+    return _hist1d_numba_seq_weight(hist_arr, a, weights, bins, np.asarray(ranges))
+
+
+@njit(nogil=True, parallel=False)
 def _hist2d_numba_seq_weight(H, tracks, weights, bins, ranges):
     delta = 1 / ((ranges[:, 1] - ranges[:, 0]) / bins)
 
@@ -1769,13 +1814,64 @@ def histnd_numba_seq(tracks, bins, ranges, use_memmap=False, tmp=None):
 if HAS_NUMBA:
 
     def histogram2d(*args, **kwargs):
+        """
+        Examples
+        --------
+        >>> x = np.random.uniform(0., 1., 100)
+        >>> y = np.random.uniform(2., 3., 100)
+        >>> weight = np.random.uniform(0, 1, 100)
+        >>> H, xedges, yedges = np.histogram2d(x, y, bins=(5, 5),
+        ...                                    range=[(0., 1.), (2., 3.)],
+        ...                                    weights=weight)
+        >>> Hn = histogram2d(x, y, bins=(5, 5),
+        ...                  ranges=[[0., 1.], [2., 3.]],
+        ...                  weights=weight)
+        >>> assert np.all(H == Hn)
+        >>> Hn1 = histogram2d(x, y, bins=(5, 5),
+        ...                   ranges=[[0., 1.], [2., 3.]],
+        ...                   weights=None)
+        >>> Hn2 = histogram2d(x, y, bins=(5, 5),
+        ...                   ranges=[[0., 1.], [2., 3.]])
+        >>> assert np.all(Hn1 == Hn2)
+        """
         if "range" in kwargs:
             kwargs["ranges"] = kwargs.pop("range")
+
+        if "weights" not in kwargs:
+            return hist2d_numba_seq(*args, **kwargs)
+
+        weights = kwargs.pop("weights")
+
+        if weights is not None:
+            return hist2d_numba_seq_weight(*args, weights, **kwargs)
+
         return hist2d_numba_seq(*args, **kwargs)
 
     def histogram(*args, **kwargs):
+        """
+        Examples
+        --------
+        >>> x = np.random.uniform(0., 1., 100)
+        >>> weights = np.random.uniform(0, 1, 100)
+        >>> H, xedges = np.histogram(x, bins=5, range=[0., 1.], weights=weights)
+        >>> Hn = histogram(x, weights=weights, bins=5, ranges=[0., 1.], tmp='out.npy',
+        ...                use_memmap=True)
+        >>> assert np.all(H == Hn)
+        >>> Hn1 = histogram(x, weights=None, bins=5, ranges=[0., 1.])
+        >>> Hn2 = histogram(x, bins=5, ranges=[0., 1.])
+        >>> assert np.all(Hn1 == Hn2)
+        """
         if "range" in kwargs:
             kwargs["ranges"] = kwargs.pop("range")
+
+        if "weights" not in kwargs:
+            return hist1d_numba_seq(*args, **kwargs)
+
+        weights = kwargs.pop("weights")
+
+        if weights is not None:
+            return hist1d_numba_seq_weight(*args, weights, **kwargs)
+
         return hist1d_numba_seq(*args, **kwargs)
 
 else:

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -1553,7 +1553,35 @@ def _hist1d_numba_seq_weight(H, tracks, weights, bins, ranges):
 
 
 def hist1d_numba_seq_weight(a, weights, bins, range, use_memmap=False, tmp=None):
-    """
+    """Numba-compiled 1-d histogram with weights.
+
+    Parameters
+    ----------
+    a : array-like
+        Input array, to be histogrammed
+    weights : array-like
+        Input weight of each of the input values ``a``
+    bins : integer
+        number of bins in the final histogram
+    range : [min, max]
+        Minimum and maximum value of the histogram
+
+    Other parameters
+    ----------------
+    use_memmap : bool
+        If ``True`` and the number of bins is above 10 million,
+        the histogram is created into a memory-mapped Numpy array
+    tmp : str
+        Temporary file name for the memory map (only relevant if
+        ``use_memmap`` is ``True``)
+
+    Returns
+    -------
+    histogram: array-like
+        Histogrammed values of a, in ``bins`` bins.
+
+    Adapted from https://iscinumpy.dev/post/histogram-speeds-in-python/
+
     Examples
     --------
     >>> if os.path.exists('out.npy'): os.unlink('out.npy')
@@ -1599,14 +1627,18 @@ def _hist2d_numba_seq_weight(H, tracks, weights, bins, ranges):
 
 
 def hist2d_numba_seq_weight(x, y, weights, bins, range, use_memmap=False, tmp=None):
-    """Numba-compiled 3d histogram
+    """Numba-compiled 2d histogram with weights
 
     From https://iscinumpy.dev/post/histogram-speeds-in-python/
 
     Parameters
     ----------
-    tracks : (array-like, array-like, array-like)
-        List of input arrays of identical length, to be histogrammed
+    x : array-like
+        List of input values in the x-direction
+    y : array-like
+        List of input values in the y-direction, of the same length of ``x``
+    weights : array-like
+        Input weight of each of the input values.
     bins : (int, int, int)
         shape of the final histogram
     range : [min, max]


### PR DESCRIPTION
Allow our fast histograms to accept weights. Also, uniformize the interface so that we have the same options across all 1d, 2d, 3d, and nd histograms. Use a single function to fail safe to the numpy implementation of each kind of histogram when Numba throws a typing error.
Breaking change: the option for data range is now `range` like in Numpy. It made no sense to have a different name for the different implementations.