### PR TITLE
Eliminate calls to old deprecated (and now, eliminated) astropy functions

### DIFF
--- a/stingray/_astropy_init.py
+++ b/stingray/_astropy_init.py
@@ -18,12 +18,6 @@ except ImportError:
 
 if not _ASTROPY_SETUP_:  # noqa
     import os
-    from warnings import warn
-    from astropy.config.configuration import (
-        update_default_config,
-        ConfigurationDefaultMissingError,
-        ConfigurationDefaultMissingWarning,
-    )
 
     # Create the test function for self test
     from astropy.tests.runner import TestRunner
@@ -31,25 +25,3 @@ if not _ASTROPY_SETUP_:  # noqa
     test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
     test.__test__ = False
     __all__ += ["test"]
-
-    # add these here so we only need to cleanup the namespace at the end
-    config_dir = None
-
-    if not os.environ.get("ASTROPY_SKIP_CONFIG_UPDATE", False):
-        config_dir = os.path.dirname(__file__)
-        config_template = os.path.join(config_dir, __package__ + ".cfg")
-        if os.path.isfile(config_template):
-            try:
-                update_default_config(__package__, config_dir, version=__version__)
-            except TypeError as orig_error:
-                try:
-                    update_default_config(__package__, config_dir)
-                except ConfigurationDefaultMissingError as e:
-                    wmsg = (
-                        e.args[0] + " Cannot install default profile. If you are "
-                        "importing from source, this is expected."
-                    )
-                    warn(ConfigurationDefaultMissingWarning(wmsg))
-                    del e
-                except Exception:
-                    raise orig_error

--- a/stingray/modeling/parameterestimation.py
+++ b/stingray/modeling/parameterestimation.py
@@ -38,23 +38,13 @@ try:
 except ImportError:
     comp_hessian = False
 
-try:
-    from astropy.modeling.fitting import fitter_to_model_params
-except ImportError:
-    from astropy.modeling.fitting import _fitter_to_model_params as fitter_to_model_params
-
-from astropy.modeling.fitting import (
-    _model_to_fit_params,
-    _validate_model,
-    _convert_input,
-)
-
 from stingray.modeling.posterior import (
     Posterior,
     PSDPosterior,
     LogLikelihood,
     PSDLogLikelihood,
     logmin,
+    fitter_to_model_params,
 )
 
 

--- a/stingray/modeling/tests/test_parameterestimation.py
+++ b/stingray/modeling/tests/test_parameterestimation.py
@@ -7,14 +7,10 @@ import logging
 import pytest
 from astropy.modeling import models
 
-try:
-    from astropy.modeling.fitting import fitter_to_model_params
-except ImportError:
-    from astropy.modeling.fitting import _fitter_to_model_params as fitter_to_model_params
-
 from stingray import Powerspectrum, AveragedPowerspectrum
 from stingray.modeling import ParameterEstimation, PSDParEst, OptimizationResults, SamplingResults
 from stingray.modeling import PSDPosterior, set_logprior, PSDLogLikelihood, LogLikelihood
+from stingray.modeling.posterior import fitter_to_model_params
 
 try:
     from statsmodels.tools.numdiff import approx_hess


### PR DESCRIPTION
Sorry I did not catch this before.

This needed to be done since 2021. To solve the problem, I'm following the example of all other Astropy affiliated packages

https://github.com/astropy/regions/pull/338/files