### PR TITLE
Update submodules before building docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,11 +3,18 @@
 # Required
 version: 2
 
+submodules:
+  include: all
+
+
 # Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    pre_install:
+      - git update-index --assume-unchanged docs/conf.py
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -17,10 +24,10 @@ sphinx:
   # Fail on all warnings to avoid broken references
   # fail_on_warning: true
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats:
-   - pdf
-   - epub
+# # Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
 
 # Optional but recommended, declare the Python requirements required
 # to build your documentation


### PR DESCRIPTION
We had an issue with the docs build, which did not include the notebooks. This fixes it.