### PR TITLE
Fixed subcs duplication

### DIFF
--- a/docs/changes/776.bugfix.rst
+++ b/docs/changes/776.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed subcs duplication by adding a check in the for loop that copies the attributes from table's meta items.

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2266,9 +2266,10 @@ def _create_crossspectrum_from_result_table(table, force_averaged=False):
         cs.unnorm_cs_all = np.array(table.meta["unnorm_subcs"])
 
     for attr, val in table.meta.items():
-        setattr(cs, attr, val)
-        setattr(cs.pds1, attr, val)
-        setattr(cs.pds2, attr, val)
+        if not attr.endswith("subcs"):
+            setattr(cs, attr, val)
+            setattr(cs.pds1, attr, val)
+            setattr(cs.pds2, attr, val)
 
     cs.err_dist = "poisson"
     if cs.variance is not None:


### PR DESCRIPTION
Fixed subcs duplication by adding a check in the for loop that copies the attributes from table's meta items. Addressing issue #773