### PR TITLE
[TST] Fix link in docs and deprecated function from numpy

### DIFF
--- a/docs/acknowledgements.rst
+++ b/docs/acknowledgements.rst
@@ -4,4 +4,4 @@ Acknowledgements
 
 Thank you to JetBrains for the free use of `PyCharm <https://www.jetbrains.com/pycharm/>`_.
 
-Stingray participated in the `Google Summer of Code <https://summerofcode.withgoogle.com>`_ in 2018 and 2020 under `Open Astronomy <http://openastronomy.org>`_, in 2017 under the `Python Software Foundation <https://www.python.org/psf/>`_, and in 2016 under `Timelab <http://timelabtechnologies.com>`_.
+Stingray participated in the `Google Summer of Code <https://summerofcode.withgoogle.com>`_ in 2018, 2020, 2021, 2022, 2023, 2024 under `Open Astronomy <http://openastronomy.org>`_, in 2017 under the `Python Software Foundation <https://www.python.org/psf/>`_, and in 2016 under Timelab.

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -12,7 +12,7 @@ If possible, we ask that you cite a DOI corresponding to the specific version of
 
 .. include:: _zenodo.rst
 
-If this isn't possible — for example, because you worked with an unreleased version of the code — you can cite Stingray's `concept DOI <https://help.zenodo.org/faq/#versioning>`__, `10.5281/zenodo.1490116 <https://zenodo.org/record/1490116>`__ (`BibTeX <https://zenodo.org/record/1490116/export/hx>`__), which will always resolve to the latest release.
+If this isn't possible — for example, because you worked with an unreleased version of the code — you can cite Stingray's `concept DOI <https://zenodo.org/help/versioning>`__, `10.5281/zenodo.1490116 <https://zenodo.org/record/1490116>`__ (`BibTeX <https://zenodo.org/record/1490116/export/hx>`__), which will always resolve to the latest release.
 
 Papers
 ======

--- a/stingray/multitaper.py
+++ b/stingray/multitaper.py
@@ -16,6 +16,12 @@ from .events import EventList
 from .lightcurve import Lightcurve
 from .utils import rebin_data, simon, fft, rfft, rfftfreq
 
+try:
+    integration_func = np.trapezoid
+except AttributeError:
+    # < Numpy 2.0.0
+    integration_func = np.trapz
+
 __all__ = ["Multitaper"]
 
 # Inspired from nitime (https://nipy.org/nitime/)
@@ -460,7 +466,7 @@ class Multitaper(Powerspectrum):
 
         psd_est = self.psd_from_freq_response(freq_response, sqrt_eigvals[:, np.newaxis])
 
-        var = np.trapz(psd_est, dx=np.pi / n_freqs) / (2 * np.pi)
+        var = integration_func(psd_est, dx=np.pi / n_freqs) / (2 * np.pi)
         del psd_est
 
         psd = np.empty(n_freqs)


### PR DESCRIPTION
A very easy one. The link timelabtechnologies.com is unreacheable, and I'm eliminating it from the docs (otherwise the linkcheck test fails)

Also, fix deprecation warning of numpy.trapz in numpy 2.0