### PR TITLE
Fix security issue (dependabot issue 1), use new M1 Mac runner

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -86,8 +86,14 @@ jobs:
             tox_env: 'py311-test-cov'
             experimental: false
 
-          - name: Mac OS, Py3.11
+          - name: Mac OS M1, Py3.11
             os: macos-14
+            python: '3.11'
+            tox_env: 'py311-test'
+            experimental: false
+
+          - name: Mac OS, Py3.11
+            os: macos-latest
             python: '3.11'
             tox_env: 'py311-test'
             experimental: false

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -87,7 +87,7 @@ jobs:
             experimental: false
 
           - name: Mac OS, Py3.11
-            os: macos-latest
+            os: macos-14
             python: '3.11'
             tox_env: 'py311-test'
             experimental: false

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -134,7 +134,7 @@ For development work, you will need the following extra libraries:
 + pytest
 + pytest-astropy
 + tox
-+ jinja2<=3.0.0
++ jinja2==3.1.3
 + docutils
 + sphinx-astropy
 + nbsphinx>=0.8.3,!=0.8.8

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-jinja2<=3.0.0
+jinja2==3.1.3
 docutils
 sphinx-astropy
 nbsphinx>=0.8.3,!=0.8.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ test =
     pytest
     pytest-astropy
 docs =
-    jinja2<=3.0.0
+    jinja2==3.1.3
     docutils
     sphinx-astropy
     nbsphinx>=0.8.3,!=0.8.8


### PR DESCRIPTION
Fixes the security issue we are getting lately: https://github.com/StingraySoftware/stingray/security/dependabot/1

Also, adds a new M1 Mac runner for tests: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/ 