### PR TITLE
Fixes to dynamical power spectrum + Dynamical Cross spectrum

### DIFF
--- a/docs/changes/779.bugfix.rst
+++ b/docs/changes/779.bugfix.rst
@@ -1,0 +1,1 @@
+Various bug fixes in DynamicalPowerspectrum, on event loading and time rebinning

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ filterwarnings =
     ignore:.*is a deprecated alias for:DeprecationWarning
     ignore:.*HIERARCH card will be created.*:
     ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning
-    ignore:.*jax.* deprecated. Use jax.*instead:DeprecationWarning
+    ignore:.*jax.* deprecated:DeprecationWarning:haiku
 
 ;addopts = --disable-warnings
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ filterwarnings =
     ignore:.*is a deprecated alias for:DeprecationWarning
     ignore:.*HIERARCH card will be created.*:
     ignore:.*FigureCanvasAgg is non-interactive.*:UserWarning
-    ignore:.*jax.* deprecated:DeprecationWarning:haiku
+    ignore:.*jax.* deprecated:DeprecationWarning:
 
 ;addopts = --disable-warnings
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2052,8 +2052,8 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         """
         Rebin the Dynamic Power Spectrum to a new time resolution.
 
-        Note: this is *not* the time resolution of the input light
-        curve! It is the integration time of each line of the dynamical power
+        Note: this is *not* changing the time resolution of the input light
+        curve! ``dt`` is the integration time of each line of the dynamical power
         spectrum (typically, an integer multiple of ``segment_size``).
 
         While the new resolution does not need to be an integer of the previous time

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2053,7 +2053,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         Rebin the Dynamic Power Spectrum to a new time resolution.
 
         While the new resolution does not need to be an integer of the previous time
-        resolution, be aware that if this is the case, the last frequency bin will be cut
+        resolution, be aware that if this is the case, the last time bin will be cut
         off by the fraction left over by the integer division
 
         Parameters

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1956,7 +1956,8 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
     dt: float
         The time resolution of the dynamical spectrum. It is **not** the time resolution of the
-        input light curve.
+        input light curve. It is the integration time of each line of the dynamical power
+        spectrum (typically, an integer multiple of ``segment_size``).
     """
 
     def __init__(self, data1, data2, segment_size, norm="frac", gti=None, sample_time=None):
@@ -2060,7 +2061,9 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         dt_new: float
             The new time resolution of the dynamical power spectrum.
             Must be larger than the time resolution of the old dynamical power
-            spectrum!
+            spectrum! Note: this is *not* the time resolution of the input light
+            curve! It is the integration time of each line of the dynamical power
+            spectrum (typically, an integer multiple of ``segment_size``).
 
         method: {"sum" | "mean" | "average"}, optional, default "sum"
             This keyword argument sets whether the counts in the new bins

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2052,6 +2052,10 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         """
         Rebin the Dynamic Power Spectrum to a new time resolution.
 
+        Note: this is *not* the time resolution of the input light
+        curve! It is the integration time of each line of the dynamical power
+        spectrum (typically, an integer multiple of ``segment_size``).
+
         While the new resolution does not need to be an integer of the previous time
         resolution, be aware that if this is the case, the last time bin will be cut
         off by the fraction left over by the integer division
@@ -2061,9 +2065,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         dt_new: float
             The new time resolution of the dynamical power spectrum.
             Must be larger than the time resolution of the old dynamical power
-            spectrum! Note: this is *not* the time resolution of the input light
-            curve! It is the integration time of each line of the dynamical power
-            spectrum (typically, an integer multiple of ``segment_size``).
+            spectrum!
 
         method: {"sum" | "mean" | "average"}, optional, default "sum"
             This keyword argument sets whether the counts in the new bins

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1923,7 +1923,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         use this and only give GTIs to the input object before making
         the cross spectrum.
 
-    dt: float
+    sample_time: float
         Compulsory for input :class:`stingray.EventList` data. The time resolution of the
         lightcurve that is created internally from the input event lists. Drives the
         Nyquist frequency.
@@ -1947,28 +1947,33 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
     freq: numpy.ndarray
         The array of mid-bin frequencies that the Fourier transform samples.
 
+    time: numpy.ndarray
+        The array of mid-point times of each interval used for the dynamical
+        power spectrum.
+
     df: float
         The frequency resolution.
 
     dt: float
-        The time resolution.
+        The time resolution of the dynamical spectrum. It is **not** the time resolution of the
+        input light curve.
     """
 
-    def __init__(self, data1, data2, segment_size, norm="frac", gti=None, dt=None):
-        if isinstance(data1, EventList) and dt is None:
-            raise ValueError("To pass input event lists, please specify dt")
+    def __init__(self, data1, data2, segment_size, norm="frac", gti=None, sample_time=None):
+        if isinstance(data1, EventList) and sample_time is None:
+            raise ValueError("To pass input event lists, please specify sample_time")
         elif isinstance(data1, Lightcurve):
-            dt = data1.dt
+            sample_time = data1.dt
             if segment_size > data1.tseg:
                 raise ValueError(
                     "Length of the segment is too long to create "
                     "any segments of the light curve!"
                 )
-        if segment_size < 2 * dt:
+        if segment_size < 2 * sample_time:
             raise ValueError("Length of the segment is too short to form a light curve!")
 
         self.segment_size = segment_size
-        self.input_dt = dt
+        self.sample_time = sample_time
         self.gti = gti
         self.norm = norm
 
@@ -1992,7 +1997,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         avg = AveragedCrossspectrum(
             data1,
             data2,
-            dt=self.input_dt,
+            dt=self.sample_time,
             segment_size=self.segment_size,
             norm=self.norm,
             gti=self.gti,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1899,11 +1899,12 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
     ----------
     data1 : :class:`stingray.Lightcurve` or :class:`stingray.EventList` object
         The time series or event list from the subject band, or channel, for which
-        the dynamical cross spectrum is to be calculated.
+        the dynamical cross spectrum is to be calculated. If :class:`stingray.EventList`, ``dt``
+        must be specified as well.
 
     data2 : :class:`stingray.Lightcurve` or :class:`stingray.EventList` object
         The time series or event list from the reference band, or channel, of the dynamical
-        cross spectrum.
+        cross spectrum. If :class:`stingray.EventList`, ``dt`` must be specified as well.
 
     segment_size : float, default 1
          Length of the segment of light curve, default value is 1 (in whatever
@@ -1921,6 +1922,11 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         object GTIs! If you're getting errors regarding your GTIs, don't
         use this and only give GTIs to the input object before making
         the cross spectrum.
+
+    dt: float
+        Compulsory for input :class:`stingray.EventList` data. The time resolution of the
+        lightcurve that is  created internally from the input event lists. Drives the
+        Nyquist frequency.
 
     Attributes
     ----------

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -1925,7 +1925,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
     dt: float
         Compulsory for input :class:`stingray.EventList` data. The time resolution of the
-        lightcurve that is  created internally from the input event lists. Drives the
+        lightcurve that is created internally from the input event lists. Drives the
         Nyquist frequency.
 
     Attributes
@@ -2014,9 +2014,9 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         Rebinning is an in-place operation, i.e. will replace the existing
         ``dyn_ps`` attribute.
 
-        While the new resolution need not be an integer multiple of the
-        previous frequency resolution, be aware that if it is not, the last
-        bin will be cut off by the fraction left over by the integer division.
+        While the new resolution does not need to be an integer of the previous frequency
+        resolution, be aware that if this is the case, the last frequency bin will be cut
+        off by the fraction left over by the integer division
 
         Parameters
         ----------
@@ -2045,9 +2045,10 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
     def rebin_time(self, dt_new, method="sum"):
         """
         Rebin the Dynamic Power Spectrum to a new time resolution.
-        While the new resolution need not be an integer multiple of the
-        previous time resolution, be aware that if it is not, the last bin
-        will be cut off by the fraction left over by the integer division.
+
+        While the new resolution does not need to be an integer of the previous time
+        resolution, be aware that if this is the case, the last frequency bin will be cut
+        off by the fraction left over by the integer division
 
         Parameters
         ----------
@@ -2066,7 +2067,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             Time axis with new rebinned time resolution.
 
         dynspec_new: numpy.ndarray
-            New rebinned Dynamical Power Spectrum.
+            New rebinned Dynamical Cross Spectrum.
         """
         if dt_new < self.dt:
             raise ValueError("New time resolution must be larger than old time resolution!")

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -13,11 +13,11 @@ from stingray.gti import bin_intervals_from_gtis, check_gtis
 from stingray.stats import pds_probability, amplitude_upper_limit
 
 from .events import EventList
-from .gti import cross_two_gtis
+from .gti import cross_two_gtis, time_intervals_from_gtis
+
 from .lightcurve import Lightcurve
 from .fourier import avg_pds_from_iterable, unnormalize_periodograms
 from .fourier import avg_pds_from_events
-from .fourier import fftfreq, fft
 from .fourier import get_flux_iterable_from_segments
 from .fourier import rms_calculation, poisson_level
 
@@ -991,15 +991,10 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         self.freq = avg.freq
         current_gti = avg.gti
 
-        from .gti import time_intervals_from_gtis
+        tstart, _ = time_intervals_from_gtis(current_gti, self.segment_size)
 
-        tstart, tend = time_intervals_from_gtis(current_gti, self.segment_size)
-
-        self.time = tstart + 0.5 * (tend - tstart)
-        if len(self.freq) < 2:
-            self.df = 1 / self.segment_size
-        else:
-            self.df = self.freq[1] - self.freq[0]
+        self.time = tstart + 0.5 * self.segment_size
+        self.df = avg.df
         self.dt = self.segment_size
 
     def rebin_frequency(self, df_new, method="sum"):

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -952,13 +952,13 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
             raise ValueError("To pass an input event lists, please specify dt")
         elif isinstance(lc, Lightcurve):
             dt = lc.dt
-            if segment_size < 2 * lc.dt:
-                raise ValueError("Length of the segment is too short to form a " "light curve!")
-            elif segment_size > lc.tseg:
+            if segment_size > lc.tseg:
                 raise ValueError(
                     "Length of the segment is too long to create "
                     "any segments of the light curve!"
                 )
+        if segment_size < 2 * dt:
+            raise ValueError("Length of the segment is too short to form a light curve!")
 
         self.segment_size = segment_size
         self.input_dt = dt

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -943,6 +943,10 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
     freq: numpy.ndarray
         The array of mid-bin frequencies that the Fourier transform samples.
 
+    time: numpy.ndarray
+        The array of mid-point times of each interval used for the dynamical
+        power spectrum.
+
     df: float
         The frequency resolution.
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -919,7 +919,7 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         use this and only give GTIs to the input object before making
         the power spectrum.
 
-    dt: float
+    sample_time: float
         Compulsory for input :class:`stingray.EventList` data. The time resolution of the
         lightcurve that is created internally from the input event lists. Drives the
         Nyquist frequency.
@@ -950,21 +950,21 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         The time resolution.
     """
 
-    def __init__(self, lc, segment_size, norm="frac", gti=None, dt=None):
-        if isinstance(lc, EventList) and dt is None:
-            raise ValueError("To pass an input event lists, please specify dt")
+    def __init__(self, lc, segment_size, norm="frac", gti=None, sample_time=None):
+        if isinstance(lc, EventList) and sample_time is None:
+            raise ValueError("To pass an input event lists, please specify sample_time")
         elif isinstance(lc, Lightcurve):
-            dt = lc.dt
+            sample_time = lc.dt
             if segment_size > lc.tseg:
                 raise ValueError(
                     "Length of the segment is too long to create "
                     "any segments of the light curve!"
                 )
-        if segment_size < 2 * dt:
+        if segment_size < 2 * sample_time:
             raise ValueError("Length of the segment is too short to form a light curve!")
 
         self.segment_size = segment_size
-        self.input_dt = dt
+        self.sample_time = sample_time
         self.gti = gti
         self.norm = norm
 
@@ -984,7 +984,7 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         """
         avg = AveragedPowerspectrum(
             lc,
-            dt=self.input_dt,
+            dt=self.sample_time,
             segment_size=self.segment_size,
             norm=self.norm,
             gti=self.gti,

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -951,7 +951,9 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         The frequency resolution.
 
     dt: float
-        The time resolution.
+        The time resolution of the dynamical spectrum. It is **not** the time resolution of the
+        input light curve. It is the integration time of each line of the dynamical power
+        spectrum (typically, an integer multiple of ``segment_size``).
     """
 
     def __init__(self, lc, segment_size, norm="frac", gti=None, sample_time=None):

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1082,7 +1082,7 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         Parameters
         ----------
         dt_new: float
-            The new time resolution of  the dynamical power spectrum.
+            The new time resolution of the dynamical power spectrum.
             Must be larger than the time resolution of the old dynamical power
             spectrum!
 
@@ -1099,14 +1099,14 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
             New rebinned Dynamical Power Spectrum.
         """
         if dt_new < self.dt:
-            raise ValueError("New time resolution must be larger than " "old time resolution!")
+            raise ValueError("New time resolution must be larger than old time resolution!")
 
         new_dynspec_object = copy.deepcopy(self)
 
         dynspec_new = []
         for data in self.dyn_ps:
             time_new, bin_counts, bin_err, _ = utils.rebin_data(
-                self.time, data, dt_new, method=method
+                self.time, data, dt_new, method=method, dx=self.dt
             )
             dynspec_new.append(bin_counts)
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -988,7 +988,6 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
             save_all=True,
         )
         self.dyn_ps = np.array(avg.cs_all).T
-
         self.freq = avg.freq
         current_gti = avg.gti
 
@@ -997,7 +996,10 @@ class DynamicalPowerspectrum(AveragedPowerspectrum):
         tstart, tend = time_intervals_from_gtis(current_gti, self.segment_size)
 
         self.time = tstart + 0.5 * (tend - tstart)
-        self.df = self.freq[1] - self.freq[0]
+        if len(self.freq) < 2:
+            self.df = 1 / self.segment_size
+        else:
+            self.df = self.freq[1] - self.freq[0]
         self.dt = self.segment_size
 
     def rebin_frequency(self, df_new, method="sum"):

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -900,7 +900,7 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
     ----------
     lc : :class:`stingray.Lightcurve` or :class:`stingray.EventList` object
         The time series or event list of which the dynamical power spectrum is
-        to be calculated.
+        to be calculated. If :class:`stingray.EventList`, ``dt`` must be specified as well.
 
     segment_size : float, default 1
          Length of the segment of light curve, default value is 1 (in whatever
@@ -918,6 +918,11 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         object GTIs! If you're getting errors regarding your GTIs, don't
         use this and only give GTIs to the input object before making
         the power spectrum.
+
+    dt: float
+        Compulsory for input :class:`stingray.EventList` data. The time resolution of the
+        lightcurve that is created internally from the input event lists. Drives the
+        Nyquist frequency.
 
     Attributes
     ----------

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1357,6 +1357,20 @@ class TestDynamicalCrossspectrum(object):
         dps_ev = DynamicalCrossspectrum(ev, ev, segment_size=10, sample_time=self.lc.dt)
         assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
 
+    def test_works_with_events_and_its_complex(self):
+        lc = copy.deepcopy(self.lc)
+        lc.counts = np.floor(lc.counts)
+        ev1 = EventList()
+        ev1.simulate_times(lc)
+        ev2 = EventList()
+        ev2.simulate_times(lc)
+
+        dps_ev = DynamicalCrossspectrum(ev1, ev1, segment_size=10, sample_time=self.lc.dt)
+        assert np.iscomplexobj(dps_ev.dyn_ps)
+        assert np.any(dps_ev.dyn_ps.imag > np.dps_ev.dyn_ps.real)
+        assert np.any(dps_ev.dyn_ps.imag < 0)
+        assert np.any(dps_ev.dyn_ps.imag > 0)
+
     def test_with_long_seg_size(self):
         with pytest.raises(ValueError):
             dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=1000)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1359,15 +1359,15 @@ class TestDynamicalCrossspectrum(object):
 
     def test_works_with_events_and_its_complex(self):
         lc = copy.deepcopy(self.lc)
-        lc.counts = np.floor(lc.counts)
+        lc.counts = np.random.poisson(10, size=lc.counts.size)
         ev1 = EventList()
         ev1.simulate_times(lc)
         ev2 = EventList()
         ev2.simulate_times(lc)
 
-        dps_ev = DynamicalCrossspectrum(ev1, ev1, segment_size=10, sample_time=self.lc.dt)
+        dps_ev = DynamicalCrossspectrum(ev1, ev2, segment_size=10, sample_time=self.lc.dt)
         assert np.iscomplexobj(dps_ev.dyn_ps)
-        assert np.any(dps_ev.dyn_ps.imag > np.dps_ev.dyn_ps.real)
+        assert np.any(dps_ev.dyn_ps.imag > dps_ev.dyn_ps.real)
         assert np.any(dps_ev.dyn_ps.imag < 0)
         assert np.any(dps_ev.dyn_ps.imag > 0)
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import scipy.special
 from astropy.io import fits
 from stingray import Lightcurve
-from stingray import Crossspectrum, AveragedCrossspectrum
+from stingray import Crossspectrum, AveragedCrossspectrum, DynamicalCrossspectrum
 from stingray.crossspectrum import cospectra_pvalue
 from stingray.crossspectrum import normalize_crossspectrum, normalize_crossspectrum_gauss
 from stingray.crossspectrum import coherence, time_lag
@@ -1316,3 +1316,167 @@ class TestRoundTrip:
         os.unlink(fname)
 
         self._check_equal(so, new_so)
+
+
+class TestDynamicalCrossspectrum(object):
+    def setup_class(cls):
+        # generate timestamps
+        timestamps = np.arange(0.005, 100.01, 0.01)
+        dt = 0.01
+        freq = 25 + 1.2 * np.sin(2 * np.pi * timestamps / 130)
+        # variability signal with drifiting frequency
+        vari = 25 * np.sin(2 * np.pi * freq * timestamps)
+        signal = vari + 50
+        # create a lightcurve
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+
+            lc = Lightcurve(timestamps, signal, err_dist="poisson", dt=dt, gti=[[0, 100]])
+
+        cls.lc = lc
+
+        # Simple lc to demonstrate rebinning of dyn ps
+        # Simple lc to demonstrate rebinning of dyn ps
+        test_times = np.arange(16)
+        test_counts = [2, 3, 1, 3, 1, 5, 2, 1, 4, 2, 2, 2, 3, 4, 1, 7]
+        cls.lc_test = Lightcurve(test_times, test_counts)
+
+    def test_with_short_seg_size(self):
+        with pytest.raises(ValueError):
+            dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=0)
+
+    def test_works_with_events(self):
+        lc = copy.deepcopy(self.lc)
+        lc.counts = np.floor(lc.counts)
+        ev = EventList.from_lc(lc)
+        dps = DynamicalCrossspectrum(lc, lc, segment_size=10)
+        with pytest.raises(ValueError):
+            # Without dt, it fails
+            _ = DynamicalCrossspectrum(ev, ev, segment_size=10)
+
+        dps_ev = DynamicalCrossspectrum(ev, ev, segment_size=10, dt=self.lc.dt)
+        assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
+
+    def test_with_long_seg_size(self):
+        with pytest.raises(ValueError):
+            dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=1000)
+
+    def test_matrix(self):
+        dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=3)
+        nsegs = int(self.lc.tseg / dps.segment_size)
+        nfreq = int((1 / self.lc.dt) / (2 * (dps.freq[1] - dps.freq[0])) - (1 / self.lc.tseg))
+        assert dps.dyn_ps.shape == (nfreq, nsegs)
+
+    def test_trace_maximum_without_boundaries(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=3)
+        max_pos = dps.trace_maximum()
+
+        assert np.max(dps.freq[max_pos]) <= 1 / self.lc.dt
+        assert np.min(dps.freq[max_pos]) >= 1 / dps.segment_size
+
+    def test_trace_maximum_with_boundaries(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=3)
+        minfreq = 21
+        maxfreq = 24
+        max_pos = dps.trace_maximum(min_freq=minfreq, max_freq=maxfreq)
+
+        assert np.max(dps.freq[max_pos]) <= maxfreq
+        assert np.min(dps.freq[max_pos]) >= minfreq
+
+    def test_size_of_trace_maximum(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=3)
+        max_pos = dps.trace_maximum()
+        nsegs = int(self.lc.tseg / dps.segment_size)
+        assert len(max_pos) == nsegs
+
+    def test_rebin_small_dt(self):
+        segment_size = 3
+        dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
+        with pytest.raises(ValueError):
+            dps.rebin_time(dt_new=2.0)
+
+    def test_rebin_small_df(self):
+        segment_size = 3
+        dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=segment_size)
+        with pytest.raises(ValueError):
+            dps.rebin_frequency(df_new=dps.df / 2.0)
+
+    def test_rebin_time_default_method(self):
+        segment_size = 3
+        dt_new = 6.0
+        rebin_time = np.array([2.5, 8.5])
+        rebin_dps = np.array([[1.73611111, 0.81018519]])
+        dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
+        new_dps = dps.rebin_time(dt_new=dt_new)
+        assert np.allclose(new_dps.time, rebin_time)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.dt, dt_new)
+
+    def test_rebin_frequency_default_method(self):
+        segment_size = 50
+        df_new = 10.0
+        rebin_freq = np.array([5.01, 15.01, 25.01, 35.01])
+        rebin_dps = np.array(
+            [
+                [
+                    [1.71989342e-04, 6.42756881e-05],
+                    [7.54455204e-04, 2.14785049e-04],
+                    [6.24831554e00, 6.24984615e00],
+                    [6.71135792e-04, 7.42516599e-05],
+                ]
+            ]
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=segment_size)
+        new_dps = dps.rebin_frequency(df_new=df_new)
+        assert np.allclose(new_dps.freq, rebin_freq)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.01)
+        assert np.isclose(new_dps.df, df_new)
+
+    @pytest.mark.parametrize("method", ["mean", "average"])
+    def test_rebin_time_mean_method(self, method):
+        segment_size = 3
+        dt_new = 6.0
+        rebin_time = np.array([2.5, 8.5])
+        rebin_dps = np.array([[1.73611111, 0.81018519]]) / 2
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
+        new_dps = dps.rebin_time(dt_new=dt_new, method=method)
+        assert np.allclose(new_dps.time, rebin_time)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.dt, dt_new)
+
+    @pytest.mark.parametrize("method", ["mean", "average"])
+    def test_rebin_frequency_mean_method(self, method):
+        segment_size = 50
+        df_new = 10.0
+        rebin_freq = np.array([5.01, 15.01, 25.01, 35.01])
+        rebin_dps = (
+            np.array(
+                [
+                    [
+                        [1.71989342e-04, 6.42756881e-05],
+                        [7.54455204e-04, 2.14785049e-04],
+                        [6.24831554e00, 6.24984615e00],
+                        [6.71135792e-04, 7.42516599e-05],
+                    ]
+                ]
+            )
+            / 500
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=segment_size)
+        new_dps = dps.rebin_frequency(df_new=df_new, method=method)
+        assert np.allclose(new_dps.freq, rebin_freq)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.00001)
+        assert np.isclose(new_dps.df, df_new)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1354,7 +1354,7 @@ class TestDynamicalCrossspectrum(object):
             # Without dt, it fails
             _ = DynamicalCrossspectrum(ev, ev, segment_size=10)
 
-        dps_ev = DynamicalCrossspectrum(ev, ev, segment_size=10, dt=self.lc.dt)
+        dps_ev = DynamicalCrossspectrum(ev, ev, segment_size=10, sample_time=self.lc.dt)
         assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
 
     def test_with_long_seg_size(self):

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -997,7 +997,7 @@ class TestDynamicalPowerspectrum(object):
             # Without dt, it fails
             _ = DynamicalPowerspectrum(ev, segment_size=10)
 
-        dps_ev = DynamicalPowerspectrum(ev, segment_size=10, dt=self.lc.dt)
+        dps_ev = DynamicalPowerspectrum(ev, segment_size=10, sample_time=self.lc.dt)
         assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
 
     def test_with_long_seg_size(self):


### PR DESCRIPTION
+ Improves performance and consistency when using events (uses the internals already tested in `AveragePowerspectrum` to create light curves dynamically for each segment, rather than allocating the full light curve on the spot)
+ Resolves a bug when rebinning in time (it relied on dt, which was calculated in a weird manner)
+ Makes tests a little more understandable, I hope

BONUS: added Dynamical Cross spectrum, because why not