### PR TITLE
Introduce power colors

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,8 @@ Stingray API
 
 Library of Time Series Methods For Astronomical X-ray Data.
 
+Base Class
+==========
 Most `stingray`` classes are subclasses of a single class, :class:`stingray.StingrayObject`, which
 implements most of the I/O functionality and common behavior (e.g. strategies to combine data and
 make operations such as the sum, difference, or negation). This class is not intended to be

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,7 +25,7 @@ of elements of the main array, which is ``time``.
 StingrayObject
 --------------
 
-.. autoclass:: stingray.StingrayTimeseries
+.. autoclass:: stingray.StingrayObject
    :members:
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,12 +5,55 @@ Stingray API
 
 Library of Time Series Methods For Astronomical X-ray Data.
 
+Most `stingray`` classes are subclasses of a single class, :class:`stingray.StingrayObject`, which
+implements most of the I/O functionality and common behavior (e.g. strategies to combine data and
+make operations such as the sum, difference, or negation). This class is not intended to be
+instantiated directly, but rather to be used as a base class for other classes. Any class wanting
+to inherit from :class:`stingray.StingrayObject` should define a ``main_array_attr`` attribute, which
+defines the name of the attribute that will be used to store the "independent variable" main data array.
+For example, for all time series-like objects, the main array is the time array, while for the
+periodograms the main array is the frequency array.
+All arrays sharing the length (not the shape: they might be multi-dimensional!) of the main array are called
+"array attributes" and are accessible through the ``array_attrs`` method.
+When applying a mask or any other selection to a :class:`stingray.StingrayObject`,
+all array attributes are filtered in the same way. Some array-like attributes might have the same length
+by chance, in this case the user or the developer should add these to the ``not_array_attr`` attribute.
+For example, :class:`stingray.StingrayTimeseries` has ``gti`` among the not_array_attrs, since it is an
+array but not related 1-to-1 to the main array, even if in some cases it might happen to have the same numbers
+of elements of the main array, which is ``time``.
+
+StingrayObject
+--------------
+
+.. autoclass:: stingray.StingrayTimeseries
+   :members:
+
+----
+
 Data Classes
 ============
 
 These classes define basic functionality related to common data types and typical methods
 that apply to these data types, including basic read/write functionality. Currently
-implemented are :class:`stingray.Lightcurve` and :class:`stingray.events.EventList`.
+implemented are :class:`stingray.StingrayTimeseries`, :class:`stingray.Lightcurve` and
+:class:`stingray.events.EventList`.
+
+All time series-like data classes inherit from :class:`stingray.StingrayTimeseries`, which
+implements most of the common functionality. The main data array is stored in the ``time``
+attribute.
+Good Time Intervals (GTIs) are stored in the ``gti`` attribute, which is a list of 2-tuples or 2-lists
+containing the start and stop times of each GTI. The ``gti`` attribute is not an array attribute, since
+it is not related 1-to-1 to the main array, even if in some cases it might happen to have the same number
+of elements of the main array. It is by default added to the ``not_array_attr`` attribute.
+
+
+StingrayTimeseries
+------------------
+
+.. autoclass:: stingray.StingrayTimeseries
+   :members:
+
+----
 
 Lightcurve
 ----------
@@ -88,7 +131,7 @@ Dynamical Powerspectrum
 .. autoclass:: stingray.DynamicalPowerspectrum
    :members:
    :inherited-members:
-   
+
 ----
 
 CrossCorrelation

--- a/docs/changes/780.feature.rst
+++ b/docs/changes/780.feature.rst
@@ -1,0 +1,1 @@
+Introduce power colors à la Heil et al. 2015

--- a/docs/changes/782.feature.rst
+++ b/docs/changes/782.feature.rst
@@ -1,0 +1,1 @@
+Add function to randomize data in small bad time intervals

--- a/docs/changes/787.trivial.rst
+++ b/docs/changes/787.trivial.rst
@@ -1,0 +1,1 @@
+More informative GTI messages

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Current Capabilities
 * simulating a light curve from another light curve and a 1-d (time) or 2-d (time-energy) impulse response
 * simulating an event list from a given light curve _and_ with a given energy spectrum
 * Good Time Interval operations
+* Filling gaps in light curves with statistically sound fake data
 
 1. Fourier methods
 ~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,14 +24,15 @@ Current Capabilities
 1. Data handling and simulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* loading event lists from fits files of a few missions (RXTE/PCA, NuSTAR/FPM, XMM-Newton/EPIC, NICER/XTI)
-* constructing light curves from event data, various operations on light curves (e.g. addition, subtraction, joining, and truncation)
+* loading event lists from fits files (and generally good handling of OGIP-compliant missions, like RXTE/PCA, NuSTAR/FPM, XMM-Newton/EPIC, NICER/XTI)
+* constructing light curves and time series from event data
+* various operations on time series (e.g. addition, subtraction, joining, and truncation)
 * simulating a light curve with a given power spectrum
 * simulating a light curve from another light curve and a 1-d (time) or 2-d (time-energy) impulse response
 * simulating an event list from a given light curve _and_ with a given energy spectrum
 * Good Time Interval operations
 
-2. Fourier methods
+1. Fourier methods
 ~~~~~~~~~~~~~~~~~~
 * power spectra and cross spectra in Leahy, rms normalization, absolute rms and no normalization
 * averaged power spectra and cross spectra
@@ -44,6 +45,7 @@ Current Capabilities
 * bispectra; *needs testing*
 * (Bayesian) quasi-periodic oscillation searches
 * Lomb-Scargle periodograms and cross spectra
+* Power Colors
 
 3. Other time series methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,7 +63,6 @@ Other future additions we are currently implementing are:
 * bicoherence
 * phase-resolved spectroscopy of quasi-periodic oscillations
 * Fourier-frequency-resolved spectroscopy
-* power colours
 * full HEASARC-compatible mission support
 * pulsar searches with :math:`H`-test
 * binary pulsar searches

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ docs =
     docutils
     sphinx-astropy
     nbsphinx>=0.8.3,!=0.8.8
+    nbconvert<7.14
     pandoc
     ipython
     towncrier<22.12.0

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2190,6 +2190,7 @@ class StingrayTimeseries(StingrayObject):
 
         btis = get_btis(self.gti, self.time[0], self.time[-1])
         if len(btis) == 0:
+            logging.info("No bad time intervals to fill")
             return copy.deepcopy(self)
         filtered_times = self.time[self.mask]
         from .utils import find_nearest
@@ -2210,6 +2211,7 @@ class StingrayTimeseries(StingrayObject):
             length = bti[1] - bti[0]
             if length > max_length:
                 continue
+            logging.info(f"Filling bad time interval {bti}")
             epsilon = 1e-5 * length
             added_gtis.append([bti[0] - epsilon, bti[1] + epsilon])
             filt_low_t, filt_low_idx = find_nearest(filtered_times, bti[0])

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2156,6 +2156,7 @@ class StingrayTimeseries(StingrayObject):
             time intervals shorter than 1/100th of the longest bad time interval.
         attrs_to_randomize : list of str, default None
             List of array_attrs to randomize. ``If None``, all array_attrs are randomized.
+            It should not include ``time`` and ``_mask``, which are treated separately.
         buffer_size : int, default 100
             Number of good data points to use to calculate the means and variance the random data
             on each side of the bad time interval
@@ -2174,8 +2175,10 @@ class StingrayTimeseries(StingrayObject):
 
         if attrs_to_randomize is None:
             attrs_to_randomize = self.array_attrs() + self.internal_array_attrs()
-            if "_mask" in attrs_to_randomize:
-                attrs_to_randomize.remove("_mask")
+            for attr in ["time", "_mask"]:
+                if attr in attrs_to_randomize:
+                    attrs_to_randomize.remove(attr)
+
         attrs_to_leave_alone = [
             a
             for a in self.array_attrs() + self.internal_array_attrs()

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2148,7 +2148,7 @@ class StingrayTimeseries(StingrayObject):
         """Fill short bad time intervals with random data.
 
         .. warning::
-            This method is only appropriate for _very short_ bad time intervals. The simulated data
+            This method is only appropriate for *very short* bad time intervals. The simulated data
             are basically white noise, so they are able to alter the statistical properties of
             variable data. For very short gaps in the data, the effect of these small
             injections of white noise should be negligible. How short depends on the single case,

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2325,15 +2325,18 @@ class StingrayTimeseries(StingrayObject):
             plt.figure(attr)
             ax = plt.gca()
 
-        if labels is None:
+        valid_labels = (isinstance(labels, Iterable) and not isinstance(labels, str)) and len(
+            labels
+        ) == 2
+        if labels is not None and not valid_labels:
+            warnings.warn("``labels`` must be an iterable with two labels for x and y axes.")
+
+        if labels is None or not valid_labels:
             labels = ["Time (s)"] + [attr]
 
-        if isinstance(labels, Iterable) and not isinstance(labels, str):
-            if len(labels) != 2:
-                warnings.warn("``labels`` must have two labels for x and y axes.")
-            else:
-                ylabel = labels[1]
-                xlabel = labels[0]
+        xlabel = labels[0]
+        ylabel = labels[1]
+        # Default values for labels
 
         ax.plot(self.time, getattr(self, attr), marker, ds="steps-mid", label=attr, zorder=10)
 
@@ -2370,7 +2373,7 @@ class StingrayTimeseries(StingrayObject):
                     bti[0],
                     bti[1],
                     alpha=0.5,
-                    color="r",
+                    facecolor="r",
                     zorder=1,
                     edgecolor="none",
                 )

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2148,14 +2148,15 @@ class StingrayTimeseries(StingrayObject):
         """Fill short bad time intervals with random data.
 
         .. warning::
-            This method is only appropriate for _short_ bad time intervals. The simulated data
+            This method is only appropriate for _very short_ bad time intervals. The simulated data
             are basically white noise, so they are able to alter the statistical properties of
             variable data. For very short gaps in the data, the effect of these small
             injections of white noise should be negligible. How short depends on the single case,
             the user is urged not to use the method as a black box and make simulations to measure
             its effect. If you have long bad time intervals, you should use more advanced
             techniques, not currently available in Stingray for this use case, such as Gaussian
-            Processes.
+            Processes. In particular, please verify that the values of ``max_length`` and
+            ``buffer_size`` are adequate to your case.
 
         To fill the gaps in all but the time points (i.e., flux measures, energies), we take the
         ``buffer_size`` (default 100) valid data points closest to the gap and repeat them randomly

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2218,6 +2218,7 @@ class StingrayTimeseries(StingrayObject):
             else:
                 low_time_arr = filtered_times[max(filt_low_idx - buffer_size, 0) : filt_low_idx]
                 high_time_arr = filtered_times[filt_hig_idx : buffer_size + filt_hig_idx]
+
                 ctrate = (
                     np.count_nonzero(low_time_arr) / (filt_low_t - low_time_arr[0])
                     + np.count_nonzero(high_time_arr) / (high_time_arr[-1] - filt_hig_t)
@@ -2227,7 +2228,7 @@ class StingrayTimeseries(StingrayObject):
                 new_times.append(local_new_times)
 
             for attr in fluxes_to_randomize:
-                low_arr = getattr(self, attr)[buffer_size - filt_low_idx : filt_low_idx]
+                low_arr = getattr(self, attr)[max(buffer_size - filt_low_idx, 0) : filt_low_idx]
                 high_arr = getattr(self, attr)[filt_hig_idx : buffer_size + filt_hig_idx]
                 if not attr in new_attrs:
                     new_attrs[attr] = [getattr(self, attr)[self.mask]]

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2159,7 +2159,7 @@ class StingrayTimeseries(StingrayObject):
 
         To fill the gaps in all but the time points (i.e., flux measures, energies), we take the
         ``buffer_size`` (default 100) valid data points closest to the gap and repeat them randomly
-        with the same empirical statistical distribution. That is, if the "blabla" attributes, in
+        with the same empirical statistical distribution. So, if the `my_fancy_attr` attribute, in
         the 100 points of the buffer, has 30 times 10, 10 times 9, and 60 times 11, there will be
         *on average* 30% of 10, 60% of 11, and 10% of 9 in the simulated data.
 
@@ -2239,7 +2239,6 @@ class StingrayTimeseries(StingrayObject):
             if even_sampling:
                 local_new_times = np.arange(bti[0] + self.dt / 2, bti[1], self.dt)
                 nevents = local_new_times.size
-                new_times.append(local_new_times)
             else:
                 low_time_arr = filtered_times[max(filt_low_idx - buffer_size, 0) : filt_low_idx]
                 high_time_arr = filtered_times[filt_hig_idx : buffer_size + filt_hig_idx]
@@ -2250,7 +2249,7 @@ class StingrayTimeseries(StingrayObject):
                 ) / 2
                 nevents = rs.poisson(ctrate * (bti[1] - bti[0]))
                 local_new_times = rs.uniform(bti[0], bti[1], nevents)
-                new_times.append(local_new_times)
+            new_times.append(local_new_times)
 
             for attr in attrs_to_randomize:
                 low_arr = getattr(self, attr)[max(buffer_size - filt_low_idx, 0) : filt_low_idx]
@@ -2277,7 +2276,7 @@ class StingrayTimeseries(StingrayObject):
 
         for attr in self.meta_attrs():
             setattr(new_obj, attr, getattr(self, attr))
-        # Todo: fix GTIs
+
         for attr, values in new_attrs.items():
             setattr(new_obj, attr, np.concatenate(values)[order])
         new_obj.gti = new_gtis

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2144,10 +2144,19 @@ class StingrayTimeseries(StingrayObject):
     ):
         """Fill short bad time intervals with random data.
 
-        Random data are extracted by randomly repeating the values of nearby good data (at least
-        ``buffer_size`` time bins). Non-uniform time series will have their times randomized from a
-        uniform distribution with the same count rate of nearby intervals (always decided from
-        ``buffer_size`` time bins).
+        To fill the gaps in all but the time points (i.e., flux measures, energies), we take the
+        ``buffer_size`` (default 100) valid data points closest to the gap and repeat them randomly
+        with the same empirical statistical distribution. That is, if the "blabla" attributes, in
+        the 100 points of the buffer, has 30 times 10, 10 times 9, and 60 times 11, there will be
+        *on average* 30% of 10, 60% of 11, and 10% of 9 in the simulated data.
+
+        Times are treated differently depending on the fact that the time series is uniformly
+        sampled or not. If it is not, the times are simulated from a uniform distribution with the
+        same count rate found in the buffer. Otherwise, times just follow the same grid used
+        inside GTIs. Using the uniformly sampled or not is decided based on the ``uniform``
+        parameter. If left to ``None``, the time series is considered uniformly sampled if
+        ``self.dt`` is greater than zero and the median separation between subsequent times is
+        within 1% of the time resolution.
 
         Other Parameters
         ----------------

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2147,6 +2147,16 @@ class StingrayTimeseries(StingrayObject):
     ):
         """Fill short bad time intervals with random data.
 
+        .. warning::
+            This method is only appropriate for _short_ bad time intervals. The simulated data
+            are basically white noise, so they are able to alter the statistical properties of
+            variable data. For very short gaps in the data, the effect of these small
+            injections of white noise should be negligible. How short depends on the single case,
+            the user is urged not to use the method as a black box and make simulations to measure
+            its effect. If you have long bad time intervals, you should use more advanced
+            techniques, not currently available in Stingray for this use case, such as Gaussian
+            Processes.
+
         To fill the gaps in all but the time points (i.e., flux measures, energies), we take the
         ``buffer_size`` (default 100) valid data points closest to the gap and repeat them randomly
         with the same empirical statistical distribution. That is, if the "blabla" attributes, in

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -1093,7 +1093,7 @@ class StingrayTimeseries(StingrayObject):
 
     dt: float
         The time resolution of the time series. Can be a scalar or an array attribute (useful
-        for non-uniformly sampled data or events from different instruments)
+        for non-evenly sampled data or events from different instruments)
 
     mjdref : float
         The MJD used as a reference for the time array.
@@ -1128,7 +1128,7 @@ class StingrayTimeseries(StingrayObject):
 
     dt: float
         The time resolution of the measurements. Can be a scalar or an array attribute (useful
-        for non-uniformly sampled data or events from different instruments)
+        for non-evenly sampled data or events from different instruments)
 
     mjdref : float
         The MJD used as a reference for the time array.
@@ -2142,7 +2142,7 @@ class StingrayTimeseries(StingrayObject):
         max_length=None,
         attrs_to_randomize=None,
         buffer_size=100,
-        uniform=None,
+        even_sampling=None,
         seed=None,
     ):
         """Fill short bad time intervals with random data.
@@ -2163,11 +2163,11 @@ class StingrayTimeseries(StingrayObject):
         the 100 points of the buffer, has 30 times 10, 10 times 9, and 60 times 11, there will be
         *on average* 30% of 10, 60% of 11, and 10% of 9 in the simulated data.
 
-        Times are treated differently depending on the fact that the time series is uniformly
+        Times are treated differently depending on the fact that the time series is evenly
         sampled or not. If it is not, the times are simulated from a uniform distribution with the
         same count rate found in the buffer. Otherwise, times just follow the same grid used
-        inside GTIs. Using the uniformly sampled or not is decided based on the ``uniform``
-        parameter. If left to ``None``, the time series is considered uniformly sampled if
+        inside GTIs. Using the evenly sampled or not is decided based on the ``even_sampling``
+        parameter. If left to ``None``, the time series is considered evenly sampled if
         ``self.dt`` is greater than zero and the median separation between subsequent times is
         within 1% of the time resolution.
 
@@ -2182,9 +2182,9 @@ class StingrayTimeseries(StingrayObject):
         buffer_size : int, default 100
             Number of good data points to use to calculate the means and variance the random data
             on each side of the bad time interval
-        uniform : bool, default None
-            Force the treatment of the data as uniformly sampled or not. If None, the data are
-            considered uniformly sampled if ``self.dt`` is larger than zero and the median
+        even_sampling : bool, default None
+            Force the treatment of the data as evenly sampled or not. If None, the data are
+            considered evenly sampled if ``self.dt`` is larger than zero and the median
             separation between subsequent times is within 1% of ``self.dt``.
         seed : int, default None
             Random seed to use for the simulation. If None, a random seed is generated.
@@ -2216,13 +2216,13 @@ class StingrayTimeseries(StingrayObject):
 
         new_times = [filtered_times.copy()]
         new_attrs = {}
-        if uniform is None:
-            # The time series is considered uniformly sampled if the median separation between
+        if even_sampling is None:
+            # The time series is considered evenly sampled if the median separation between
             # subsequent times is within 1% of the time resolution
-            uniform = False
+            even_sampling = False
             if self.dt > 0 and np.isclose(np.median(np.diff(self.time)), self.dt, rtol=0.01):
-                uniform = True
-            logging.info(f"Data are {'not' if not uniform else ''} uniformly sampled")
+                even_sampling = True
+            logging.info(f"Data are {'not' if not even_sampling else ''} evenly sampled")
 
         added_gtis = []
 
@@ -2236,7 +2236,7 @@ class StingrayTimeseries(StingrayObject):
             added_gtis.append([bti[0] - epsilon, bti[1] + epsilon])
             filt_low_t, filt_low_idx = find_nearest(filtered_times, bti[0])
             filt_hig_t, filt_hig_idx = find_nearest(filtered_times, bti[1], side="right")
-            if uniform:
+            if even_sampling:
                 local_new_times = np.arange(bti[0] + self.dt / 2, bti[1], self.dt)
                 nevents = local_new_times.size
                 new_times.append(local_new_times)

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2230,11 +2230,11 @@ class StingrayTimeseries(StingrayObject):
             for attr in attrs_to_randomize:
                 low_arr = getattr(self, attr)[max(buffer_size - filt_low_idx, 0) : filt_low_idx]
                 high_arr = getattr(self, attr)[filt_hig_idx : buffer_size + filt_hig_idx]
-                if not attr in new_attrs:
+                if attr not in new_attrs:
                     new_attrs[attr] = [getattr(self, attr)[self.mask]]
                 new_attrs[attr].append(rs.choice(np.concatenate([low_arr, high_arr]), nevents))
             for attr in attrs_to_leave_alone:
-                if not attr in new_attrs:
+                if attr not in new_attrs:
                     new_attrs[attr] = [getattr(self, attr)[self.mask]]
                 if attr == "_mask":
                     new_attrs[attr].append(np.ones(nevents, dtype=bool))

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2328,8 +2328,12 @@ class StingrayTimeseries(StingrayObject):
         if labels is None:
             labels = ["Time (s)"] + [attr]
 
-        ylabel = labels[1]
-        xlabel = labels[0]
+        if isinstance(labels, Iterable) and not isinstance(labels, str):
+            if len(labels) != 2:
+                warnings.warn("``labels`` must have two labels for x and y axes.")
+            else:
+                ylabel = labels[1]
+                xlabel = labels[0]
 
         ax.plot(self.time, getattr(self, attr), marker, ds="steps-mid", label=attr, zorder=10)
 

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2176,7 +2176,7 @@ class StingrayTimeseries(StingrayObject):
         ----------------
         max_length : float
             Maximum length of a bad time interval to be filled. If None, the criterion is bad
-            time intervals shorter than 1/100th of the longest bad time interval.
+            time intervals shorter than 1/100th of the longest good time interval.
         attrs_to_randomize : list of str, default None
             List of array_attrs to randomize. ``If None``, all array_attrs are randomized.
             It should not include ``time`` and ``_mask``, which are treated separately.

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2137,7 +2137,7 @@ class StingrayTimeseries(StingrayObject):
     def fill_bad_time_intervals(
         self,
         max_length=None,
-        fluxes_to_randomize=None,
+        attrs_to_randomize=None,
         buffer_size=100,
         uniform=None,
         seed=None,
@@ -2154,7 +2154,7 @@ class StingrayTimeseries(StingrayObject):
         max_length : float
             Maximum length of a bad time interval to be filled. If None, the criterion is bad
             time intervals shorter than 1/100th of the longest bad time interval.
-        fluxes_to_randomize : list of str, default None
+        attrs_to_randomize : list of str, default None
             List of array_attrs to randomize. ``If None``, all array_attrs are randomized.
         buffer_size : int, default 100
             Number of good data points to use to calculate the means and variance the random data
@@ -2172,14 +2172,14 @@ class StingrayTimeseries(StingrayObject):
 
         rs = get_random_state(seed)
 
-        if fluxes_to_randomize is None:
-            fluxes_to_randomize = self.array_attrs() + self.internal_array_attrs()
-            if "_mask" in fluxes_to_randomize:
-                fluxes_to_randomize.remove("_mask")
-        fluxes_to_leave_alone = [
+        if attrs_to_randomize is None:
+            attrs_to_randomize = self.array_attrs() + self.internal_array_attrs()
+            if "_mask" in attrs_to_randomize:
+                attrs_to_randomize.remove("_mask")
+        attrs_to_leave_alone = [
             a
             for a in self.array_attrs() + self.internal_array_attrs()
-            if a not in fluxes_to_randomize
+            if a not in attrs_to_randomize
         ]
 
         if max_length is None:
@@ -2227,13 +2227,13 @@ class StingrayTimeseries(StingrayObject):
                 local_new_times = rs.uniform(bti[0], bti[1], nevents)
                 new_times.append(local_new_times)
 
-            for attr in fluxes_to_randomize:
+            for attr in attrs_to_randomize:
                 low_arr = getattr(self, attr)[max(buffer_size - filt_low_idx, 0) : filt_low_idx]
                 high_arr = getattr(self, attr)[filt_hig_idx : buffer_size + filt_hig_idx]
                 if not attr in new_attrs:
                     new_attrs[attr] = [getattr(self, attr)[self.mask]]
                 new_attrs[attr].append(rs.choice(np.concatenate([low_arr, high_arr]), nevents))
-            for attr in fluxes_to_leave_alone:
+            for attr in attrs_to_leave_alone:
                 if not attr in new_attrs:
                     new_attrs[attr] = [getattr(self, attr)[self.mask]]
                 if attr == "_mask":

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2110,7 +2110,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             power spectrum!
 
         method: {"sum" | "mean" | "average"}, optional, default "sum"
-            This keyword argument sets whether the counts in the new bins
+            This keyword argument sets whether the powers in the new bins
             should be summed or averaged.
         """
         new_dynspec_object = copy.deepcopy(self)
@@ -2148,7 +2148,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             spectrum!
 
         method: {"sum" | "mean" | "average"}, optional, default "sum"
-            This keyword argument sets whether the counts in the new bins
+            This keyword argument sets whether the powers in the new bins
             should be summed or averaged.
 
         Returns
@@ -2191,7 +2191,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             The number of intervals to be combined into one.
 
         method: {"sum" | "mean" | "average"}, optional, default "sum"
-            This keyword argument sets whether the counts in the new bins
+            This keyword argument sets whether the powers in the new bins
             should be summed or averaged.
 
         Returns

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2195,7 +2195,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             New rebinned Dynamical Cross Spectrum.
         """
         if not np.issubdtype(type(n), np.integer):
-            warnings.warn("n must be an integer. Converting")
+            warnings.warn("n must be an integer. Casting to int")
 
             n = int(n)
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2280,6 +2280,8 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         """
         Return the power colors of the dynamical power spectrum.
 
+        See Heil et al. 2015, MNRAS, 448, 3348
+
         Parameters
         ----------
         frequency_edges: iterable

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2092,7 +2092,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         self.dt = self.segment_size
         self.m = 1
 
-    def rebin_frequency(self, df_new, method="sum"):
+    def rebin_frequency(self, df_new, method="average"):
         """
         Rebin the Dynamic Power Spectrum to a new frequency resolution.
         Rebinning is an in-place operation, i.e. will replace the existing
@@ -2109,7 +2109,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             Must be larger than the frequency resolution of the old dynamical
             power spectrum!
 
-        method: {"sum" | "mean" | "average"}, optional, default "sum"
+        method: {"sum" | "mean" | "average"}, optional, default "average"
             This keyword argument sets whether the powers in the new bins
             should be summed or averaged.
         """
@@ -2128,7 +2128,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
         return new_dynspec_object
 
-    def rebin_time(self, dt_new, method="sum"):
+    def rebin_time(self, dt_new, method="average"):
         """
         Rebin the Dynamic Power Spectrum to a new time resolution.
 
@@ -2147,7 +2147,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             Must be larger than the time resolution of the old dynamical power
             spectrum!
 
-        method: {"sum" | "mean" | "average"}, optional, default "sum"
+        method: {"sum" | "mean" | "average"}, optional, default "average"
             This keyword argument sets whether the powers in the new bins
             should be summed or averaged.
 
@@ -2177,7 +2177,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         new_dynspec_object.m = int(step) * self.m
         return new_dynspec_object
 
-    def rebin_by_n_intervals(self, n, method="sum"):
+    def rebin_by_n_intervals(self, n, method="average"):
         """
         Rebin the Dynamic Power Spectrum to a new time resolution, by summing contiguous intervals.
 
@@ -2190,7 +2190,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         n: int
             The number of intervals to be combined into one.
 
-        method: {"sum" | "mean" | "average"}, optional, default "sum"
+        method: {"sum" | "mean" | "average"}, optional, default "average"
             This keyword argument sets whether the powers in the new bins
             should be summed or averaged.
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2028,6 +2028,9 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         The time resolution of the dynamical spectrum. It is **not** the time resolution of the
         input light curve. It is the integration time of each line of the dynamical power
         spectrum (typically, an integer multiple of ``segment_size``).
+
+    m: int
+        The number of averaged cross spectra.
     """
 
     def __init__(self, data1, data2, segment_size, norm="frac", gti=None, sample_time=None):

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2083,6 +2083,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         self.time = tstart + 0.5 * self.segment_size
         self.df = avg.df
         self.dt = self.segment_size
+        self.m = 1
 
     def rebin_frequency(self, df_new, method="sum"):
         """
@@ -2108,7 +2109,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         new_dynspec_object = copy.deepcopy(self)
         dynspec_new = []
         for data in self.dyn_ps.T:
-            freq_new, bin_counts, bin_err, _ = rebin_data(
+            freq_new, bin_counts, bin_err, step = rebin_data(
                 self.freq, data, dx_new=df_new, method=method
             )
             dynspec_new.append(bin_counts)
@@ -2116,6 +2117,8 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         new_dynspec_object.freq = freq_new
         new_dynspec_object.dyn_ps = np.array(dynspec_new).T
         new_dynspec_object.df = df_new
+        new_dynspec_object.m = int(step) * self.m
+
         return new_dynspec_object
 
     def rebin_time(self, dt_new, method="sum"):
@@ -2156,7 +2159,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
         dynspec_new = []
         for data in self.dyn_ps:
-            time_new, bin_counts, _, _ = rebin_data(
+            time_new, bin_counts, _, step = rebin_data(
                 self.time, data, dt_new, method=method, dx=self.dt
             )
             dynspec_new.append(bin_counts)
@@ -2164,6 +2167,73 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         new_dynspec_object.time = time_new
         new_dynspec_object.dyn_ps = np.array(dynspec_new)
         new_dynspec_object.dt = dt_new
+        new_dynspec_object.m = int(step) * self.m
+        return new_dynspec_object
+
+    def rebin_by_n_intervals(self, n, method="sum"):
+        """
+        Rebin the Dynamic Power Spectrum to a new time resolution.
+
+        Note: this is *not* changing the time resolution of the input light
+        curve! ``dt`` is the integration time of each line of the dynamical power
+        spectrum (typically, an integer multiple of ``segment_size``).
+
+        While the new resolution does not need to be an integer of the previous time
+        resolution, be aware that if this is the case, the last time bin will be cut
+        off by the fraction left over by the integer division
+
+        Parameters
+        ----------
+        n: int
+            The number of intervals to be combined into one.
+
+        method: {"sum" | "mean" | "average"}, optional, default "sum"
+            This keyword argument sets whether the counts in the new bins
+            should be summed or averaged.
+
+        Returns
+        -------
+        time_new: numpy.ndarray
+            Time axis with new rebinned time resolution.
+
+        dynspec_new: numpy.ndarray
+            New rebinned Dynamical Cross Spectrum.
+        """
+        if not np.issubdtype(type(n), np.integer):
+            warnings.warn("n must be an integer. Converting")
+
+            n = int(n)
+
+        if n == 1:
+            return copy.deepcopy(self)
+        if n < 1:
+            raise ValueError("n must be >= 1")
+
+        new_dynspec_object = copy.deepcopy(self)
+
+        dynspec_new = []
+        time_new = []
+        for i, data in enumerate(self.dyn_ps.T):
+            if i % n == 0:
+                count = 1
+                bin_counts = data
+                bin_times = self.time[i]
+            else:
+                count += 1
+                bin_counts += data
+                bin_times += self.time[i]
+            if count == n:
+                if method in ["mean", "average"]:
+                    bin_counts /= n
+                dynspec_new.append(bin_counts)
+                bin_times /= n
+                time_new.append(bin_times)
+
+        new_dynspec_object.time = time_new
+        new_dynspec_object.dyn_ps = np.array(dynspec_new).T
+        new_dynspec_object.dt *= n
+        new_dynspec_object.m = n * self.m
+
         return new_dynspec_object
 
     def trace_maximum(self, min_freq=None, max_freq=None):
@@ -2245,6 +2315,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
                     frequencies_to_exclude=frequencies_to_exclude,
                     df=self.df,
                     poisson_power=poisson_power,
+                    m=self.m,
                 )
             )
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2179,7 +2179,11 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
     def rebin_by_n_intervals(self, n, method="sum"):
         """
-        Rebin the Dynamic Power Spectrum to a new time resolution, by summing n intervals.
+        Rebin the Dynamic Power Spectrum to a new time resolution, by summing contiguous intervals.
+
+        This is different from meth:`DynamicalPowerspectrum.rebin_time` in that it averages ``n``
+        consecutive intervals regardless of their distance in time. ``rebin_time`` will instead
+        average intervals that are separated at most by a time ``dt_new``.
 
         Parameters
         ----------

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2233,11 +2233,14 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             The power colors for each spectrum and their respective errors
         """
         power_colors = []
+        if np.iscomplexobj(self.dyn_ps):
+            warnings.warn("When using power_colors, complex powers will be cast to real.")
+
         for ps in self.dyn_ps.T:
             power_colors.append(
                 power_color(
                     self.freq,
-                    ps,
+                    ps.real,
                     frequency_edges=frequency_edges,
                     frequencies_to_exclude=frequencies_to_exclude,
                     df=self.df,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2030,7 +2030,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         spectrum (typically, an integer multiple of ``segment_size``).
 
     m: int
-        The number of averaged cross spectra.
+        The number of averaged powers in each spectral bin (initially 1, it changes after rebinning).
     """
 
     def __init__(self, data1, data2, segment_size, norm="frac", gti=None, sample_time=None):

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2278,7 +2278,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         poisson_power=0,
     ):
         """
-        Return the power colors of the dynamical power spectrum.
+        Compute the power colors of the dynamical power spectrum.
 
         See Heil et al. 2015, MNRAS, 448, 3348
 

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2316,8 +2316,8 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
                 power_color(
                     self.freq,
                     ps.real,
-                    frequency_edges=freq_edges,
-                    frequencies_to_exclude=freqs_to_exclude,
+                    freq_edges=freq_edges,
+                    freqs_to_exclude=freqs_to_exclude,
                     df=self.df,
                     poisson_power=poisson_power,
                     m=self.m,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2273,8 +2273,8 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
     def power_colors(
         self,
-        frequency_edges=[1 / 256, 1 / 32, 0.25, 2.0, 16.0],
-        frequencies_to_exclude=None,
+        freq_edges=[1 / 256, 1 / 32, 0.25, 2.0, 16.0],
+        freqs_to_exclude=None,
         poisson_power=0,
     ):
         """
@@ -2284,10 +2284,10 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
         Parameters
         ----------
-        frequency_edges: iterable
+        freq_edges: iterable
             The edges of the frequency bins to be used for the power colors.
 
-        frequencies_to_exclude : 1-d or 2-d iterable, optional, default None
+        freqs_to_exclude : 1-d or 2-d iterable, optional, default None
             The ranges of frequencies to exclude from the calculation of the power color.
             For example, the frequencies containing strong QPOs.
             A 1-d iterable should contain two values for the edges of a single range. (E.g.
@@ -2296,7 +2296,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
         poisson_power : float or iterable, optional, default 0
             The Poisson noise level of the power spectrum. If iterable, it should have the same
-            length as ``frequency``. (This might apply to the case of a power spectrum with a
+            length as ``freq``. (This might apply to the case of a power spectrum with a
             strong dead time distortion)
 
         Returns
@@ -2316,8 +2316,8 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
                 power_color(
                     self.freq,
                     ps.real,
-                    frequency_edges=frequency_edges,
-                    frequencies_to_exclude=frequencies_to_exclude,
+                    frequency_edges=freq_edges,
+                    frequencies_to_exclude=freqs_to_exclude,
                     df=self.df,
                     poisson_power=poisson_power,
                     m=self.m,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2175,15 +2175,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
     def rebin_by_n_intervals(self, n, method="sum"):
         """
-        Rebin the Dynamic Power Spectrum to a new time resolution.
-
-        Note: this is *not* changing the time resolution of the input light
-        curve! ``dt`` is the integration time of each line of the dynamical power
-        spectrum (typically, an integer multiple of ``segment_size``).
-
-        While the new resolution does not need to be an integer of the previous time
-        resolution, be aware that if this is the case, the last time bin will be cut
-        off by the fraction left over by the integer division
+        Rebin the Dynamic Power Spectrum to a new time resolution, by summing n intervals.
 
         Parameters
         ----------

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -54,8 +54,8 @@ def integrate_power_in_frequency_range(
         The error on the integrated power
 
     """
-    frequency = np.array(frequency, dtype=float)
-    power = np.asarray(power, dtype=float)
+    frequency = np.array(frequency)
+    power = np.array(power)
     if not isinstance(poisson_power, Iterable):
         poisson_power = np.ones_like(frequency) * poisson_power
     if df is None:

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -102,10 +102,10 @@ def power_color(
     frequency,
     power,
     power_err=None,
-    frequency_edges=[1 / 256, 1 / 32, 0.25, 2.0, 16.0],
+    freq_edges=[1 / 256, 1 / 32, 0.25, 2.0, 16.0],
     df=None,
     m=1,
-    frequencies_to_exclude=None,
+    freqs_to_exclude=None,
     poisson_power=0,
     return_log=False,
 ):
@@ -125,7 +125,7 @@ def power_color(
     ----------------
     power_err : iterable
         The power error bar at each frequency
-    frequency_edges : iterable, optional, default ``[0.0039, 0.031, 0.25, 2.0, 16.0]``
+    freq_edges : iterable, optional, default ``[0.0039, 0.031, 0.25, 2.0, 16.0]``
         The frequency intervals to use to calculate the power color. If empty,
         the power color is calculated in the whole frequency range.
     df : float or float iterable, optional, default None
@@ -133,7 +133,7 @@ def power_color(
         from the median difference of input frequencies.
     m : int, optional, default 1
         The number of segments and/or contiguous frequency bins averaged to obtain power
-    frequencies_to_exclude : 1-d or 2-d iterable, optional, default None
+    freqs_to_exclude : 1-d or 2-d iterable, optional, default None
         The ranges of frequencies to exclude from the calculation of the power color.
         For example, the frequencies containing strong QPOs.
         A 1-d iterable should contain two values for the edges of a single range. (E.g.
@@ -152,7 +152,7 @@ def power_color(
     power_color_err : float
         The error on the power color
     """
-    frequency_edges = np.asarray(frequency_edges)
+    freq_edges = np.asarray(freq_edges)
     frequency = np.asarray(frequency)
     power = np.asarray(power)
 
@@ -161,9 +161,9 @@ def power_color(
     input_frequency_low_edges = frequency - df / 2
     input_frequency_high_edges = frequency + df / 2
 
-    if frequency_edges.min() < input_frequency_low_edges[0]:
+    if freq_edges.min() < input_frequency_low_edges[0]:
         raise ValueError("The minimum frequency is larger than the first frequency edge")
-    if frequency_edges.max() > input_frequency_high_edges[-1]:
+    if freq_edges.max() > input_frequency_high_edges[-1]:
         raise ValueError("The maximum frequency is lower than the last frequency edge")
 
     if power_err is None:
@@ -171,17 +171,17 @@ def power_color(
     else:
         power_err = np.asarray(power_err)
 
-    if frequencies_to_exclude is not None:
-        if len(np.shape(frequencies_to_exclude)) == 1:
-            frequencies_to_exclude = [frequencies_to_exclude]
+    if freqs_to_exclude is not None:
+        if len(np.shape(freqs_to_exclude)) == 1:
+            freqs_to_exclude = [freqs_to_exclude]
 
         if (
-            not isinstance(frequencies_to_exclude, Iterable)
-            or len(np.shape(frequencies_to_exclude)) != 2
-            or np.shape(frequencies_to_exclude)[1] != 2
+            not isinstance(freqs_to_exclude, Iterable)
+            or len(np.shape(freqs_to_exclude)) != 2
+            or np.shape(freqs_to_exclude)[1] != 2
         ):
-            raise ValueError("frequencies_to_exclude must be of format [[f0, f1], [f2, f3], ...]")
-        for f0, f1 in frequencies_to_exclude:
+            raise ValueError("freqs_to_exclude must be of format [[f0, f1], [f2, f3], ...]")
+        for f0, f1 in freqs_to_exclude:
             frequency_mask = (input_frequency_low_edges > f0) & (input_frequency_high_edges < f1)
             idx0, idx1 = np.searchsorted(frequency, [f0, f1])
             power[frequency_mask] = np.mean([power[idx0], power[idx1]])
@@ -189,7 +189,7 @@ def power_color(
     var00, var00_err = integrate_power_in_frequency_range(
         frequency,
         power,
-        frequency_edges[:2],
+        freq_edges[:2],
         power_err=power_err,
         df=df,
         m=m,
@@ -198,7 +198,7 @@ def power_color(
     var01, var01_err = integrate_power_in_frequency_range(
         frequency,
         power,
-        frequency_edges[2:4],
+        freq_edges[2:4],
         power_err=power_err,
         df=df,
         m=m,
@@ -207,7 +207,7 @@ def power_color(
     var10, var10_err = integrate_power_in_frequency_range(
         frequency,
         power,
-        frequency_edges[1:3],
+        freq_edges[1:3],
         power_err=power_err,
         df=df,
         m=m,
@@ -216,7 +216,7 @@ def power_color(
     var11, var11_err = integrate_power_in_frequency_range(
         frequency,
         power,
-        frequency_edges[3:5],
+        freq_edges[3:5],
         power_err=power_err,
         df=df,
         m=m,

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -54,8 +54,10 @@ def integrate_power_in_frequency_range(
         The error on the integrated power
 
     """
-    frequency = np.array(frequency)
+    frequency = np.array(frequency, dtype=float)
     power = np.array(power)
+    if not np.iscomplexobj(power):
+        power = power.astype(float)
     if not isinstance(poisson_power, Iterable):
         poisson_power = np.ones_like(frequency) * poisson_power
     if df is None:

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -122,10 +122,11 @@ def power_color(
         from the median difference of input frequencies.
     m : int, optional, default 1
         The number of segments and/or contiguous frequency bins averaged to obtain power
-    frequencies_to_exclude : 2-d iterable, optional, default None
+    frequencies_to_exclude : 1-d or 2-d iterable, optional, default None
         The ranges of frequencies to exclude from the calculation of the power color.
         For example, the frequencies containing strong QPOs.
-        E.g. ``[[0.1, 0.2], [3, 4]]`` will exclude the ranges 0.1-0.2 Hz and 3-4 Hz.
+        A 1-d iterable should contain two values for the edges of a single range. (E.g.
+        ``[0.1, 0.2]``). ``[[0.1, 0.2], [3, 4]]`` will exclude the ranges 0.1-0.2 Hz and 3-4 Hz.
     poisson_level : float, optional, default 0
         The Poisson noise level of the power spectrum.
 
@@ -156,8 +157,12 @@ def power_color(
         power_err = np.asarray(power_err)
 
     if frequencies_to_exclude is not None:
+        if len(np.shape(frequencies_to_exclude)):
+            frequencies_to_exclude = [frequencies_to_exclude]
+        if np.shape(frequencies_to_exclude)[1] != 2:
+            raise ValueError("frequencies_to_exclude must be of format [[f0, f1], [f2, f3], ...]")
         for f0, f1 in frequencies_to_exclude:
-            frequency_mask = (input_frequency_low_edges > f0) | (input_frequency_high_edges < f1)
+            frequency_mask = (input_frequency_low_edges > f0) & (input_frequency_high_edges < f1)
             idx0, idx1 = np.searchsorted(frequency, [f0, f1])
             power[frequency_mask] = np.mean([power[idx0], power[idx1]])
             power_err[frequency_mask] = np.max([power_err[idx0], power_err[idx1]])

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -1486,7 +1486,7 @@ def avg_pds_from_iterable(
 
         # If the user wants to normalize using the mean of the total
         # lightcurve, normalize it here
-        cs_seg = unnorm_power
+        cs_seg = copy.deepcopy(unnorm_power)
         if not use_common_mean:
             mean = n_ph / n_bin
 
@@ -1872,7 +1872,7 @@ def avg_cs_from_iterables(
                 unnorm_pd1 = unnorm_pd1[fgt0]
                 unnorm_pd2 = unnorm_pd2[fgt0]
 
-        cs_seg = unnorm_power
+        cs_seg = copy.deepcopy(unnorm_power)
         p1_seg = unnorm_pd1
         p2_seg = unnorm_pd2
 

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -157,9 +157,14 @@ def power_color(
         power_err = np.asarray(power_err)
 
     if frequencies_to_exclude is not None:
-        if len(np.shape(frequencies_to_exclude)):
+        if len(np.shape(frequencies_to_exclude)) == 1:
             frequencies_to_exclude = [frequencies_to_exclude]
-        if np.shape(frequencies_to_exclude)[1] != 2:
+
+        if (
+            not isinstance(frequencies_to_exclude, Iterable)
+            or len(np.shape(frequencies_to_exclude)) != 2
+            or np.shape(frequencies_to_exclude)[1] != 2
+        ):
             raise ValueError("frequencies_to_exclude must be of format [[f0, f1], [f2, f3], ...]")
         for f0, f1 in frequencies_to_exclude:
             frequency_mask = (input_frequency_low_edges > f0) & (input_frequency_high_edges < f1)

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -112,6 +112,8 @@ def power_color(
     """
     Calculate the power color of a power spectrum.
 
+    See Heil et al. 2015, MNRAS, 448, 3348
+
     Parameters
     ----------
     frequency : iterable

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -110,7 +110,22 @@ def power_color(
     return_log=False,
 ):
     """
-    Calculate the power color of a power spectrum.
+    Calculate two power colors from a power spectrum.
+
+    Power colors are an alternative to spectral colors to understand the spectral state of an
+    accreting source. They are defined as the ratio of the power in two frequency ranges,
+    analogously to the colors calculated from electromagnetic spectra.
+
+    This function calculates two power colors, using the four frequency ranges contained
+    between the five frequency edges in ``freq_edges``. Given [f0, f1, f2, f3, f4], the
+    two power colors are calculated as the following ratios of the integrated power
+    (which are variances):
+
+    + PC0 = Var([f0, f1]) / Var([f2, f3])
+
+    + PC1 = Var([f1, f2]) / Var([f3, f4])
+
+    Errors are calculated using simple error propagation from the integrated power errors.
 
     See Heil et al. 2015, MNRAS, 448, 3348
 
@@ -126,8 +141,8 @@ def power_color(
     power_err : iterable
         The power error bar at each frequency
     freq_edges : iterable, optional, default ``[0.0039, 0.031, 0.25, 2.0, 16.0]``
-        The frequency intervals to use to calculate the power color. If empty,
-        the power color is calculated in the whole frequency range.
+        The five edges defining the four frequency intervals to use to calculate the power color.
+        If empty, the power color is calculated using the frequencies from Heil et al. 2015.
     df : float or float iterable, optional, default None
         The frequency resolution of the input data. If None, it is calculated
         from the median difference of input frequencies.
@@ -147,12 +162,19 @@ def power_color(
 
     Returns
     -------
-    power_color : float
-        The power color
-    power_color_err : float
-        The error on the power color
+    PC0 : float
+        The first power color
+    PC0_err : float
+        The error on the first power color
+    PC1 : float
+        The second power color
+    PC1_err : float
+        The error on the second power color
     """
     freq_edges = np.asarray(freq_edges)
+    if len(freq_edges) != 5:
+        raise ValueError("freq_edges must have 5 elements")
+
     frequency = np.asarray(frequency)
     power = np.asarray(power)
 

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -165,7 +165,6 @@ def power_color(
             frequency_mask = (input_frequency_low_edges > f0) & (input_frequency_high_edges < f1)
             idx0, idx1 = np.searchsorted(frequency, [f0, f1])
             power[frequency_mask] = np.mean([power[idx0], power[idx1]])
-            power_err[frequency_mask] = np.max([power_err[idx0], power_err[idx1]])
 
     var00, var00_err = integrate_power_in_frequency_range(
         frequency,

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -659,7 +659,10 @@ def load_events_and_gtis(
             )
         except Exception as e:  # pragma: no cover
             warnings.warn(
-                f"No valid GTI extensions found. \nError: {str(e)}\nGTIs will be set to the entire time series.",
+                (
+                    f"No valid GTI extensions found. \nError: {str(e)}\n"
+                    "GTIs will be set to the entire time series."
+                ),
                 AstropyUserWarning,
             )
             gti_list = np.array([[t_start, t_stop]], dtype=np.longdouble)

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -658,9 +658,10 @@ def load_events_and_gtis(
                 det_numbers=det_number,
             )
         except Exception as e:  # pragma: no cover
-            warnings.warn("No valid GTI extensions found:", AstropyUserWarning)
-            traceback.print_exc()
-            warnings.warn("GTIs will be set to the entire time series.", AstropyUserWarning)
+            warnings.warn(
+                f"No valid GTI extensions found. \nError: {str(e)}\nGTIs will be set to the entire time series.",
+                AstropyUserWarning,
+            )
             gti_list = np.array([[t_start, t_stop]], dtype=np.longdouble)
     else:
         gti_list = load_gtis(gti_file, gtistring)

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -2,6 +2,7 @@ import logging
 import math
 import copy
 import os
+import sys
 import traceback
 import warnings
 from collections.abc import Iterable
@@ -658,7 +659,7 @@ def load_events_and_gtis(
             )
         except Exception as e:  # pragma: no cover
             warnings.warn("No valid GTI extensions found:", AstropyUserWarning)
-            traceback.print_exception(e)
+            traceback.print_exc()
             warnings.warn("GTIs will be set to the entire time series.", AstropyUserWarning)
             gti_list = np.array([[t_start, t_stop]], dtype=np.longdouble)
     else:

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1608,11 +1608,14 @@ class Lightcurve(StingrayTimeseries):
         self,
         witherrors=False,
         labels=None,
-        axis=None,
+        ax=None,
         title=None,
         marker="-",
         save=False,
         filename=None,
+        axis_limits=None,
+        axis=None,
+        plot_btis=True,
     ):
         """
         Plot the light curve using ``matplotlib``.
@@ -1629,10 +1632,13 @@ class Lightcurve(StingrayTimeseries):
         labels : iterable, default ``None``
             A list of tuple with ``xlabel`` and ``ylabel`` as strings.
 
-        axis : list, tuple, string, default ``None``
+        axis_limits : list, tuple, string, default ``None``
             Parameter to set axis properties of the ``matplotlib`` figure. For example
             it can be a list like ``[xmin, xmax, ymin, ymax]`` or any other
             acceptable argument for the``matplotlib.pyplot.axis()`` method.
+
+        axis : list, tuple, string, default ``None``
+            Deprecated in favor of ``axis_limits``, same functionality.
 
         title : str, default ``None``
             The title of the plot.
@@ -1647,39 +1653,69 @@ class Lightcurve(StingrayTimeseries):
 
         filename : str
             File name of the image to save. Depends on the boolean ``save``.
+
+        ax : ``matplotlib.pyplot.axis`` object
+            Axis to be used for plotting. Defaults to creating a new one.
+
+        plot_btis : bool
+            Plot the bad time intervals as red areas on the plot
         """
-
-        fig = plt.figure()
-        if witherrors:
-            fig = plt.errorbar(self.time, self.counts, yerr=self.counts_err, fmt=marker)
-        else:
-            fig = plt.plot(self.time, self.counts, marker)
-
-        if labels is not None:
-            try:
-                plt.xlabel(labels[0])
-                plt.ylabel(labels[1])
-            except TypeError:
-                utils.simon("``labels`` must be either a list or tuple with " "x and y labels.")
-                raise
-            except IndexError:
-                utils.simon("``labels`` must have two labels for x and y " "axes.")
-                # Not raising here because in case of len(labels)==1, only
-                # x-axis will be labelled.
-
         if axis is not None:
-            plt.axis(axis)
+            warnings.warn(
+                "The ``axis`` argument is deprecated in favor of ``axis_limits``. "
+                "Please use that instead.",
+                DeprecationWarning,
+            )
+            axis_limits = axis
 
-        if title is not None:
-            plt.title(title)
+        flux_attr = "counts"
+        if not self.input_counts:
+            flux_attr = "countrate"
 
-        if save:
-            if filename is None:
-                plt.savefig("out.png")
-            else:
-                plt.savefig(filename)
-        else:
-            plt.show(block=False)
+        return super().plot(
+            flux_attr,
+            witherrors=witherrors,
+            labels=labels,
+            ax=ax,
+            title=title,
+            marker=marker,
+            save=save,
+            filename=filename,
+            plot_btis=plot_btis,
+            axis_limits=axis_limits,
+        )
+
+    #     fig = plt.figure()
+    #     if witherrors:
+    #         fig = plt.errorbar(self.time, self.counts, yerr=self.counts_err, fmt=marker)
+    #     else:
+    #         fig = plt.plot(self.time, self.counts, marker)
+
+    #     if labels is not None:
+    #         try:
+    #             plt.xlabel(labels[0])
+    #             plt.ylabel(labels[1])
+    #         except TypeError:
+    #             utils.simon("``labels`` must be either a list or tuple with " "x and y labels.")
+    #             raise
+    #         except IndexError:
+    #             utils.simon("``labels`` must have two labels for x and y " "axes.")
+    #             # Not raising here because in case of len(labels)==1, only
+    #             # x-axis will be labelled.
+
+    #     if axis is not None:
+    #         plt.axis(axis)
+
+    #     if title is not None:
+    #         plt.title(title)
+
+    #     if save:
+    #         if filename is None:
+    #             plt.savefig("out.png")
+    #         else:
+    #             plt.savefig(filename)
+    #     else:
+    #         plt.show(block=False)
 
     @classmethod
     def read(

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1685,38 +1685,6 @@ class Lightcurve(StingrayTimeseries):
             axis_limits=axis_limits,
         )
 
-    #     fig = plt.figure()
-    #     if witherrors:
-    #         fig = plt.errorbar(self.time, self.counts, yerr=self.counts_err, fmt=marker)
-    #     else:
-    #         fig = plt.plot(self.time, self.counts, marker)
-
-    #     if labels is not None:
-    #         try:
-    #             plt.xlabel(labels[0])
-    #             plt.ylabel(labels[1])
-    #         except TypeError:
-    #             utils.simon("``labels`` must be either a list or tuple with " "x and y labels.")
-    #             raise
-    #         except IndexError:
-    #             utils.simon("``labels`` must have two labels for x and y " "axes.")
-    #             # Not raising here because in case of len(labels)==1, only
-    #             # x-axis will be labelled.
-
-    #     if axis is not None:
-    #         plt.axis(axis)
-
-    #     if title is not None:
-    #         plt.title(title)
-
-    #     if save:
-    #         if filename is None:
-    #             plt.savefig("out.png")
-    #         else:
-    #             plt.savefig(filename)
-    #     else:
-    #         plt.show(block=False)
-
     @classmethod
     def read(
         cls, filename, fmt=None, format_=None, err_dist="gauss", skip_checks=False, **fits_kwargs

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1066,6 +1066,7 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         self.dt = self.segment_size
         self.meanrate = avg.nphots / avg.n / avg.dt
         self.nphots = avg.nphots
+        self.m = 1
 
     def power_colors(
         self,

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -210,7 +210,8 @@ class Powerspectrum(Crossspectrum):
             M_freq = self.m
             K_freq = self.k
             freq_bins = maxind - minind
-        T = self.dt * self.n
+
+        T = self.dt * self.n * 2
 
         if white_noise_offset is not None:
             powers = self.power[minind:maxind]
@@ -237,6 +238,7 @@ class Powerspectrum(Crossspectrum):
                 poisson_noise_unnorm = unnormalize_periodograms(
                     poisson_noise_level, self.dt, self.n, self.nphots, norm=self.norm
                 )
+
             return rms_calculation(
                 self.unnorm_power[minind:maxind],
                 min_freq,
@@ -1058,6 +1060,8 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
             gti=self.gti,
             save_all=True,
         )
+        conv = avg.cs_all / avg.unnorm_cs_all
+        self.unnorm_conversion = np.nanmean(conv)
         self.dyn_ps = np.array(avg.cs_all).T
         self.freq = avg.freq
         current_gti = avg.gti

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1077,8 +1077,8 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
 
     def power_colors(
         self,
-        frequency_edges=[1 / 256, 1 / 32, 0.25, 2.0, 16.0],
-        frequencies_to_exclude=None,
+        freq_edges=[1 / 256, 1 / 32, 0.25, 2.0, 16.0],
+        freqs_to_exclude=None,
         poisson_power=None,
     ):
         """
@@ -1086,10 +1086,10 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
 
         Parameters
         ----------
-        frequency_edges: iterable
+        freq_edges: iterable
             The edges of the frequency bins to be used for the power colors.
 
-        frequencies_to_exclude : 1-d or 2-d iterable, optional, default None
+        freqs_to_exclude : 1-d or 2-d iterable, optional, default None
             The ranges of frequencies to exclude from the calculation of the power color.
             For example, the frequencies containing strong QPOs.
             A 1-d iterable should contain two values for the edges of a single range. (E.g.
@@ -1118,8 +1118,8 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
             )
 
         return super().power_colors(
-            freq_edges=frequency_edges,
-            freqs_to_exclude=frequencies_to_exclude,
+            freq_edges=freq_edges,
+            freqs_to_exclude=freqs_to_exclude,
             poisson_power=poisson_power,
         )
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1064,6 +1064,56 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         self.time = tstart + 0.5 * self.segment_size
         self.df = avg.df
         self.dt = self.segment_size
+        self.meanrate = avg.nphots / avg.n / avg.dt
+        self.nphots = avg.nphots
+
+    def power_colors(
+        self,
+        frequency_edges=[1 / 256, 1 / 32, 0.25, 2.0, 16.0],
+        frequencies_to_exclude=None,
+        poisson_power=None,
+    ):
+        """
+        Return the power colors of the dynamical power spectrum.
+
+        Parameters
+        ----------
+        frequency_edges: iterable
+            The edges of the frequency bins to be used for the power colors.
+
+        frequencies_to_exclude : 1-d or 2-d iterable, optional, default None
+            The ranges of frequencies to exclude from the calculation of the power color.
+            For example, the frequencies containing strong QPOs.
+            A 1-d iterable should contain two values for the edges of a single range. (E.g.
+            ``[0.1, 0.2]``). ``[[0.1, 0.2], [3, 4]]`` will exclude the ranges 0.1-0.2 Hz and
+            3-4 Hz.
+
+        poisson_level : float or iterable, optional
+            Defaults to the theoretical Poisson noise level (e.g. 2 for Leahy normalization).
+            The Poisson noise level of the power spectrum. If iterable, it should have the same
+            length as ``frequency``. (This might apply to the case of a power spectrum with a
+            strong dead time distortion)
+
+        Returns
+        -------
+        pc0: np.ndarray
+        pc0_err: np.ndarray
+        pc1: np.ndarray
+        pc1_err: np.ndarray
+            The power colors for each spectrum and their respective errors
+        """
+        if poisson_power is None:
+            poisson_power = poisson_level(
+                norm=self.norm,
+                meanrate=self.meanrate,
+                n_ph=self.nphots,
+            )
+
+        return super().power_colors(
+            frequency_edges=frequency_edges,
+            frequencies_to_exclude=frequencies_to_exclude,
+            poisson_power=poisson_power,
+        )
 
 
 def powerspectrum_from_time_array(

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1013,6 +1013,9 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         The time resolution of the dynamical spectrum. It is **not** the time resolution of the
         input light curve. It is the integration time of each line of the dynamical power
         spectrum (typically, an integer multiple of ``segment_size``).
+
+    m: int
+        The number of averaged cross spectra.
     """
 
     def __init__(self, lc, segment_size, norm="frac", gti=None, sample_time=None):

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1118,8 +1118,8 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
             )
 
         return super().power_colors(
-            frequency_edges=frequency_edges,
-            frequencies_to_exclude=frequencies_to_exclude,
+            freq_edges=frequency_edges,
+            freqs_to_exclude=frequencies_to_exclude,
             poisson_power=poisson_power,
         )
 

--- a/stingray/pulse/overlapandsave/ols.py
+++ b/stingray/pulse/overlapandsave/ols.py
@@ -196,7 +196,7 @@ def prepareh(h, nfft: List[int], rfftn=None):
         The FFT-transformed, conjugate filter array
     """
     rfftn = rfftn or np.fft.rfftn
-    return np.conj(rfftn(flip(np.conj(h)), nfft))
+    return np.conj(rfftn(flip(np.conj(h)), nfft, axes=np.arange(len(nfft))))
 
 
 def slice2range(s: slice):
@@ -365,7 +365,9 @@ def olsStep(
         for (start, length, nh, border) in zip(starts, lengths, nh, border)
     )
     xpart = padEdges(x, slices, mode=mode, **kwargs)
-    output = irfftn(rfftn(xpart, nfft) * hfftconj, nfft)
+    output = irfftn(
+        rfftn(xpart, nfft, axes=np.arange(len(nfft))) * hfftconj, nfft, axes=np.arange(len(nfft))
+    )
     return output[tuple(slice(0, s) for s in lengths)]
 
 

--- a/stingray/tests/test_base.py
+++ b/stingray/tests/test_base.py
@@ -1310,6 +1310,11 @@ class TestFillBTI(object):
             time=time_edges[:-1] + 0.5, counts=counts, blablas=blablas, gti=cls.gti, dt=1
         )
 
+    def test_no_btis_returns_copy(self):
+        ts = StingrayTimeseries([1, 2, 3], energy=[4, 6, 8], gti=[[0.5, 3.5]])
+        ts_new = ts.fill_bad_time_intervals()
+        assert ts == ts_new
+
     def test_event_like(self):
         ev_like_filt = copy.deepcopy(self.ev_like)
         # I introduce a small gap in the GTIs

--- a/stingray/tests/test_base.py
+++ b/stingray/tests/test_base.py
@@ -1381,8 +1381,8 @@ class TestFillBTI(object):
         # I introduce a small gap in the GTIs
         ev_like_filt.gti = np.asarray([[0, 498], [500, 900], [950, 1000]])
         # Results should be exactly the same
-        ev_new0 = ev_like_filt.fill_bad_time_intervals(uniform=False, seed=201903)
-        ev_new1 = ev_like_filt.fill_bad_time_intervals(uniform=None, seed=201903)
+        ev_new0 = ev_like_filt.fill_bad_time_intervals(even_sampling=False, seed=201903)
+        ev_new1 = ev_like_filt.fill_bad_time_intervals(even_sampling=None, seed=201903)
         for attr in ["time", "energy"]:
             assert np.allclose(getattr(ev_new0, attr), getattr(ev_new1, attr))
 
@@ -1391,8 +1391,8 @@ class TestFillBTI(object):
         # I introduce a small gap in the GTIs
         lc_like_filt.gti = np.asarray([[0, 498], [500, 900], [950, 1000]])
         # Results should be exactly the same
-        lc_new0 = lc_like_filt.fill_bad_time_intervals(uniform=True, seed=201903)
-        lc_new1 = lc_like_filt.fill_bad_time_intervals(uniform=None, seed=201903)
+        lc_new0 = lc_like_filt.fill_bad_time_intervals(even_sampling=True, seed=201903)
+        lc_new1 = lc_like_filt.fill_bad_time_intervals(even_sampling=None, seed=201903)
         for attr in ["time", "counts", "blablas"]:
             assert np.allclose(getattr(lc_new0, attr), getattr(lc_new1, attr))
 

--- a/stingray/tests/test_base.py
+++ b/stingray/tests/test_base.py
@@ -1361,3 +1361,29 @@ class TestFillBTI(object):
         lc_new1 = lc_like_filt.fill_bad_time_intervals(uniform=None, seed=201903)
         for attr in ["time", "counts", "blablas"]:
             assert np.allclose(getattr(lc_new0, attr), getattr(lc_new1, attr))
+
+    def test_bti_close_to_edge_event_like(self):
+        ev_like_filt = copy.deepcopy(self.ev_like)
+        # I introduce a small gap in the GTIs
+        ev_like_filt.gti = np.asarray([[0, 0.5], [1, 900], [950, 1000]])
+        ev_new = ev_like_filt.fill_bad_time_intervals()
+        assert np.allclose(ev_new.gti, self.gti)
+
+        ev_like_filt = copy.deepcopy(self.ev_like)
+        # I introduce a small gap in the GTIs
+        ev_like_filt.gti = np.asarray([[0, 900], [950, 999], [999.5, 1000]])
+        ev_new = ev_like_filt.fill_bad_time_intervals()
+        assert np.allclose(ev_new.gti, self.gti)
+
+    def test_bti_close_to_edge_lc_like(self):
+        lc_like_filt = copy.deepcopy(self.lc_like)
+        # I introduce a small gap in the GTIs
+        lc_like_filt.gti = np.asarray([[0, 0.5], [1, 900], [950, 1000]])
+        lc_new = lc_like_filt.fill_bad_time_intervals()
+        assert np.allclose(lc_new.gti, self.gti)
+
+        lc_like_filt = copy.deepcopy(self.lc_like)
+        # I introduce a small gap in the GTIs
+        lc_like_filt.gti = np.asarray([[0, 900], [950, 999], [999.5, 1000]])
+        lc_new = lc_like_filt.fill_bad_time_intervals()
+        assert np.allclose(lc_new.gti, self.gti)

--- a/stingray/tests/test_base.py
+++ b/stingray/tests/test_base.py
@@ -1318,7 +1318,7 @@ class TestFillBTI(object):
     def test_event_like(self):
         ev_like_filt = copy.deepcopy(self.ev_like)
         # I introduce a small gap in the GTIs
-        ev_like_filt.gti = np.asarray([[0, 498], [500, 900], [950, 1000]])
+        ev_like_filt.gti = np.asarray([[0, 498], [500, 520], [522, 700], [702, 900], [950, 1000]])
         ev_new = ev_like_filt.fill_bad_time_intervals()
 
         assert np.allclose(ev_new.gti, self.gti)
@@ -1328,13 +1328,13 @@ class TestFillBTI(object):
         ev_new.gti = ev_like_filt.gti
 
         new_masked, filt_masked = ev_new.apply_gtis(), ev_like_filt.apply_gtis()
-        for attr in ["time", "energy"]:
+        for attr in ["time", "energy", "blablas"]:
             assert np.allclose(getattr(new_masked, attr), getattr(filt_masked, attr))
 
     def test_lc_like(self):
         lc_like_filt = copy.deepcopy(self.lc_like)
         # I introduce a small gap in the GTIs
-        lc_like_filt.gti = np.asarray([[0, 498], [500, 900], [950, 1000]])
+        lc_like_filt.gti = np.asarray([[0, 498], [500, 520], [522, 700], [702, 900], [950, 1000]])
         lc_new = lc_like_filt.fill_bad_time_intervals()
         assert np.allclose(lc_new.gti, self.gti)
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1486,6 +1486,45 @@ class TestDynamicalCrossspectrum(object):
         assert np.allclose(new_dps.dyn_ps, rebin_dps)
         assert np.isclose(new_dps.dt, dt_new)
 
+    def test_rebin_n(self):
+        segment_size = 3
+        dt_new = 6.0
+        rebin_time = np.array([2.5, 8.5])
+        rebin_dps = np.array([[1.73611111, 0.81018519]])
+        dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
+        new_dps = dps.rebin_by_n_intervals(n=2)
+        assert np.allclose(new_dps.time, rebin_time)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.dt, dt_new)
+
+    def test_rebin_n_warns_for_non_integer(self):
+        segment_size = 3
+        dt_new = 6.0
+        rebin_time = np.array([2.5, 8.5])
+        rebin_dps = np.array([[1.73611111, 0.81018519]])
+        dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
+        with pytest.warns(UserWarning, match="n must be an integer. Casting to int"):
+            new_dps = dps.rebin_by_n_intervals(n=2.1)
+        assert np.allclose(new_dps.time, rebin_time)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps)
+        assert np.isclose(new_dps.dt, dt_new)
+
+    def test_rebin_n_fails_for_n_lt_1(self):
+        segment_size = 3
+
+        dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
+        with pytest.raises(ValueError, match="n must be >= 1"):
+            _ = dps.rebin_by_n_intervals(n=0)
+        dps2 = dps.rebin_by_n_intervals(n=1)
+        assert np.allclose(dps2.dyn_ps, dps.dyn_ps)
+
+    def test_rebin_copies_for_n_1(self):
+        segment_size = 3
+
+        dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
+        dps2 = dps.rebin_by_n_intervals(n=1)
+        assert np.allclose(dps2.dyn_ps, dps.dyn_ps)
+
     def test_rebin_frequency_default_method(self):
         segment_size = 50
         df_new = 10.0

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1408,6 +1408,7 @@ class TestDynamicalCrossspectrum(object):
 
         dps_ev = DynamicalCrossspectrum(ev, ev, segment_size=10, sample_time=self.lc.dt)
         assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
+        dps_ev.power_colors(frequency_edges=[1 / 5, 1 / 2, 1, 2.0, 16.0])
 
     def test_works_with_events_and_its_complex(self):
         lc = copy.deepcopy(self.lc)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1497,13 +1497,13 @@ class TestDynamicalCrossspectrum(object):
         with pytest.raises(ValueError):
             dps.rebin_frequency(df_new=dps.df / 2.0)
 
-    def test_rebin_time_default_method(self):
+    def test_rebin_time_sum_method(self):
         segment_size = 3
         dt_new = 6.0
         rebin_time = np.array([2.5, 8.5])
         rebin_dps = np.array([[1.73611111, 0.81018519]])
         dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
-        new_dps = dps.rebin_time(dt_new=dt_new)
+        new_dps = dps.rebin_time(dt_new=dt_new, method="sum")
         assert np.allclose(new_dps.time, rebin_time)
         assert np.allclose(new_dps.dyn_ps, rebin_dps)
         assert np.isclose(new_dps.dt, dt_new)
@@ -1514,7 +1514,7 @@ class TestDynamicalCrossspectrum(object):
         rebin_time = np.array([2.5, 8.5])
         rebin_dps = np.array([[1.73611111, 0.81018519]])
         dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
-        new_dps = dps.rebin_by_n_intervals(n=2)
+        new_dps = dps.rebin_by_n_intervals(n=2, method="sum")
         assert np.allclose(new_dps.time, rebin_time)
         assert np.allclose(new_dps.dyn_ps, rebin_dps)
         assert np.isclose(new_dps.dt, dt_new)
@@ -1537,7 +1537,7 @@ class TestDynamicalCrossspectrum(object):
         rebin_dps = np.array([[1.73611111, 0.81018519]])
         dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
         with pytest.warns(UserWarning, match="n must be an integer. Casting to int"):
-            new_dps = dps.rebin_by_n_intervals(n=2.1)
+            new_dps = dps.rebin_by_n_intervals(n=2.1, method="sum")
         assert np.allclose(new_dps.time, rebin_time)
         assert np.allclose(new_dps.dyn_ps, rebin_dps)
         assert np.isclose(new_dps.dt, dt_new)
@@ -1558,7 +1558,7 @@ class TestDynamicalCrossspectrum(object):
         dps2 = dps.rebin_by_n_intervals(n=1)
         assert np.allclose(dps2.dyn_ps, dps.dyn_ps)
 
-    def test_rebin_frequency_default_method(self):
+    def test_rebin_frequency_sum_method(self):
         segment_size = 50
         df_new = 10.0
         rebin_freq = np.array([5.01, 15.01, 25.01, 35.01])
@@ -1575,7 +1575,7 @@ class TestDynamicalCrossspectrum(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=segment_size)
-        new_dps = dps.rebin_frequency(df_new=df_new)
+        new_dps = dps.rebin_frequency(df_new=df_new, method="sum")
         assert np.allclose(new_dps.freq, rebin_freq)
         assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.01)
         assert np.isclose(new_dps.df, df_new)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1409,7 +1409,7 @@ class TestDynamicalCrossspectrum(object):
         dps_ev = DynamicalCrossspectrum(ev, ev, segment_size=10, sample_time=self.lc.dt)
         assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
         with pytest.warns(UserWarning, match="When using power_colors, complex "):
-            dps_ev.power_colors(frequency_edges=[1 / 5, 1 / 2, 1, 2.0, 16.0])
+            dps_ev.power_colors(freq_edges=[1 / 5, 1 / 2, 1, 2.0, 16.0])
 
     def test_rms_is_correct(self):
         lc = copy.deepcopy(self.lc)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1497,6 +1497,17 @@ class TestDynamicalCrossspectrum(object):
         assert np.allclose(new_dps.dyn_ps, rebin_dps)
         assert np.isclose(new_dps.dt, dt_new)
 
+    def test_rebin_n_average(self):
+        segment_size = 3
+        dt_new = 6.0
+        rebin_time = np.array([2.5, 8.5])
+        rebin_dps = np.array([[1.73611111, 0.81018519]])
+        dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)
+        new_dps = dps.rebin_by_n_intervals(n=2, method="average")
+        assert np.allclose(new_dps.time, rebin_time)
+        assert np.allclose(new_dps.dyn_ps, rebin_dps / 2)
+        assert np.isclose(new_dps.dt, dt_new)
+
     def test_rebin_n_warns_for_non_integer(self):
         segment_size = 3
         dt_new = 6.0
@@ -1518,7 +1529,7 @@ class TestDynamicalCrossspectrum(object):
         dps2 = dps.rebin_by_n_intervals(n=1)
         assert np.allclose(dps2.dyn_ps, dps.dyn_ps)
 
-    def test_rebin_copies_for_n_1(self):
+    def test_rebin_n_copies_for_n_1(self):
         segment_size = 3
 
         dps = DynamicalCrossspectrum(self.lc_test, self.lc_test, segment_size=segment_size)

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1408,7 +1408,8 @@ class TestDynamicalCrossspectrum(object):
 
         dps_ev = DynamicalCrossspectrum(ev, ev, segment_size=10, sample_time=self.lc.dt)
         assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
-        dps_ev.power_colors(frequency_edges=[1 / 5, 1 / 2, 1, 2.0, 16.0])
+        with pytest.warns(UserWarning, match="When using power_colors, complex "):
+            dps_ev.power_colors(frequency_edges=[1 / 5, 1 / 2, 1, 2.0, 16.0])
 
     def test_works_with_events_and_its_complex(self):
         lc = copy.deepcopy(self.lc)

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -728,3 +728,10 @@ class TestPowerColor(object):
         good = self.freq < 15  # the smallest frequency is 1/256
         with pytest.raises(ValueError, match="The maximum frequency is lower "):
             power_color(self.freq[good], self.power[good])
+
+    def test_excluded_frequencies(self):
+        pc0, _, pc1, _ = power_color(self.freq, self.power, frequencies_to_exclude=[1, 1.1])
+        # The colors calculated with these frequency edges on a 1/f spectrum should be 1
+        # The excluded frequency interval is small enough that the approximation should work
+        assert np.isclose(pc0, 1, atol=0.001)
+        assert np.isclose(pc1, 1, atol=0.001)

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -293,7 +293,19 @@ class TestFourier(object):
             silent=True,
             return_subcs=True,
         )
+
         assert np.isclose(out_comm["power"].std(), out["power"].std(), rtol=0.1)
+        assert np.isclose(out_comm["unnorm_power"].std(), out["unnorm_power"].std(), rtol=0.1)
+        # Run the same check on the subcs
+        assert np.isclose(out_comm.meta["subcs"].std(), out.meta["subcs"].std(), rtol=0.1)
+        assert np.isclose(
+            out_comm.meta["unnorm_subcs"].std(), out.meta["unnorm_subcs"].std(), rtol=0.1
+        )
+        # Now verify that the normalizations are consistent between single power and subcs
+        assert np.isclose(
+            out_comm["unnorm_power"].std() / out_comm["power"].std(),
+            out_comm.meta["unnorm_subcs"].std() / out_comm.meta["subcs"].std(),
+        )
 
     @pytest.mark.parametrize("use_common_mean", [True, False])
     @pytest.mark.parametrize("norm", ["frac", "abs", "none", "leahy"])

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -748,13 +748,18 @@ class TestPowerColor(object):
         with pytest.raises(ValueError, match="The maximum frequency is lower "):
             power_color(self.freq[good], self.power[good])
 
+        with pytest.raises(ValueError, match="freq_edges must have 5 elements"):
+            power_color(self.freq, self.power, freq_edges=[1])
+        with pytest.raises(ValueError, match="freq_edges must have 5 elements"):
+            power_color(self.freq, self.power, freq_edges=[1, 2, 3, 4, 5, 6])
+
     def test_bad_excluded_interval(self):
         for fte in ([1, 1.1, 3.0], [4], [[1, 1.1, 3.0]], 0, [[[1, 3]]]):
-            with pytest.raises(ValueError, match="frequencies_to_exclude must be of "):
-                power_color(self.freq, self.power, frequencies_to_exclude=fte)
+            with pytest.raises(ValueError, match="freqs_to_exclude must be of "):
+                power_color(self.freq, self.power, freqs_to_exclude=fte)
 
     def test_excluded_frequencies(self):
-        pc0, _, pc1, _ = power_color(self.freq, self.power, frequencies_to_exclude=[1, 1.1])
+        pc0, _, pc1, _ = power_color(self.freq, self.power, freqs_to_exclude=[1, 1.1])
         # The colors calculated with these frequency edges on a 1/f spectrum should be 1
         # The excluded frequency interval is small enough that the approximation should work
         assert np.isclose(pc0, 1, atol=0.001)

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -729,6 +729,11 @@ class TestPowerColor(object):
         with pytest.raises(ValueError, match="The maximum frequency is lower "):
             power_color(self.freq[good], self.power[good])
 
+    def test_bad_excluded_interval(self):
+        for fte in ([1, 1.1, 3.0], [4], [[1, 1.1, 3.0]], 0, [[[1, 3]]]):
+            with pytest.raises(ValueError, match="frequencies_to_exclude must be of "):
+                power_color(self.freq, self.power, frequencies_to_exclude=fte)
+
     def test_excluded_frequencies(self):
         pc0, _, pc1, _ = power_color(self.freq, self.power, frequencies_to_exclude=[1, 1.1])
         # The colors calculated with these frequency edges on a 1/f spectrum should be 1

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -721,6 +721,12 @@ class TestPowerColor(object):
         assert np.isclose(pc0, 1)
         assert np.isclose(pc1, 1)
 
+    def test_return_log(self):
+        pc0, _, pc1, _ = power_color(self.freq, self.power, return_log=True)
+        # The colors calculated with these frequency edges on a 1/f spectrum should be 1
+        assert np.isclose(pc0, 0, atol=0.001)
+        assert np.isclose(pc1, 0, atol=0.001)
+
     def test_bad_edges(self):
         good = self.freq > 1 / 255  # the smallest frequency is 1/256
         with pytest.raises(ValueError, match="The minimum frequency is larger "):
@@ -759,3 +765,16 @@ class TestPowerColor(object):
         assert np.isclose(pc1e, 1, atol=0.001)
         assert np.isclose(pc0e_err / pc0_err, 2, atol=0.001)
         assert np.isclose(pc1e_err / pc1_err, 2, atol=0.001)
+
+    def test_hue(self):
+        center = (4.51920, 0.453724)
+        log_center = np.log10(np.asarray(center))
+        for angle in np.radians(np.arange(0, 380, 20)):
+            factor = np.random.uniform(0.1, 10)
+            x = factor * np.cos(3 / 4 * np.pi - angle) + log_center[0]
+            y = factor * np.sin(3 / 4 * np.pi - angle) + log_center[1]
+            hue = hue_from_power_color(10**x, 10**y, center)
+            # Compare the angles in a safe way
+            c2 = (np.sin(hue) - np.sin(angle)) ** 2 + (np.cos(hue) - np.cos(angle)) ** 2
+            angle_diff = np.arccos((2.0 - c2) / 2.0)
+            assert np.isclose(angle_diff, 0, atol=0.001)

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -687,11 +687,12 @@ class TestIntegration(object):
 
     def test_power_integration_poisson(self):
         freq_range = [0.5, 2.5]
-        pow, powe = integrate_power_in_frequency_range(
-            self.freq, self.power, freq_range, poisson_level=1
-        )
-        assert np.allclose(pow, 2)
-        assert np.allclose(powe, 2 * np.sqrt(2))
+        for poisson_power in (1, np.ones_like(self.power)):
+            pow, powe = integrate_power_in_frequency_range(
+                self.freq, self.power, freq_range, poisson_power=poisson_power
+            )
+            assert np.allclose(pow, 2)
+            assert np.allclose(powe, 2 * np.sqrt(2))
 
     def test_power_integration_err(self):
         freq_range = [0.5, 2.5]

--- a/stingray/tests/test_fourier.py
+++ b/stingray/tests/test_fourier.py
@@ -735,3 +735,21 @@ class TestPowerColor(object):
         # The excluded frequency interval is small enough that the approximation should work
         assert np.isclose(pc0, 1, atol=0.001)
         assert np.isclose(pc1, 1, atol=0.001)
+
+    def test_with_power_err(self):
+        pc0, pc0_err, pc1, pc1_err = power_color(
+            self.freq,
+            self.power,
+            power_err=self.power / 2,
+        )
+        pc0e, pc0e_err, pc1e, pc1e_err = power_color(
+            self.freq,
+            self.power,
+            power_err=self.power,
+        )
+        assert np.isclose(pc0, 1, atol=0.001)
+        assert np.isclose(pc1, 1, atol=0.001)
+        assert np.isclose(pc0e, 1, atol=0.001)
+        assert np.isclose(pc1e, 1, atol=0.001)
+        assert np.isclose(pc0e_err / pc0_err, 2, atol=0.001)
+        assert np.isclose(pc1e_err / pc1_err, 2, atol=0.001)

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -71,7 +71,7 @@ class TestIO(object):
     def test_event_file_read_and_automatic_sort(self):
         """Test event file reading."""
         fname = os.path.join(datadir, "monol_testA_calib.evt")
-        with pytest.warns(AstropyUserWarning, match="No extensions found with a"):
+        with pytest.warns(AstropyUserWarning, match="No valid GTI extensions"):
             evdata = load_events_and_gtis(fname)
         fname_unsrt = os.path.join(datadir, "monol_testA_calib_unsrt.evt")
         with pytest.warns(UserWarning, match="not sorted. Sorting them for you"):
@@ -93,7 +93,7 @@ class TestIO(object):
     def test_event_file_read_additional_energy_cal(self):
         """Test event file reading."""
         fname = os.path.join(datadir, "monol_testA_calib.evt")
-        with pytest.warns(AstropyUserWarning, match="No extensions found with a"):
+        with pytest.warns(AstropyUserWarning, match="No valid GTI extensions"):
             vals = load_events_and_gtis(fname, additional_columns=["energy"])
         # These energies were calibrated with a different calibration than
         # returned from rough_calibration, on purpose! (notice the +1.)

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -1148,9 +1148,10 @@ class TestLightcurve(object):
     def test_plot_wrong_label_type(self):
         lc = Lightcurve(self.times, self.counts)
 
-        with pytest.raises(TypeError):
-            with pytest.warns(UserWarning, match="must be either a list or tuple") as w:
-                lc.plot(labels=123)
+        with pytest.warns(
+            UserWarning, match="``labels`` must be an iterable with two labels "
+        ) as w:
+            lc.plot(labels=123)
         plt.close("all")
 
     def test_plot_labels_index_error(self):
@@ -1158,7 +1159,9 @@ class TestLightcurve(object):
         with pytest.warns(UserWarning) as w:
             lc.plot(labels=("x"))
 
-            assert np.any(["must have two labels" in str(wi.message) for wi in w])
+            assert np.any(
+                ["``labels`` must be an iterable with two labels " in str(wi.message) for wi in w]
+            )
         plt.close("all")
 
     def test_plot_default_filename(self):

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -1175,11 +1175,16 @@ class TestLightcurve(object):
         os.unlink("lc.png")
         plt.close("all")
 
-    def test_plot_axis(self):
+    def test_plot_axis_arg(self):
         lc = Lightcurve(self.times, self.counts)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=UserWarning)
+        with pytest.warns(DeprecationWarning, match="argument is deprecated in favor"):
             lc.plot(axis=[0, 1, 0, 100])
+        assert plt.fignum_exists(1)
+        plt.close("all")
+
+    def test_plot_axis_limits_arg(self):
+        lc = Lightcurve(self.times, self.counts)
+        lc.plot(axis_limits=[0, 1, 0, 100])
         assert plt.fignum_exists(1)
         plt.close("all")
 

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -1110,13 +1110,13 @@ class TestDynamicalPowerspectrum(object):
         with pytest.raises(ValueError):
             dps.rebin_frequency(df_new=dps.df / 2.0)
 
-    def test_rebin_time_default_method(self):
+    def test_rebin_time_sum_method(self):
         segment_size = 3
         dt_new = 6.0
         rebin_time = np.array([2.5, 8.5])
         rebin_dps = np.array([[1.73611111, 0.81018519]])
         dps = DynamicalPowerspectrum(self.lc_test, segment_size=segment_size)
-        new_dps = dps.rebin_time(dt_new=dt_new)
+        new_dps = dps.rebin_time(dt_new=dt_new, method="sum")
         assert np.allclose(new_dps.time, rebin_time)
         assert np.allclose(new_dps.dyn_ps, rebin_dps)
         assert np.isclose(new_dps.dt, dt_new)
@@ -1138,7 +1138,7 @@ class TestDynamicalPowerspectrum(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             dps = DynamicalPowerspectrum(self.lc, segment_size=segment_size)
-        new_dps = dps.rebin_frequency(df_new=df_new)
+        new_dps = dps.rebin_frequency(df_new=df_new, method="sum")
         assert np.allclose(new_dps.freq, rebin_freq)
         assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.01)
         assert np.isclose(new_dps.df, df_new)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -1034,6 +1034,7 @@ class TestDynamicalPowerspectrum(object):
 
         dps_ev = DynamicalPowerspectrum(ev, segment_size=10, sample_time=self.lc.dt)
         assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
+        dps_ev.power_colors(frequency_edges=[1 / 5, 1 / 2, 1, 2.0, 16.0])
 
     def test_with_long_seg_size(self):
         with pytest.raises(ValueError):

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -1034,7 +1034,7 @@ class TestDynamicalPowerspectrum(object):
 
         dps_ev = DynamicalPowerspectrum(ev, segment_size=10, sample_time=self.lc.dt)
         assert np.allclose(dps.dyn_ps, dps_ev.dyn_ps)
-        dps_ev.power_colors(frequency_edges=[1 / 5, 1 / 2, 1, 2.0, 16.0])
+        dps_ev.power_colors(freq_edges=[1 / 5, 1 / 2, 1, 2.0, 16.0])
 
     def test_rms_is_correct(self):
         lc = copy.deepcopy(self.lc)

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -1299,7 +1299,7 @@ def nearest_power_of_two(x):
     return x_nearest
 
 
-def find_nearest(array, value):
+def find_nearest(array, value, side="left"):
     """
     Return the array value that is closest to the input value (Abigail Stevens:
     Thanks StackOverflow!)
@@ -1313,6 +1313,11 @@ def find_nearest(array, value):
     value : int or float
         The value you want to find the closest to in the array.
 
+    Other Parameters
+    ----------------
+    side : str
+        Look at the ``numpy.searchsorted`` documentation for more information.
+
     Returns
     -------
     array[idx] : int or float
@@ -1322,7 +1327,7 @@ def find_nearest(array, value):
         The index of the array of the closest value.
 
     """
-    idx = np.searchsorted(array, value, side="left")
+    idx = np.searchsorted(array, value, side=side)
     if idx == len(array) or np.fabs(value - array[idx - 1]) < np.fabs(value - array[idx]):
         return array[idx - 1], idx - 1
     else:


### PR DESCRIPTION
This PR introduces Power colors à la Heil et al. 2015. Now we can calculate *power colors* (both linear and logarithmic) and the *hue*, also defined according to the same paper by Heil+. I added the relevant functions in `fourier.py`, and tested them in `test_fourier.py`
Moreover, Power colors can be directly calculated from the spectra in a `DynamicalCrossspectrum` or `DynamicalPowerspectrum`, with the new methods `power_colors`.

In order to make power colors more usable, we also needed a  simple way to combine contiguous power spectra to improve the S/N. I added a function to `DynamicalCrossspectrum` to combine n contiguous spectra together, regardless of their distance in time (e.g. two intervals on the opposite side of an occultation in NICER).

Demonstration here: https://github.com/StingraySoftware/notebooks/pull/76

![image](https://github.com/StingraySoftware/stingray/assets/7190189/9baa4dfe-309c-48b7-aff3-4ae70e5859c2)

![image](https://github.com/StingraySoftware/stingray/assets/7190189/82a8fe23-b218-4557-a1d2-427ea0c9b501)


