### PR TITLE
Fix count rate estimation error for particularly bad GTIs

### DIFF
--- a/stingray/base.py
+++ b/stingray/base.py
@@ -1,4 +1,5 @@
 """Base classes"""
+
 from __future__ import annotations
 
 from collections.abc import Iterable
@@ -2289,12 +2290,15 @@ class StingrayTimeseries(StingrayObject):
                 high_time_arr = filtered_times[filt_hig_idx : buffer_size + filt_hig_idx]
                 high_time_arr = high_time_arr[high_time_arr < bti[1] + buffer_size]
 
-                ctrate_low = ctrate_high = np.nan
-
                 if len(low_time_arr) > 0 and (filt_low_t - low_time_arr[0]) > 0:
                     ctrate_low = np.count_nonzero(low_time_arr) / (filt_low_t - low_time_arr[0])
+                else:
+                    ctrate_low = np.nan
                 if len(high_time_arr) > 0 and (high_time_arr[-1] - filt_hig_t) > 0:
                     ctrate_high = np.count_nonzero(high_time_arr) / (high_time_arr[-1] - filt_hig_t)
+                else:
+                    ctrate_high = np.nan
+
                 if not np.isfinite(ctrate_low) and not np.isfinite(ctrate_high):
                     warnings.warn(
                         f"No valid data around to simulate the time series in interval "

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2286,11 +2286,17 @@ class StingrayTimeseries(StingrayObject):
             else:
                 low_time_arr = filtered_times[max(filt_low_idx - buffer_size, 0) : filt_low_idx]
                 high_time_arr = filtered_times[filt_hig_idx : buffer_size + filt_hig_idx]
-
-                ctrate = (
-                    np.count_nonzero(low_time_arr) / (filt_low_t - low_time_arr[0])
-                    + np.count_nonzero(high_time_arr) / (high_time_arr[-1] - filt_hig_t)
-                ) / 2
+                ctrate_low = ctrate_high = np.nan
+                if len(low_time_arr) > 0:
+                    ctrate_low = np.count_nonzero(low_time_arr) / (filt_low_t - low_time_arr[0])
+                if len(high_time_arr) > 0:
+                    ctrate_high = np.count_nonzero(high_time_arr) / (high_time_arr[-1] - filt_hig_t)
+                ctrate = np.nanmean([ctrate_low, ctrate_high])
+                if not np.isfinite(ctrate):
+                    warnings.warn(
+                        f"No valid data around to simulate the time series in interval {bti[0]}-{bti[1]}. Skipping."
+                    )
+                    continue
                 nevents = rs.poisson(ctrate * (bti[1] - bti[0]))
                 local_new_times = rs.uniform(bti[0], bti[1], nevents)
             new_times.append(local_new_times)

--- a/stingray/base.py
+++ b/stingray/base.py
@@ -2285,18 +2285,24 @@ class StingrayTimeseries(StingrayObject):
                 nevents = local_new_times.size
             else:
                 low_time_arr = filtered_times[max(filt_low_idx - buffer_size, 0) : filt_low_idx]
+                low_time_arr = low_time_arr[low_time_arr > bti[0] - buffer_size]
                 high_time_arr = filtered_times[filt_hig_idx : buffer_size + filt_hig_idx]
+                high_time_arr = high_time_arr[high_time_arr < bti[1] + buffer_size]
+
                 ctrate_low = ctrate_high = np.nan
-                if len(low_time_arr) > 0:
+
+                if len(low_time_arr) > 0 and (filt_low_t - low_time_arr[0]) > 0:
                     ctrate_low = np.count_nonzero(low_time_arr) / (filt_low_t - low_time_arr[0])
-                if len(high_time_arr) > 0:
+                if len(high_time_arr) > 0 and (high_time_arr[-1] - filt_hig_t) > 0:
                     ctrate_high = np.count_nonzero(high_time_arr) / (high_time_arr[-1] - filt_hig_t)
-                ctrate = np.nanmean([ctrate_low, ctrate_high])
-                if not np.isfinite(ctrate):
+                if not np.isfinite(ctrate_low) and not np.isfinite(ctrate_high):
                     warnings.warn(
-                        f"No valid data around to simulate the time series in interval {bti[0]}-{bti[1]}. Skipping."
+                        f"No valid data around to simulate the time series in interval "
+                        f"{bti[0]:g}-{bti[1]:g}. Skipping. Please check that the buffer size is "
+                        f"adequate."
                     )
                     continue
+                ctrate = np.nanmean([ctrate_low, ctrate_high])
                 nevents = rs.poisson(ctrate * (bti[1] - bti[0]))
                 local_new_times = rs.uniform(bti[0], bti[1], nevents)
             new_times.append(local_new_times)

--- a/stingray/tests/test_base.py
+++ b/stingray/tests/test_base.py
@@ -1327,6 +1327,18 @@ class TestFillBTI(object):
         for attr in ["time", "energy", "blablas"]:
             assert np.allclose(getattr(new_masked, attr), getattr(filt_masked, attr))
 
+    def test_no_counts_in_buffer(self):
+        ev_like_filt = copy.deepcopy(self.ev_like)
+        # I introduce a small gap in the GTIs
+        ev_like_filt.gti = np.asarray([[0, 490], [491, 498], [500, 505], [510, 520], [522, 700]])
+
+        # I empty out two GTIs
+        bad = (ev_like_filt.time > 490) & (ev_like_filt.time < 510)
+        ev_like_filt = ev_like_filt.apply_mask(~bad)
+
+        with pytest.warns(UserWarning, match="simulate the time series in interval 498-500"):
+            ev_like_filt.fill_bad_time_intervals(max_length=3, buffer_size=2)
+
     def test_lc_like(self):
         lc_like_filt = copy.deepcopy(self.lc_like)
         # I introduce a small gap in the GTIs


### PR DESCRIPTION
In `StingrayTimeseries.fill_bad_time_intervals`, when the buffer size is small and count rates are low, there was the possibility that the count rate estimation failed with a numpy error. E.g., the test `test_no_counts_in_buffer` I added failed. Here, I catch the condition and warn that this is happening. Also, I made the estimation more robust when only one of the GTIs on the side of the bad time intervals has good data.