### PR TITLE
Fix deadtime model

### DIFF
--- a/docs/changes/800.trivial.rst
+++ b/docs/changes/800.trivial.rst
@@ -1,1 +1,1 @@
-Dead time model fixes: stop summing when going below computer precision; better plotting of check_A and check_B
+Dead time model fixes: more stable computations, a friendlier API for the non-paralyzable model, better plotting of check_A and check_B

--- a/docs/changes/800.trivial.rst
+++ b/docs/changes/800.trivial.rst
@@ -1,0 +1,1 @@
+Dead time model fixes: stop summing when going below computer precision; better plotting of check_A and check_B

--- a/docs/deadtime.rst
+++ b/docs/deadtime.rst
@@ -8,5 +8,5 @@ In this tutorial, we will show the effects of dead time on X-ray observations, a
 .. toctree::
    :maxdepth: 2
 
-   notebooks/Deadtime/Check dead time model in Stingray.ipynb
-   notebooks/Deadtime/Check FAD correction in Stingray.ipynb
+   notebooks/Deadtime/Dead time model in Stingray.ipynb
+   notebooks/Deadtime/FAD correction in Stingray.ipynb

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -295,9 +295,12 @@ def pds_model_zhang(N, rate, td, tb, limit_k=60, rate_is_incident=True):
     power : array of floats
         Power spectrum
     """
-    tau = 1 / rate
-
-    r0 = r_det(td, rate) if rate_is_incident else rate
+    if rate_is_incident:
+        tau = 1 / rate
+        r0 = r_det(td, rate)
+    else:
+        r0 = rate
+        tau = 1 / r_in(td, rate)
 
     # Nph = N / tau
     logger.info("Calculating PDS model (update)")
@@ -365,9 +368,14 @@ def non_paralyzable_dead_time_model(
 
     n_bins = n_approx if n_approx is not None else np.size(freqs)
 
-    # Nph = N / tau
-    logger.info("Calculating PDS model (update)")
-    zh_f, zh_p = pds_model_zhang(n_bins, rate, dead_time, bin_time, limit_k=limit_k)
+    zh_f, zh_p = pds_model_zhang(
+        int(n_bins),
+        (rate + background_rate),
+        dead_time,
+        bin_time,
+        limit_k=limit_k,
+        rate_is_incident=False,
+    )
 
     # Rescale by the source rate wrt background rate
     if background_rate > 0:

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -30,14 +30,14 @@ __all__ = [
 
 
 @njit()
-def sterling_factor(m):
-    return (
-        1
-        + STERLING_PARAMETERS[0] / m
-        + STERLING_PARAMETERS[1] / m**2
-        + STERLING_PARAMETERS[2] / m**3
-        + STERLING_PARAMETERS[3] / m**4
-    )
+def _stirling_factor(m):
+    """First few terms of series expansion appearing in Stirling's approximation."""
+    fact = 1.0
+    power = 1.0
+    for i in range(1, 5):
+        power *= m
+        fact += STERLING_PARAMETERS[i - 1] / power
+    return fact
 
 
 @njit()
@@ -79,7 +79,7 @@ def e_m_x_x_over_factorial(x, m):
         return np.exp(-x) * x**m * __INVERSE_FACTORIALS[m]
 
     # Use Stirling's approximation
-    return 1.0 / np.sqrt(TWOPI * m) * np.power(x * np.exp(1 - x / m) / m, m) / sterling_factor(m)
+    return 1.0 / np.sqrt(TWOPI * m) * np.power(x * np.exp(1 - x / m) / m, m) / _stirling_factor(m)
 
 
 def r_in(td, r_0):

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -64,7 +64,7 @@ def e_m_x_x_over_factorial(x, m):
         return 1.0
 
     # For decently small numbers, use the direct formula
-    if m * np.log10(x) < 100:
+    if m * np.log10(x) < 50:
         return np.exp(-x) * x**m * __INVERSE_FACTORIALS[m]
 
     # Use Stirling's approximation

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -188,10 +188,6 @@ def check_B(rate, td, tb, max_k=100, save_to=None, linthresh=0.000001):
         plt.close(fig)
 
 
-def find_ideal_limit_k(rate, td, tb, max_k=1000, threshold=0.0001):
-    """Find the ideal limit_k for the B and A function."""
-
-
 @njit(parallel=True)
 def _inner_loop_pds_zhang(N, tau, r0, td, tb, limit_k=60):
     """Calculate the power spectrum, as per Eq. 44 in Zhang+95."""

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -25,7 +25,6 @@ __all__ = [
     "non_paralyzable_dead_time_model",
     "check_A",
     "check_B",
-    "heaviside",
 ]
 
 

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -19,18 +19,18 @@ STERLING_PARAMETERS = np.array([1 / 12, 1 / 288, -139 / 51840, -571 / 2488320])
 
 
 @njit()
-def sterling_factor(l):
+def sterling_factor(m):
     return (
         1
-        + STERLING_PARAMETERS[0] / l
-        + STERLING_PARAMETERS[1] / l**2
-        + STERLING_PARAMETERS[2] / l**3
-        + STERLING_PARAMETERS[3] / l**4
+        + STERLING_PARAMETERS[0] / m
+        + STERLING_PARAMETERS[1] / m**2
+        + STERLING_PARAMETERS[2] / m**3
+        + STERLING_PARAMETERS[3] / m**4
     )
 
 
 @njit()
-def e_m_x_x_over_factorial(x, l):
+def e_m_x_x_over_factorial(x, m):
     r"""Approximate the large number ratio in Eq. 34.
 
     The original formula for :math:`G_n` (eq. 34 in Zhang+95) has factors of the kind
@@ -48,26 +48,26 @@ def e_m_x_x_over_factorial(x, l):
 
     .. math::
 
-       \frac{e^{-x} x^l}{l!} \approx \frac{1}{A(l)\sqrt{2\pi l}} \left(\frac{x e}{l}\right)^l e^{-x}
+       \frac{e^{-x} x^l}{l!} \approx \frac{1}{A(l)\sqrt{2\pi l}}\left(\frac{x e}{l}\right)^l e^{-x}
 
     and then, bringing the exponential into the parenthesis
 
     .. math::
 
-       \frac{e^{-x} x^l}{l!} \approx \frac{1}{A(l)\sqrt{2\pi l}} \left(\frac{x e^{1-x/l}}{l}\right)^l
+       \frac{e^{-x} x^l}{l!}\approx\frac{1}{A(l)\sqrt{2\pi l}} \left(\frac{x e^{1-x/l}}{l}\right)^l
 
     The function inside the brackets has a maximum around :math:`x \approx l` and is well-behaved,
     allowing to approximate the product for large :math:`l` without the need to calculate the
     factorial or the exponentials directly.
     """
-    if x == 0.0 and l == 0:
+    if x == 0.0 and m == 0:
         return 1.0
 
-    if l < 100:
-        return np.exp(-x) * x**l * __INVERSE_FACTORIALS[l]
+    if m < 100:
+        return np.exp(-x) * x**m * __INVERSE_FACTORIALS[m]
 
     # Use Stirling's approximation
-    return 1.0 / np.sqrt(TWOPI * l) * np.power(x * np.exp(1 - x / l) / l, l) / sterling_factor(l)
+    return 1.0 / np.sqrt(TWOPI * m) * np.power(x * np.exp(1 - x / m) / m, m) / sterling_factor(m)
 
 
 def r_in(td, r_0):
@@ -87,12 +87,12 @@ def Gn(x, n):
     """Term in Eq. 34 in Zhang+95."""
     s = 0.0
 
-    for l in range(0, n):
-        new_val = e_m_x_x_over_factorial(x, l) * (n - l)
+    for m in range(0, n):
+        new_val = e_m_x_x_over_factorial(x, m) * (n - m)
 
         s += new_val
         # The curve above has a maximum around x~l
-        if x != 0 and l > 2 * x and -np.log10(np.abs(new_val / s)) > PRECISION:
+        if x != 0 and m > 2 * x and -np.log10(np.abs(new_val / s)) > PRECISION:
             break
 
     return s

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -18,6 +18,16 @@ TWOPI = np.pi * 2
 
 STERLING_PARAMETERS = np.array([1 / 12, 1 / 288, -139 / 51840, -571 / 2488320])
 
+__all__ = [
+    "r_det",
+    "r_in",
+    "pds_model_zhang",
+    "non_paralyzable_dead_time_model",
+    "check_A",
+    "check_B",
+    "heaviside",
+]
+
 
 @njit()
 def sterling_factor(m):

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -377,8 +377,6 @@ def non_paralyzable_dead_time_model(
 
     Returns
     -------
-    freqs : array of floats
-        Frequency array
     power : array of floats
         Power spectrum
     """
@@ -402,6 +400,7 @@ def non_paralyzable_dead_time_model(
         limit_k=limit_k,
         rate_is_incident=False,
     )
+
     # Rescale by the source rate wrt background rate
     if background_rate > 0:
         zh_p = (zh_p - 2) * rate / (rate + background_rate) + 2

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -385,8 +385,8 @@ def non_paralyzable_dead_time_model(
 
     if rate + background_rate > 1 / dead_time:
         raise ValueError(
-            "The sum of the source and background count rates is larger than the inverse of the dead time. "
-            "This is not a physical situation. Please check your input."
+            "The sum of the source and background count rates is larger than the inverse "
+            "of the dead time. This is not a physical situation. Please check your input."
         )
 
     if bin_time is None:

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -63,7 +63,8 @@ def e_m_x_x_over_factorial(x, m):
     if x == 0.0 and m == 0:
         return 1.0
 
-    if m < 100:
+    # For decently small numbers, use the direct formula
+    if m * np.log10(x) < 100:
         return np.exp(-x) * x**m * __INVERSE_FACTORIALS[m]
 
     # Use Stirling's approximation

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -64,7 +64,7 @@ def e_m_x_x_over_factorial(x, m):
         return 1.0
 
     # For decently small numbers, use the direct formula
-    if m * np.log10(x) < 50:
+    if m < 50 or (x > 1 and m * max(np.log10(x), 1) < 50):
         return np.exp(-x) * x**m * __INVERSE_FACTORIALS[m]
 
     # Use Stirling's approximation
@@ -93,7 +93,7 @@ def Gn(x, n):
 
         s += new_val
         # The curve above has a maximum around x~l
-        if x != 0 and m > 2 * x and -np.log10(np.abs(new_val)) > PRECISION:
+        if x != 0 and m > 2 * x and -np.log10(np.abs(new_val / s)) > PRECISION:
             break
 
     return s
@@ -126,8 +126,7 @@ def h(k, n, td, tb, tau):
         return 0.0
 
     val = k - n * (td + tau) / tb + tau / tb * Gn(factor / tau, n)
-    # if factor == 0:
-    #     print("h", k, n, td, tb, tau, factor, val)
+
     return val
 
 
@@ -306,8 +305,11 @@ def pds_model_zhang(N, rate, td, tb, limit_k=60):
     logger.info("Calculating PDS model (update)")
     P = _inner_loop_pds_zhang(N, tau, r0, td, tb, limit_k=limit_k)
 
-    if tb > 100 * td:
-        warnings.warn(f"The bin time is much larger than the dead time. tb={tb / td:.2f} * td")
+    if tb > 10 * td:
+        warnings.warn(
+            f"The bin time is much larger than the dead time. "
+            f" Calculations might be slow. tb={tb / td:.2f} * td"
+        )
 
     maxf = 0.5 / tb
     df = maxf / len(P)

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -111,23 +111,6 @@ def Gn(x, n):
 
 
 @njit()
-def heaviside(x):
-    """Heaviside function. Returns 1 if x>0, and 0 otherwise.
-
-    Examples
-    --------
-    >>> heaviside(2)
-    1
-    >>> heaviside(-1)
-    0
-    """
-    if x >= 0:
-        return 1
-    else:
-        return 0
-
-
-@njit()
 def h(k, n, td, tb, tau):
     """Term in Eq. 35 in Zhang+95."""
     # Typo in Zhang+95 corrected. k * tb, not k * td

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -181,6 +181,7 @@ def check_A(rate, td, tb, max_k=100, save_to=None, linthresh=0.000001):
     A_values = A(k_values, r0, td, tb, tau)
 
     plt.plot(k_values, A_values - limit, color="k")
+    plt.semilogx()
     plt.yscale("symlog", linthresh=linthresh)
     plt.axhline(0, ls="--", color="k")
     plt.xlabel("$k$")
@@ -235,6 +236,7 @@ def check_B(rate, td, tb, max_k=100, save_to=None, linthresh=0.000001):
     B_values = B(k_values, r0, td, tb, tau, limit_k=max_k)
     plt.plot(k_values, B_values, color="k")
     plt.axhline(0, ls="--", color="k")
+    plt.semilogx()
     plt.yscale("symlog", linthresh=linthresh)
     plt.xlabel("$k$")
     plt.ylabel("$B_k$")

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -93,7 +93,7 @@ def Gn(x, n):
 
         s += new_val
         # The curve above has a maximum around x~l
-        if x != 0 and m > 2 * x and -np.log10(np.abs(new_val / s)) > PRECISION:
+        if x != 0 and m > 2 * x and -np.log10(np.abs(new_val)) > PRECISION:
             break
 
     return s

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -1,11 +1,14 @@
 from stingray.utils import njit, prange
+
 from stingray.loggingconfig import setup_logger
+
+from collections.abc import Iterable
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.special import factorial
 
 
-__FACTORIALS = factorial(np.arange(160))
+__FACTORIALS = factorial(np.arange(700))
 
 logger = setup_logger()
 
@@ -22,12 +25,19 @@ def r_det(td, r_i):
     return 1.0 / (tau + td)
 
 
+PRECISION = np.finfo(float).precision
+
+
 @njit()
 def Gn(x, n):
     """Term in Eq. 34 in Zhang+95."""
-    s = 0
+    s = 0.0
     for l in range(0, n):
-        s += (n - l) / __FACTORIALS[l] * x**l
+        new_val = (n - l) / __FACTORIALS[l] * x**l
+        if -np.log10(new_val) > PRECISION:
+            break
+        s += new_val
+
     return np.exp(-x) * s
 
 
@@ -53,8 +63,10 @@ def h(k, n, td, tb, tau):
     """Term in Eq. 35 in Zhang+95."""
     # Typo in Zhang+95 corrected. k * tb, not k * td
     if k * tb < n * td:
-        return 0
-    return k - n * (td + tau) / tb + tau / tb * Gn((k * tb - n * td) / tau, n)
+        return 0.0
+    factor = k * tb - n * td
+    val = k - n * (td + tau) / tb + tau / tb * Gn(factor / tau, n)
+    return val
 
 
 INFINITE = 100
@@ -63,7 +75,7 @@ INFINITE = 100
 @njit()
 def A0(r0, td, tb, tau):
     """Term in Eq. 38 in Zhang+95."""
-    s = 0
+    s = 0.0
     for n in range(1, INFINITE):
         s += h(1, n, td, tb, tau)
 
@@ -71,19 +83,35 @@ def A0(r0, td, tb, tau):
 
 
 @njit()
-def A(k, r0, td, tb, tau):
+def A_single_k(k, r0, td, tb, tau):
     """Term in Eq. 39 in Zhang+95."""
     if k == 0:
         return A0(r0, td, tb, tau)
     # Equation 39
-    s = 0
-    for n in range(1, INFINITE):
-        s += h(k + 1, n, td, tb, tau) - 2 * h(k, n, td, tb, tau) + h(k - 1, n, td, tb, tau)
+    s = 0.0
+    for n in range(1, INFINITE * 1000):
+        new_val = h(k + 1, n, td, tb, tau) - 2 * h(k, n, td, tb, tau) + h(k - 1, n, td, tb, tau)
+        s += new_val
+        if (n > k * tb / td) and -np.log10(new_val) > PRECISION:
+            break
 
     return r0 * tb * s
 
 
-def check_A(rate, td, tb, max_k=100, save_to=None):
+def A(k, r0, td, tb, tau):
+    """Term in Eq. 39 in Zhang+95."""
+    if isinstance(k, Iterable):
+        return np.array([A_single_k(ki, r0, td, tb, tau) for ki in k])
+    return A_single_k(k, r0, td, tb, tau)
+
+
+def limit_A(rate, td, tb):
+    """Limit of A for k->infty, as per Eq. 43 in Zhang+95."""
+    r0 = r_det(td, rate)
+    return r0**2 * tb**2
+
+
+def check_A(rate, td, tb, max_k=100, save_to=None, linthresh=0.000001):
     """Test that A is well-behaved.
 
     Check that Ak ->r0**2tb**2 for k->infty, as per Eq. 43 in
@@ -92,52 +120,76 @@ def check_A(rate, td, tb, max_k=100, save_to=None):
     tau = 1 / rate
     r0 = r_det(td, rate)
 
-    value = r0**2 * tb**2
+    limit = limit_A(rate, td, tb)
     fig = plt.figure()
-    for k in range(max_k):
-        plt.scatter(k, A(k, r0, td, tb, tau), color="k")
-    plt.axhline(value, ls="--", color="k")
+
+    k_values = np.arange(0, max_k + 1)
+    A_values = A(k_values, r0, td, tb, tau)
+
+    plt.plot(k_values, A_values - limit, color="k")
+    plt.yscale("symlog", linthresh=linthresh)
+    plt.axhline(0, ls="--", color="k")
     plt.xlabel("$k$")
-    plt.ylabel("$A_k$")
+    plt.ylabel("$A_k - r_0^2 t_b^2$")
     if save_to is not None:
         plt.savefig(save_to)
         plt.close(fig)
 
 
 @njit()
-def B(k, r0, td, tb, tau):
+def B_raw(k, r0, td, tb, tau):
     """Term in Eq. 45 in Zhang+95."""
     if k == 0:
-        return 2 * (A(0, r0, td, tb, tau) - r0**2 * tb**2) / (r0 * tb)
+        return 2 * (A_single_k(0, r0, td, tb, tau) - r0**2 * tb**2) / (r0 * tb)
 
-    return 4 * (A(k, r0, td, tb, tau) - r0**2 * tb**2) / (r0 * tb)
+    return 4 * (A_single_k(k, r0, td, tb, tau) - r0**2 * tb**2) / (r0 * tb)
 
 
 @njit()
-def safe_B(k, r0, td, tb, tau, limit_k=60):
+def safe_B_single_k(k, r0, td, tb, tau, limit_k=60):
     """Term in Eq. 39 in Zhang+95, with a cut in the maximum k.
 
     This can be risky. Only use if B is really 0 for high k.
     """
     if k > limit_k:
-        return 0
-    return B(k, r0, td, tb, tau)
+        return 0.0
+    return B_raw(k, r0, td, tb, tau)
 
 
-def check_B(rate, td, tb, max_k=100, save_to=None):
+def safe_B(k, r0, td, tb, tau, limit_k=60):
+    """Term in Eq. 39 in Zhang+95, with a cut in the maximum k.
+
+    This can be risky. Only use if B is really 0 for high k.
+    """
+    if isinstance(k, Iterable):
+        return np.array([safe_B_single_k(ki, r0, td, tb, tau, limit_k=limit_k) for ki in k])
+    return safe_B_single_k(int(k), r0, td, tb, tau, limit_k=limit_k)
+
+
+def B(k, r0, td, tb, tau, limit_k=60):
+    return safe_B(k, r0, td, tb, tau, limit_k=limit_k)
+
+
+def check_B(rate, td, tb, max_k=100, save_to=None, linthresh=0.000001):
     """Check that B->0 for k->infty."""
     tau = 1 / rate
     r0 = r_det(td, rate)
 
     fig = plt.figure()
-    for k in range(max_k):
-        plt.scatter(k, B(k, r0, td, tb, tau), color="k")
+    k_values = np.arange(0, max_k + 1)
+    B_values = B(k_values, r0, td, tb, tau, limit_k=max_k)
+    plt.plot(k_values, B_values, color="k")
     plt.axhline(0, ls="--", color="k")
+    plt.yscale("symlog", linthresh=linthresh)
     plt.xlabel("$k$")
     plt.ylabel("$B_k$")
     if save_to is not None:
         plt.savefig(save_to)
         plt.close(fig)
+
+
+def find_ideal_limit_k(rate, td, tb, max_k=1000, threshold=0.0001):
+    """Find the ideal limit_k for the B and A function."""
 
 
 @njit(parallel=True)
@@ -150,11 +202,11 @@ def _inner_loop_pds_zhang(N, tau, r0, td, tb, limit_k=60):
             eq8_sum += (
                 (N - k)
                 / N
-                * safe_B(k, r0, td, tb, tau, limit_k=limit_k)
+                * safe_B_single_k(k, r0, td, tb, tau, limit_k=limit_k)
                 * np.cos(2 * np.pi * j * k / N)
             )
 
-        P[j] = safe_B(0, r0, td, tb, tau) + eq8_sum
+        P[j] = safe_B_single_k(0, r0, td, tb, tau) + eq8_sum
 
     return P
 

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -520,7 +520,7 @@ def non_paralyzable_dead_time_model(
     power : array of floats
         Power spectrum
     """
-
+    print(rate, background_rate, 1 / dead_time)
     if rate + background_rate > 1 / dead_time:
         raise ValueError(
             "The sum of the source and background count rates is larger than the inverse "

--- a/stingray/deadtime/model.py
+++ b/stingray/deadtime/model.py
@@ -520,7 +520,6 @@ def non_paralyzable_dead_time_model(
     power : array of floats
         Power spectrum
     """
-    print(rate, background_rate, 1 / dead_time)
     if rate + background_rate > 1 / dead_time:
         raise ValueError(
             "The sum of the source and background count rates is larger than the inverse "

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -77,14 +77,16 @@ def test_non_paralyzable_model_accurate(rates):
     assert np.isclose(np.mean(ratio), 1, rtol=0.01)
 
 
-def test_checkA():
-    check_A(300, 2.5e-3, 0.001, max_k=100, save_to="check_A.png")
+@pytest.mark.parametrize("is_incident", [True, False])
+def test_checkA(is_incident):
+    check_A(300, 2.5e-3, 0.001, max_k=100, save_to="check_A.png", rate_is_incident=is_incident)
     assert os.path.exists("check_A.png")
     os.unlink("check_A.png")
 
 
-def test_checkB():
-    check_B(300, 2.5e-3, 0.001, max_k=100, save_to="check_B.png")
+@pytest.mark.parametrize("is_incident", [True, False])
+def test_checkB(is_incident):
+    check_B(300, 2.5e-3, 0.001, max_k=100, save_to="check_B.png", rate_is_incident=is_incident)
     assert os.path.exists("check_B.png")
     os.unlink("check_B.png")
 
@@ -107,3 +109,12 @@ def test_A_and_B_array(tb):
 def test_pds_model_warns():
     with pytest.warns(UserWarning, match="The bin time is much larger than the "):
         pds_model_zhang(10, 100.0, 2.5e-3, 0.1, limit_k=10)
+
+
+def test_non_paralyzable_model_fail_bad_rate():
+    """Fail if combined rate is larger than 1 / deadtime."""
+    with pytest.raises(
+        ValueError,
+        match="The sum of the source and background count rates is larger than the inverse",
+    ):
+        non_paralyzable_dead_time_model(np.arange(10), 2.5e-3, rate=300, background_rate=300)

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -35,7 +35,7 @@ def test_deadtime_conversion():
     np.testing.assert_almost_equal(rin, original_rate)
 
 
-@pytest.mark.parametrize("rate", [1.0, 1000.0])
+@pytest.mark.parametrize("rate", [1.0, 100.0])
 def test_zhang_model_accurate(rate):
     bintime = 0.0002
     deadtime = 2.5e-3
@@ -66,11 +66,11 @@ def test_checkB():
     os.unlink("check_B.png")
 
 
-@pytest.mark.parametrize("rate", [0.1, 1000.0])
 @pytest.mark.parametrize("tb", [0.0001, 0.1])
-def test_A_and_B_array(rate, tb):
+def test_A_and_B_array(tb):
     td = 2.5e-3
     ks = np.array([1, 5, 20, 60])
+    rate = 10
     tau = 1 / rate
     r0 = r_det(td, rate)
     assert np.array_equal(np.array([A(k, r0, td, tb, tau) for k in ks]), A(ks, r0, td, tb, tau))

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -94,7 +94,7 @@ def test_checkB(is_incident):
 @pytest.mark.parametrize("tb", [0.0001, 0.1])
 def test_A_and_B_array(tb):
     td = 2.5e-3
-    ks = np.array([1, 5, 20, 60])
+    ks = np.array([1, 5, 20, 70])
     rate = 10
     tau = 1 / rate
     r0 = r_det(td, rate)

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -35,7 +35,7 @@ def test_deadtime_conversion():
     np.testing.assert_almost_equal(rin, original_rate)
 
 
-@pytest.mark.parametrize("rate", [1.0, 2000.0])
+@pytest.mark.parametrize("rate", [1.0, 1000.0])
 def test_zhang_model_accurate(rate):
     bintime = 0.0002
     deadtime = 2.5e-3
@@ -46,7 +46,7 @@ def test_zhang_model_accurate(rate):
     lc_dt = Lightcurve.make_lightcurve(events_dt, bintime, tstart=0, tseg=length)
     pds = AveragedPowerspectrum(lc_dt, fftlen, norm="leahy")
 
-    zh_f, zh_p = pds_model_zhang(1000, rate, deadtime, bintime, limit_k=400)
+    zh_f, zh_p = pds_model_zhang(1000, rate, deadtime, bintime, limit_k=600)
 
     deadtime_fun = interp1d(zh_f, zh_p, bounds_error=False, fill_value="extrapolate")
     ratio = pds.power / deadtime_fun(pds.freq)
@@ -73,7 +73,7 @@ def test_A_and_B_array(rate, tb):
     ks = np.array([1, 5, 20, 60])
     tau = 1 / rate
     r0 = r_det(td, rate)
-
+    print(ks * tb / tau)
     assert np.array_equal(np.array([A(k, r0, td, tb, tau) for k in ks]), A(ks, r0, td, tb, tau))
     assert np.array_equal(np.array([B(k, r0, td, tb, tau) for k in ks]), B(ks, r0, td, tb, tau))
 

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -8,6 +8,7 @@ from stingray.powerspectrum import AveragedPowerspectrum
 from stingray.deadtime.model import r_det, r_in, pds_model_zhang, non_paralyzable_dead_time_model
 from stingray.deadtime.model import check_A, check_B, A, B
 from stingray.filters import filter_for_deadtime
+from stingray.utils import HAS_NUMBA
 
 
 pytestmark = pytest.mark.slow
@@ -54,6 +55,7 @@ def test_zhang_model_accurate(rate):
     assert np.isclose(np.std(ratio), 1 / np.sqrt(pds.m), rtol=0.1)
 
 
+@pytest.mark.skipif("not HAS_NUMBA")
 @pytest.mark.parametrize("rates", [(1.0, 0.0), (1.0, 1.0), (100.0, 10.0), (100, 200)])
 def test_non_paralyzable_model_accurate(rates):
     bintime = 0.0002

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -6,17 +6,11 @@ from scipy.interpolate import interp1d
 from stingray.lightcurve import Lightcurve
 from stingray.powerspectrum import AveragedPowerspectrum
 from stingray.deadtime.model import r_det, r_in, pds_model_zhang, non_paralyzable_dead_time_model
-from stingray.deadtime.model import check_A, check_B, heaviside, A, B
+from stingray.deadtime.model import check_A, check_B, A, B
 from stingray.filters import filter_for_deadtime
 
 
 pytestmark = pytest.mark.slow
-
-
-def test_heaviside():
-    assert heaviside(2) == 1
-    assert heaviside(0) == 1
-    assert heaviside(-1) == 0
 
 
 def simulate_events(rate, length, deadtime=2.5e-3, bkg_rate=0.0, **filter_kwargs):

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -46,7 +46,7 @@ def test_zhang_model_accurate(rate):
     lc_dt = Lightcurve.make_lightcurve(events_dt, bintime, tstart=0, tseg=length)
     pds = AveragedPowerspectrum(lc_dt, fftlen, norm="leahy")
 
-    zh_f, zh_p = pds_model_zhang(1000, rate, deadtime, bintime, limit_k=600)
+    zh_f, zh_p = pds_model_zhang(100, rate, deadtime, bintime, limit_k=600)
 
     deadtime_fun = interp1d(zh_f, zh_p, bounds_error=False, fill_value="extrapolate")
     ratio = pds.power / deadtime_fun(pds.freq)
@@ -73,10 +73,14 @@ def test_A_and_B_array(tb):
     rate = 10
     tau = 1 / rate
     r0 = r_det(td, rate)
-    assert np.array_equal(np.array([A(k, r0, td, tb, tau) for k in ks]), A(ks, r0, td, tb, tau))
-    assert np.array_equal(np.array([B(k, r0, td, tb, tau) for k in ks]), B(ks, r0, td, tb, tau))
+    assert np.array_equal(
+        np.array([A(k, r0, td, tb, tau) for k in ks]), A(ks, r0, td, tb, tau), equal_nan=True
+    )
+    assert np.array_equal(
+        np.array([B(k, r0, td, tb, tau) for k in ks]), B(ks, r0, td, tb, tau), equal_nan=True
+    )
 
 
 def test_pds_model_warns():
     with pytest.warns(UserWarning, match="The bin time is much larger than the "):
-        pds_model_zhang(10, 100.0, 2.5e-3, 1, limit_k=10)
+        pds_model_zhang(10, 100.0, 2.5e-3, 0.1, limit_k=10)

--- a/stingray/deadtime/tests/test_models.py
+++ b/stingray/deadtime/tests/test_models.py
@@ -73,7 +73,6 @@ def test_A_and_B_array(rate, tb):
     ks = np.array([1, 5, 20, 60])
     tau = 1 / rate
     r0 = r_det(td, rate)
-    print(ks * tb / tau)
     assert np.array_equal(np.array([A(k, r0, td, tb, tau) for k in ks]), A(ks, r0, td, tb, tau))
     assert np.array_equal(np.array([B(k, r0, td, tb, tau) for k in ks]), B(ks, r0, td, tb, tau))
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1251,7 +1251,8 @@ class TestAveragedCrossspectrum(object):
         assert np.all(np.isfinite(cs.classical_significances(threshold=maxpower / 2.0)))
 
     def test_deadtime_corr(self):
-        tmax = 10.0
+        tmax = 100.0
+        segment_size = 1
         events1 = np.sort(np.random.uniform(0, tmax, 10000))
         events2 = np.sort(np.random.uniform(0, tmax, 10000))
         events1_dt = filter_for_deadtime(events1, deadtime=0.0025)
@@ -1261,7 +1262,7 @@ class TestAveragedCrossspectrum(object):
             events2_dt,
             gti=[[0, tmax]],
             dt=0.01,
-            segment_size=1,
+            segment_size=segment_size,
             save_all=True,
             norm="leahy",
         )
@@ -1271,7 +1272,9 @@ class TestAveragedCrossspectrum(object):
                 dead_time=0.0025, rate=np.size(events1_dt) / tmax, paralyzable=True
             )
 
-        cs = cs_dt.deadtime_correct(dead_time=0.0025, rate=np.size(events1_dt) / tmax)
+        cs = cs_dt.deadtime_correct(
+            dead_time=0.0025, rate=np.size(events1_dt) / (tmax / segment_size)
+        )
         # Poisson noise has a scatter of sqrt(2/N) in the cospectrum
         assert np.isclose(np.std(cs.power.real), np.sqrt(2 / 10), rtol=0.1)
 

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -9,12 +9,13 @@ from astropy.io import fits
 from stingray import Lightcurve
 from stingray import Crossspectrum, AveragedCrossspectrum, DynamicalCrossspectrum
 from stingray import AveragedPowerspectrum
-from stingray.crossspectrum import cospectra_pvalue
+from stingray.crossspectrum import cospectra_pvalue, crossspectrum_from_time_array
 from stingray.crossspectrum import normalize_crossspectrum, normalize_crossspectrum_gauss
 from stingray.crossspectrum import coherence, time_lag
 from stingray import StingrayError
 from stingray.simulator import Simulator
 from stingray.fourier import poisson_level
+from stingray.filters import filter_for_deadtime
 
 from stingray.events import EventList
 import copy
@@ -1248,6 +1249,31 @@ class TestAveragedCrossspectrum(object):
             cs = AveragedCrossspectrum(test_lc1, test_lc2, segment_size=10, norm="leahy")
         maxpower = np.max(cs.power)
         assert np.all(np.isfinite(cs.classical_significances(threshold=maxpower / 2.0)))
+
+    def test_deadtime_corr(self):
+        tmax = 10.0
+        events1 = np.sort(np.random.uniform(0, tmax, 10000))
+        events2 = np.sort(np.random.uniform(0, tmax, 10000))
+        events1_dt = filter_for_deadtime(events1, deadtime=0.0025)
+        events2_dt = filter_for_deadtime(events2, deadtime=0.0025)
+        cs_dt = crossspectrum_from_time_array(
+            events1_dt,
+            events2_dt,
+            gti=[[0, tmax]],
+            dt=0.01,
+            segment_size=1,
+            save_all=True,
+            norm="leahy",
+        )
+        # Paralyzable is not implemented yet
+        with pytest.raises(NotImplementedError):
+            cs = cs_dt.deadtime_correct(
+                dead_time=0.0025, rate=np.size(events1_dt) / tmax, paralyzable=True
+            )
+
+        cs = cs_dt.deadtime_correct(dead_time=0.0025, rate=np.size(events1_dt) / tmax)
+        # Poisson noise has a scatter of sqrt(2/N) in the cospectrum
+        assert np.isclose(np.std(cs.power.real), np.sqrt(2 / 10), rtol=0.1)
 
 
 class TestCoherenceFunction(object):

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -13,6 +13,7 @@ from stingray.crossspectrum import cospectra_pvalue, crossspectrum_from_time_arr
 from stingray.crossspectrum import normalize_crossspectrum, normalize_crossspectrum_gauss
 from stingray.crossspectrum import coherence, time_lag
 from stingray import StingrayError
+from stingray.utils import HAS_NUMBA
 from stingray.simulator import Simulator
 from stingray.fourier import poisson_level
 from stingray.filters import filter_for_deadtime
@@ -1250,6 +1251,7 @@ class TestAveragedCrossspectrum(object):
         maxpower = np.max(cs.power)
         assert np.all(np.isfinite(cs.classical_significances(threshold=maxpower / 2.0)))
 
+    @pytest.mark.skipif("not HAS_NUMBA")
     def test_deadtime_corr(self):
         tmax = 100.0
         segment_size = 1

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1261,7 +1261,7 @@ class TestAveragedCrossspectrum(object):
             events1_dt,
             events2_dt,
             gti=[[0, tmax]],
-            dt=0.01,
+            dt=0.001,
             segment_size=segment_size,
             save_all=True,
             norm="leahy",
@@ -1272,11 +1272,9 @@ class TestAveragedCrossspectrum(object):
                 dead_time=0.0025, rate=np.size(events1_dt) / tmax, paralyzable=True
             )
 
-        cs = cs_dt.deadtime_correct(
-            dead_time=0.0025, rate=np.size(events1_dt) / (tmax / segment_size)
-        )
+        cs = cs_dt.deadtime_correct(dead_time=0.0025, rate=np.size(events1_dt) / tmax)
         # Poisson noise has a scatter of sqrt(2/N) in the cospectrum
-        assert np.isclose(np.std(cs.power.real), np.sqrt(2 / 10), rtol=0.1)
+        assert np.isclose(np.std(cs.power.real), np.sqrt(2 / (tmax / segment_size)), rtol=0.1)
 
 
 class TestCoherenceFunction(object):

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from astropy.io import fits
 from stingray import Lightcurve
 from stingray.events import EventList
+from stingray.utils import HAS_NUMBA
 from stingray import Powerspectrum, AveragedPowerspectrum, DynamicalPowerspectrum
 from stingray.powerspectrum import powerspectrum_from_time_array
 from astropy.modeling.models import Lorentz1D
@@ -342,6 +343,7 @@ class TestAveragedPowerspectrumEvents(object):
         assert np.isclose(np.mean(ps.power), 2.0, atol=1e-2, rtol=1e-2)
         assert np.isclose(np.std(ps.power), 2.0 / np.sqrt(ps.m), atol=0.1, rtol=0.1)
 
+    @pytest.mark.skipif("not HAS_NUMBA")
     def test_deadtime_corr(self):
         tmax = 100.0
         segment_size = 1
@@ -501,9 +503,7 @@ class TestPowerspectrum(object):
         square of the number of data points in the light curve
         """
         ps = Powerspectrum(self.lc, norm="Leahy")
-        ps_var = (np.sum(self.lc.counts) / ps.n**2.0) * (
-            np.sum(ps.power[:-1]) + ps.power[-1] / 2.0
-        )
+        ps_var = (np.sum(self.lc.counts) / ps.n**2.0) * (np.sum(ps.power[:-1]) + ps.power[-1] / 2.0)
 
         assert np.isclose(ps_var, np.var(self.lc.counts), atol=0.01)
 

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -501,7 +501,9 @@ class TestPowerspectrum(object):
         square of the number of data points in the light curve
         """
         ps = Powerspectrum(self.lc, norm="Leahy")
-        ps_var = (np.sum(self.lc.counts) / ps.n**2.0) * (np.sum(ps.power[:-1]) + ps.power[-1] / 2.0)
+        ps_var = (np.sum(self.lc.counts) / ps.n**2.0) * (
+            np.sum(ps.power[:-1]) + ps.power[-1] / 2.0
+        )
 
         assert np.isclose(ps_var, np.var(self.lc.counts), atol=0.01)
 

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -503,7 +503,7 @@ class TestPowerspectrum(object):
         square of the number of data points in the light curve
         """
         ps = Powerspectrum(self.lc, norm="Leahy")
-        ps_var = (np.sum(self.lc.counts) / ps.n**2.0) * (np.sum(ps.power[:-1]) + ps.power[-1] / 2.0)
+        ps_var = (np.sum(self.lc.counts) / ps.n**2) * (np.sum(ps.power[:-1]) + ps.power[-1] / 2.0)
 
         assert np.isclose(ps_var, np.var(self.lc.counts), atol=0.01)
 

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -10,7 +10,9 @@ from astropy.io import fits
 from stingray import Lightcurve
 from stingray.events import EventList
 from stingray import Powerspectrum, AveragedPowerspectrum, DynamicalPowerspectrum
+from stingray.powerspectrum import powerspectrum_from_time_array
 from astropy.modeling.models import Lorentz1D
+from stingray.filters import filter_for_deadtime
 
 _HAS_XARRAY = importlib.util.find_spec("xarray") is not None
 _HAS_PANDAS = importlib.util.find_spec("pandas") is not None
@@ -340,6 +342,24 @@ class TestAveragedPowerspectrumEvents(object):
         assert np.isclose(np.mean(ps.power), 2.0, atol=1e-2, rtol=1e-2)
         assert np.isclose(np.std(ps.power), 2.0 / np.sqrt(ps.m), atol=0.1, rtol=0.1)
 
+    def test_deadtime_corr(self):
+        tmax = 100.0
+        segment_size = 1
+        events = np.sort(np.random.uniform(0, tmax, 10000))
+        events_dt = filter_for_deadtime(events, deadtime=0.0025)
+        pds_dt = powerspectrum_from_time_array(
+            events_dt,
+            gti=[[0, tmax]],
+            dt=0.001,
+            segment_size=segment_size,
+            save_all=True,
+            norm="leahy",
+        )
+
+        pds = pds_dt.deadtime_correct(dead_time=0.0025, rate=np.size(events_dt) / tmax)
+        assert np.isclose(np.mean(pds.power), 2, rtol=0.1)
+        assert np.isclose(np.std(pds.power), 2 / np.sqrt(tmax / segment_size), rtol=0.1)
+
 
 class TestPowerspectrum(object):
     @classmethod
@@ -481,9 +501,7 @@ class TestPowerspectrum(object):
         square of the number of data points in the light curve
         """
         ps = Powerspectrum(self.lc, norm="Leahy")
-        ps_var = (np.sum(self.lc.counts) / ps.n**2.0) * (
-            np.sum(ps.power[:-1]) + ps.power[-1] / 2.0
-        )
+        ps_var = (np.sum(self.lc.counts) / ps.n**2.0) * (np.sum(ps.power[:-1]) + ps.power[-1] / 2.0)
 
         assert np.isclose(ps_var, np.var(self.lc.counts), atol=0.01)
 

--- a/stingray/tests/test_utils.py
+++ b/stingray/tests/test_utils.py
@@ -367,6 +367,12 @@ def test_equal_count_energy_ranges():
         assert np.count_nonzero(good) == 10000
 
 
+def test_heaviside():
+    assert utils.heaviside(2) == 1
+    assert utils.heaviside(0) == 1
+    assert utils.heaviside(-1) == 0
+
+
 def test_histogram_equiv_numpy():
     x = np.random.uniform(0.0, 1.0, 100)
     (H, _) = np.histogram(x, bins=5, range=(0.0, 1.0))

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -140,7 +140,25 @@ __all__ = [
     "nearest_power_of_two",
     "find_nearest",
     "check_isallfinite",
+    "heaviside",
 ]
+
+
+@njit()
+def heaviside(x):
+    """Heaviside function. Returns 1 if x>0, and 0 otherwise.
+
+    Examples
+    --------
+    >>> heaviside(2)
+    1
+    >>> heaviside(-1)
+    0
+    """
+    if x >= 0:
+        return 1
+    else:
+        return 0
 
 
 @njit


### PR DESCRIPTION
The dead time model had a few issues: 

+ the sum of many values below computer precision which produced large errors in the final result -> I set a limit for new additions so that numbers get only added when larger than `10**(-np.finfo(float).precision)`

+ `check_A` and `check_B` had useless axes in some conditions due to the large dynamic range of values -> I changed them to "symlog" to allow for negative numbers with small powers of ten.
![image](https://github.com/StingraySoftware/stingray/assets/7190189/223c6197-2159-4f28-b33f-2ec9bc8f92ce)
I also added a trend line that estimates the estimated floating point error propagation after using the Bks for the actual calculation


Also in this PR: 

+ Added the possibility of calculating `B` and `A` for ranges of the parameter `k`

+ Added a new functions that calculates the deadtime-distorted PDS with more user-friendly parameters (e.g. providing the frequency array, starting from detected (not incident) count rate, using background to rescale, etc.)
![new_deadtime_model](https://github.com/StingraySoftware/stingray/assets/7190189/4d5198df-ef91-49fa-85b9-ddcde227f7ff)

+ Added a method to Crossspectrum and derivatives to directly correct the powers, assuming a constant dead time
![image](https://github.com/StingraySoftware/stingray/assets/7190189/3cd649fa-3bbb-46d4-9e63-8cfa4f8084b9)


