### PR TITLE
Shift and add

### DIFF
--- a/docs/changes/849.feature.rst
+++ b/docs/changes/849.feature.rst
@@ -1,0 +1,2 @@
+implementation of the shift-and-add technique for QPOs and other varying power spectral features
+

--- a/docs/timeseries.rst
+++ b/docs/timeseries.rst
@@ -6,3 +6,4 @@ Working with more generic time series
 
    notebooks/StingrayTimeseries/StingrayTimeseries Tutorial.ipynb
    notebooks/StingrayTimeseries/Working with weights and polarization.ipynb
+   notebooks/Modeling/GP_Modeling/GP_modeling_tutorial.ipynb

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2146,7 +2146,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             return
 
         if segment_size is None or data1 is None or data2 is None:
-            raise RuntimeError("data1, data2, and segment_size must all be specified")
+            raise TypeError("data1, data2, and segment_size must all be specified")
 
         if isinstance(data1, EventList) and sample_time is None:
             raise ValueError("To pass input event lists, please specify sample_time")

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2132,7 +2132,22 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         The number of averaged powers in each spectral bin (initially 1, it changes after rebinning).
     """
 
-    def __init__(self, data1, data2, segment_size, norm="frac", gti=None, sample_time=None):
+    def __init__(
+        self, data1=None, data2=None, segment_size=None, norm="frac", gti=None, sample_time=None
+    ):
+        self.segment_size = segment_size
+        self.sample_time = sample_time
+        self.gti = gti
+        self.norm = norm
+
+        if segment_size is None and data1 is None and data2 is None:
+            self._initialize_empty()
+            self.dyn_ps = None
+            return
+
+        if segment_size is None or data1 is None or data2 is None:
+            raise RuntimeError("data1, data2, and segment_size must all be specified")
+
         if isinstance(data1, EventList) and sample_time is None:
             raise ValueError("To pass input event lists, please specify sample_time")
         elif isinstance(data1, Lightcurve):
@@ -2144,11 +2159,6 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
                 )
         if segment_size < 2 * sample_time:
             raise ValueError("Length of the segment is too short to form a light curve!")
-
-        self.segment_size = segment_size
-        self.sample_time = sample_time
-        self.gti = gti
-        self.norm = norm
 
         self._make_matrix(data1, data2)
 
@@ -2369,6 +2379,68 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
             max_positions.append(np.where(ps == max_power)[0][0])
 
         return np.array(max_positions)
+
+    def shift_and_add(self, f0_list, nbins=100, output_obj_type=AveragedCrossspectrum):
+        """Shift and add the dynamical power spectrum.
+
+        This is the basic operation for the shift-and-add operation used to track
+        kHz QPOs in X-ray binaries (e.g. Méndez et al. 1998, ApJ, 494, 65).
+
+        Parameters
+        ----------
+        freqs : np.array
+            Array of frequencies, the same for all powers. Must be sorted and on a uniform
+            grid.
+        power_list : list of np.array
+            List of power spectra. Each power spectrum must have the same length
+            as the frequency array.
+        f0_list : list of float
+            List of central frequencies
+
+        Other parameters
+        ----------------
+        nbins : int, default 100
+            Number of bins to extract
+
+        Returns
+        -------
+        output: :class:`AveragedPowerspectrum` or :class:`AveragedCrossspectrum`
+            The final averaged power spectrum.
+
+        Examples
+        --------
+        >>> power_list = [[2, 5, 2, 2, 2], [1, 1, 5, 1, 1], [3, 3, 3, 5, 3]]
+        >>> power_list = np.array(power_list).T
+        >>> freqs = np.arange(5) * 0.1
+        >>> f0_list = [0.1, 0.2, 0.3, 0.4]
+        >>> dps = DynamicalCrossspectrum()
+        >>> dps.dyn_ps = power_list
+        >>> dps.freq = freqs
+        >>> dps.df = 0.1
+        >>> dps.m = 1
+        >>> output = dps.shift_and_add(f0_list, nbins=5)
+        >>> assert np.array_equal(output.m, [2, 3, 3, 3, 2])
+        >>> assert np.array_equal(output.power, [2. , 2. , 5. , 2. , 1.5])
+        >>> assert np.allclose(output.freq, [0.05, 0.15, 0.25, 0.35, 0.45])
+        """
+        from .fourier import shift_and_add
+
+        final_freqs, final_powers, count = shift_and_add(
+            self.freq, self.dyn_ps.T, f0_list, nbins=nbins, M=self.m, df=self.df
+        )
+
+        output = output_obj_type()
+        good = ~np.isnan(final_powers)
+
+        output.freq = final_freqs[good]
+        output.power = final_powers[good]
+        output.m = count[good]
+        output.df = self.df
+        output.norm = self.norm
+        output.gti = self.gti
+        output.segment_size = self.segment_size
+
+        return output
 
     def power_colors(
         self,

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2381,7 +2381,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         return np.array(max_positions)
 
     def shift_and_add(self, f0_list, nbins=100, output_obj_type=AveragedCrossspectrum, rebin=None):
-        """Shift and add the dynamical power spectrum.
+        """Shift and add the dynamical cross spectrum.
 
         This is the basic operation for the shift-and-add operation used to track
         kHz QPOs in X-ray binaries (e.g. Méndez et al. 1998, ApJ, 494, 65).
@@ -2404,6 +2404,10 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         rebin : int, default None
             Rebin the final spectrum by this factor. At the moment, the rebinning
             is linear.
+        output_obj_type : class, default :class:`AveragedCrossspectrum`
+            The type of the output object. Can be, e.g. :class:`AveragedCrossspectrum` or
+            :class:`AveragedPowerspectrum`.
+
         Returns
         -------
         output: :class:`AveragedPowerspectrum` or :class:`AveragedCrossspectrum`

--- a/stingray/crossspectrum.py
+++ b/stingray/crossspectrum.py
@@ -2380,7 +2380,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
 
         return np.array(max_positions)
 
-    def shift_and_add(self, f0_list, nbins=100, output_obj_type=AveragedCrossspectrum):
+    def shift_and_add(self, f0_list, nbins=100, output_obj_type=AveragedCrossspectrum, rebin=None):
         """Shift and add the dynamical power spectrum.
 
         This is the basic operation for the shift-and-add operation used to track
@@ -2401,7 +2401,9 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         ----------------
         nbins : int, default 100
             Number of bins to extract
-
+        rebin : int, default None
+            Rebin the final spectrum by this factor. At the moment, the rebinning
+            is linear.
         Returns
         -------
         output: :class:`AveragedPowerspectrum` or :class:`AveragedCrossspectrum`
@@ -2426,7 +2428,7 @@ class DynamicalCrossspectrum(AveragedCrossspectrum):
         from .fourier import shift_and_add
 
         final_freqs, final_powers, count = shift_and_add(
-            self.freq, self.dyn_ps.T, f0_list, nbins=nbins, M=self.m, df=self.df
+            self.freq, self.dyn_ps.T, f0_list, nbins=nbins, M=self.m, df=self.df, rebin=rebin
         )
 
         output = output_obj_type()

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -1442,7 +1442,9 @@ def shift_and_add(freqs, power_list, f0_list, nbins=100, rebin=None, df=None, M=
     Returns
     -------
     f : np.array
-        Array of output frequencies
+        Array of output frequencies. This will be centered on the mean of the
+        input ``f0_list``, and have the same frequency resolution as the original
+        frequency array.
     p : np.array
         Array of output powers
     n : np.array

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -20,6 +20,7 @@ from .utils import (
     show_progress,
     sum_if_not_none_or_initialize,
     fix_segment_size_to_integer_samples,
+    rebin_data,
 )
 
 
@@ -1485,6 +1486,7 @@ def shift_and_add(freqs, power_list, f0_list, nbins=100, rebin=None, df=None, M=
     final_powers = final_powers / count
 
     if rebin is not None:
+        _, count, _, _ = rebin_data(final_freqs, count, rebin * df)
         final_freqs, final_powers, _, _ = rebin_data(final_freqs, final_powers, rebin * df)
         final_powers = final_powers / rebin
 

--- a/stingray/fourier.py
+++ b/stingray/fourier.py
@@ -21,6 +21,7 @@ from .utils import (
     sum_if_not_none_or_initialize,
     fix_segment_size_to_integer_samples,
     rebin_data,
+    njit,
 )
 
 
@@ -1359,7 +1360,66 @@ def get_flux_iterable_from_segments(
         yield cts
 
 
-def center_pds_on_f(freqs, powers, f0, nbins=100):
+@njit()
+def _safe_array_slice_indices(input_size, input_center_idx, nbins):
+    """Calculate the indices needed to extract a n-bin slice of an array, centered at an index.
+
+    Let us say we have an array of size ``input_size`` and we want to extract a slice of
+    ``nbins`` centered at index ``input_center_idx``. We should be robust when the slice goes
+    beyond the edges of the input array, possibly leaving missing values in the output array.
+    This function calculates the indices needed to extract the slice from the input array, and
+    the indices in the output array that will be filled.
+
+    In the most common case, the slice is entirely contained within the input array, so that the
+    output slice will just be ``[0:nbins]`` and the input slice
+    ``[input_center_idx - nbins // 2: input_center_idx - nbins // 2 + nbins]``.
+
+    Parameters
+    ----------
+    input_size : int
+        Input array size
+    center_idx : int
+        Index of the center of the slice
+    nbins : int
+        Number of bins to extract
+
+    Returns
+    -------
+    input_slice : list
+        Indices to extract the slice from the input array
+    output_slice : list
+        Indices to fill the output array
+
+    Examples
+    --------
+    >>> _safe_array_slice_indices(input_size=10, input_center_idx=5, nbins=3)
+    ([4, 7], [0, 3])
+
+    If the slice goes beyond the right edge: the output slice will only cover
+    the first two bins of the output array, and up to the end of the input array.
+    >>> _safe_array_slice_indices(input_size=6, input_center_idx=5, nbins=3)
+    ([4, 6], [0, 2])
+
+    """
+
+    minbin = input_center_idx - nbins // 2
+    maxbin = minbin + nbins
+
+    if minbin < 0:
+        output_slice = [-minbin, min(nbins, input_size - minbin)]
+        input_slice = [0, minbin + nbins]
+    elif maxbin > input_size:
+        output_slice = [0, nbins - (maxbin - input_size)]
+        input_slice = [minbin, input_size]
+    else:
+        output_slice = [0, nbins]
+        input_slice = [minbin, maxbin]
+
+    return input_slice, output_slice
+
+
+@njit()
+def extract_pds_slice_around_freq(freqs, powers, f0, nbins=100):
     """Extract a slice of PDS around a given frequency.
 
     This function extracts a slice of the power spectrum around a given frequency.
@@ -1385,27 +1445,57 @@ def center_pds_on_f(freqs, powers, f0, nbins=100):
     >>> freqs = np.arange(1, 100) * 0.1
     >>> powers = 10 / freqs
     >>> f0 = 0.3
-    >>> p = center_pds_on_f(freqs, powers, f0)
+    >>> p = extract_pds_slice_around_freq(freqs, powers, f0)
     >>> assert np.isnan(p[0])
     >>> assert not np.any(np.isnan(p[48:]))
     """
     powers = np.asarray(powers)
     chunk = np.zeros(nbins) + np.nan
-    fchunk = np.zeros(nbins)
+    # fchunk = np.zeros(nbins)
 
     start_f_idx = np.searchsorted(freqs, f0)
 
-    minbin = start_f_idx - nbins // 2
-    maxbin = minbin + nbins
-
-    if minbin < 0:
-        chunk[-minbin : min(nbins, powers.size - minbin)] = powers[: minbin + nbins]
-    elif maxbin > powers.size:
-        chunk[: nbins - (maxbin - powers.size)] = powers[minbin:]
-    else:
-        chunk[:] = powers[minbin:maxbin]
-
+    input_slice, output_slice = _safe_array_slice_indices(powers.size, start_f_idx, nbins)
+    chunk[output_slice[0] : output_slice[1]] = powers[input_slice[0] : input_slice[1]]
     return chunk
+
+
+@njit()
+def _shift_and_average_core(input_array_list, weight_list, center_indices, nbins):
+    """Core function to shift_and_add, JIT-compiled for your convenience.
+
+    Parameters
+    ----------
+    input_array_list : list of np.array
+        List of input arrays
+    weight_list : list of float
+        List of weights for each input array
+    center_indices : list of int
+        Central indices of the slice of each input array to be summed
+    nbins : int
+        Number of bins to extract around the central index of each input array
+
+    Returns
+    -------
+    output_array : np.array
+        Average of the input arrays, weighted by the weights
+    sum_of_weights : np.array
+        Sum of the weights at each output bin
+    """
+    input_size = input_array_list[0].size
+    output_array = np.zeros(nbins)
+    sum_of_weights = np.zeros(nbins)
+    for idx, array, weight in zip(center_indices, input_array_list, weight_list):
+        input_slice, output_slice = _safe_array_slice_indices(input_size, idx, nbins)
+
+        for i in range(input_slice[1] - input_slice[0]):
+            output_array[output_slice[0] + i] += array[input_slice[0] + i] * weight
+
+            sum_of_weights[output_slice[0] + i] += weight
+
+    output_array = output_array / sum_of_weights
+
+    return output_array, sum_of_weights
 
 
 def shift_and_add(freqs, power_list, f0_list, nbins=100, rebin=None, df=None, M=None):
@@ -1442,9 +1532,7 @@ def shift_and_add(freqs, power_list, f0_list, nbins=100, rebin=None, df=None, M=
     Returns
     -------
     f : np.array
-        Array of output frequencies. This will be centered on the mean of the
-        input ``f0_list``, and have the same frequency resolution as the original
-        frequency array.
+        Array of output frequencies
     p : np.array
         Array of output powers
     n : np.array
@@ -1460,32 +1548,28 @@ def shift_and_add(freqs, power_list, f0_list, nbins=100, rebin=None, df=None, M=
     >>> assert np.array_equal(p, [2. , 2. , 5. , 2. , 1.5])
     >>> assert np.allclose(f, [0.05, 0.15, 0.25, 0.35, 0.45])
     """
-    final_powers = np.zeros(nbins)
+
+    # Check if the input list of power contains numpy arrays
+    if not hasattr(power_list[0], "size"):
+        power_list = np.asarray(power_list)
+    # input_size = np.size(power_list[0])
     freqs = np.asarray(freqs)
 
-    mid_idx = np.searchsorted(freqs, np.mean(f0_list))
+    # mid_idx = np.searchsorted(freqs, np.mean(f0_list))
     if M is None:
         M = 1
     if not isinstance(M, Iterable):
         M = np.ones(len(power_list)) * M
 
-    count = np.zeros(nbins)
-    for f0, powers, m in zip(f0_list, power_list, M):
-        idx = np.searchsorted(freqs, f0_list)
+    center_f_indices = np.searchsorted(freqs, f0_list)
 
-        powers = np.asarray(powers) * m
-        new_power = center_pds_on_f(freqs, powers, f0, nbins=nbins)
-        bad = np.isnan(new_power)
-        new_power[bad] = 0.0
-        final_powers += new_power
-        count += np.array(~bad, dtype=int) * m
+    final_powers, count = _shift_and_average_core(power_list, M, center_f_indices, nbins)
 
     if df is None:
         df = freqs[1] - freqs[0]
 
     final_freqs = np.arange(-nbins // 2, nbins // 2 + 1)[:nbins] * df
     final_freqs = final_freqs - (final_freqs[0] + final_freqs[-1]) / 2 + np.mean(f0_list)
-    final_powers = final_powers / count
 
     if rebin is not None:
         _, count, _, _ = rebin_data(final_freqs, count, rebin * df)

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -1383,8 +1383,7 @@ class Lightcurve(StingrayTimeseries):
     def to_lightkurve(self):
         """
         Returns a `lightkurve.LightCurve` object.
-        This feature requires `Lightkurve
-        <https://docs.lightkurve.org/>`_ to be installed
+        This feature requires ``Lightkurve`` to be installed
         (e.g. ``pip install lightkurve``).  An `ImportError` will
         be raised if this package is not available.
 

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1032,7 +1032,7 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
             return
 
         if segment_size is None or lc is None:
-            raise RuntimeError("lc and segment_size must all be specified")
+            raise TypeError("lc and segment_size must all be specified")
 
         if isinstance(lc, EventList) and sample_time is None:
             raise ValueError("To pass an input event lists, please specify sample_time")

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1049,6 +1049,52 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         self._make_matrix(lc)
 
     def shift_and_add(self, f0_list, nbins=100, rebin=None):
+        """Shift-and-add the dynamical power spectrum.
+
+        This is the basic operation for the shift-and-add operation used to track
+        kHz QPOs in X-ray binaries (e.g. Méndez et al. 1998, ApJ, 494, 65).
+
+        Parameters
+        ----------
+        freqs : np.array
+            Array of frequencies, the same for all powers. Must be sorted and on a uniform
+            grid.
+        power_list : list of np.array
+            List of power spectra. Each power spectrum must have the same length
+            as the frequency array.
+        f0_list : list of float
+            List of central frequencies
+
+        Other parameters
+        ----------------
+        nbins : int, default 100
+            Number of bins to extract
+        rebin : int, default None
+            Rebin the final spectrum by this factor. At the moment, the rebinning
+            is linear.
+
+        Returns
+        -------
+        output: :class:`AveragedPowerspectrum`
+            The final averaged power spectrum.
+
+        Examples
+        --------
+        >>> power_list = [[2, 5, 2, 2, 2], [1, 1, 5, 1, 1], [3, 3, 3, 5, 3]]
+        >>> power_list = np.array(power_list).T
+        >>> freqs = np.arange(5) * 0.1
+        >>> f0_list = [0.1, 0.2, 0.3, 0.4]
+        >>> dps = DynamicalPowerspectrum()
+        >>> dps.dyn_ps = power_list
+        >>> dps.freq = freqs
+        >>> dps.df = 0.1
+        >>> dps.m = 1
+        >>> output = dps.shift_and_add(f0_list, nbins=5)
+        >>> assert isinstance(output, AveragedPowerspectrum)
+        >>> assert np.array_equal(output.m, [2, 3, 3, 3, 2])
+        >>> assert np.array_equal(output.power, [2. , 2. , 5. , 2. , 1.5])
+        >>> assert np.allclose(output.freq, [0.05, 0.15, 0.25, 0.35, 0.45])
+        """
         return super().shift_and_add(
             f0_list, nbins=nbins, output_obj_type=AveragedPowerspectrum, rebin=rebin
         )

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1020,7 +1020,20 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         The number of averaged cross spectra.
     """
 
-    def __init__(self, lc, segment_size, norm="frac", gti=None, sample_time=None):
+    def __init__(self, lc=None, segment_size=None, norm="frac", gti=None, sample_time=None):
+        self.segment_size = segment_size
+        self.sample_time = sample_time
+        self.gti = gti
+        self.norm = norm
+
+        if segment_size is None and lc is None:
+            self._initialize_empty()
+            self.dyn_ps = None
+            return
+
+        if segment_size is None or lc is None:
+            raise RuntimeError("lc and segment_size must all be specified")
+
         if isinstance(lc, EventList) and sample_time is None:
             raise ValueError("To pass an input event lists, please specify sample_time")
         elif isinstance(lc, Lightcurve):
@@ -1033,12 +1046,10 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
         if segment_size < 2 * sample_time:
             raise ValueError("Length of the segment is too short to form a light curve!")
 
-        self.segment_size = segment_size
-        self.sample_time = sample_time
-        self.gti = gti
-        self.norm = norm
-
         self._make_matrix(lc)
+
+    def shift_and_add(self, f0_list, nbins=100):
+        return super().shift_and_add(f0_list, nbins=nbins, output_obj_type=AveragedPowerspectrum)
 
     def _make_matrix(self, lc):
         """

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -1048,8 +1048,10 @@ class DynamicalPowerspectrum(DynamicalCrossspectrum):
 
         self._make_matrix(lc)
 
-    def shift_and_add(self, f0_list, nbins=100):
-        return super().shift_and_add(f0_list, nbins=nbins, output_obj_type=AveragedPowerspectrum)
+    def shift_and_add(self, f0_list, nbins=100, rebin=None):
+        return super().shift_and_add(
+            f0_list, nbins=nbins, output_obj_type=AveragedPowerspectrum, rebin=rebin
+        )
 
     def _make_matrix(self, lc):
         """

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1430,6 +1430,10 @@ class TestDynamicalCrossspectrum(object):
         test_counts = [2, 3, 1, 3, 1, 5, 2, 1, 4, 2, 2, 2, 3, 4, 1, 7]
         cls.lc_test = Lightcurve(test_times, test_counts)
 
+    def test_bad_args(self):
+        with pytest.raises(TypeError, match=".must all be specified"):
+            _ = DynamicalCrossspectrum(1)
+
     def test_with_short_seg_size(self):
         with pytest.raises(ValueError):
             dps = DynamicalCrossspectrum(self.lc, self.lc, segment_size=0)
@@ -1673,5 +1677,5 @@ class TestDynamicalCrossspectrum(object):
         dps.m = 1
         output = dps.shift_and_add(f0_list, nbins=5)
         assert np.array_equal(output.m, [2, 3, 3, 3, 2])
-        assert np.array_equal(output.power, [2. , 2. , 5. , 2. , 1.5])
+        assert np.array_equal(output.power, [2.0, 2.0, 5.0, 2.0, 1.5])
         assert np.allclose(output.freq, [0.05, 0.15, 0.25, 0.35, 0.45])

--- a/stingray/tests/test_crossspectrum.py
+++ b/stingray/tests/test_crossspectrum.py
@@ -1660,3 +1660,18 @@ class TestDynamicalCrossspectrum(object):
         assert np.allclose(new_dps.freq, rebin_freq)
         assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.00001)
         assert np.isclose(new_dps.df, df_new)
+
+    def test_shift_and_add(self):
+        power_list = [[2, 5, 2, 2, 2], [1, 1, 5, 1, 1], [3, 3, 3, 5, 3]]
+        power_list = np.array(power_list).T
+        freqs = np.arange(5) * 0.1
+        f0_list = [0.1, 0.2, 0.3, 0.4]
+        dps = DynamicalCrossspectrum()
+        dps.dyn_ps = power_list
+        dps.freq = freqs
+        dps.df = 0.1
+        dps.m = 1
+        output = dps.shift_and_add(f0_list, nbins=5)
+        assert np.array_equal(output.m, [2, 3, 3, 3, 2])
+        assert np.array_equal(output.power, [2. , 2. , 5. , 2. , 1.5])
+        assert np.allclose(output.freq, [0.05, 0.15, 0.25, 0.35, 0.45])

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -878,6 +878,10 @@ class TestDynamicalPowerspectrum(object):
         test_counts = [2, 3, 1, 3, 1, 5, 2, 1, 4, 2, 2, 2, 3, 4, 1, 7]
         cls.lc_test = Lightcurve(test_times, test_counts)
 
+    def test_bad_args(self):
+        with pytest.raises(TypeError, match=".must all be specified"):
+            _ = DynamicalPowerspectrum(1)
+
     def test_with_short_seg_size(self):
         with pytest.raises(ValueError):
             dps = DynamicalPowerspectrum(self.lc, segment_size=0)

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -1021,6 +1021,21 @@ class TestDynamicalPowerspectrum(object):
         assert np.allclose(new_dps.dyn_ps, rebin_dps, atol=0.00001)
         assert np.isclose(new_dps.df, df_new)
 
+    def test_shift_and_add(self):
+        power_list = [[2, 5, 2, 2, 2], [1, 1, 5, 1, 1], [3, 3, 3, 5, 3]]
+        power_list = np.array(power_list).T
+        freqs = np.arange(5) * 0.1
+        f0_list = [0.1, 0.2, 0.3, 0.4]
+        dps = DynamicalPowerspectrum()
+        dps.dyn_ps = power_list
+        dps.freq = freqs
+        dps.df = 0.1
+        dps.m = 1
+        output = dps.shift_and_add(f0_list, nbins=5)
+        assert np.array_equal(output.m, [2, 3, 3, 3, 2])
+        assert np.array_equal(output.power, [2.0, 2.0, 5.0, 2.0, 1.5])
+        assert np.allclose(output.freq, [0.05, 0.15, 0.25, 0.35, 0.45])
+
 
 class TestRoundTrip:
     @classmethod

--- a/stingray/tests/test_powerspectrum.py
+++ b/stingray/tests/test_powerspectrum.py
@@ -1040,6 +1040,21 @@ class TestDynamicalPowerspectrum(object):
         assert np.array_equal(output.power, [2.0, 2.0, 5.0, 2.0, 1.5])
         assert np.allclose(output.freq, [0.05, 0.15, 0.25, 0.35, 0.45])
 
+    def test_shift_and_add_rebin(self):
+        power_list = [[2, 5, 2, 2, 2], [1, 1, 5, 1, 1], [3, 3, 3, 5, 3]]
+        power_list = np.array(power_list).T
+        freqs = np.arange(5) * 0.1
+        f0_list = [0.1, 0.2, 0.3, 0.4]
+        dps = DynamicalPowerspectrum()
+        dps.dyn_ps = power_list
+        dps.freq = freqs
+        dps.df = 0.1
+        dps.m = 1
+        output = dps.shift_and_add(f0_list, nbins=5, rebin=2)
+        assert np.array_equal(output.m, [5, 6])
+        assert np.array_equal(output.power, [2.0, 3.5])
+        assert np.allclose(output.freq, [0.1, 0.3])
+
 
 class TestRoundTrip:
     @classmethod


### PR DESCRIPTION
Basic implementation of the shift-and-add technique from [Mendez+1998](https://iopscience.iop.org/article/10.1086/311600/pdf)
Guide for review: the basic mechanism is in `fourier.py`, the examples in the doctests should be self-explanatory. In`DynamicalCrossspectrum` and `DynamicalPowerspectrum`, I just wrap the same functionality in convenient methods that unpack the relevant information from the dynamical spectra and use the function in `fourier.py`.

Example: if a QPO is changing its frequency during our observation
![Screenshot 2024-10-04 at 14 01 18](https://github.com/user-attachments/assets/1b9ef72e-8011-400e-91be-eb4dcc5844ad)

we can think of tracing its maximum (e.g. with `dcs.trace_maximum()`, here I did it by hand):
![Screenshot 2024-10-04 at 14 03 31](https://github.com/user-attachments/assets/cfe65892-7c02-4aaa-bc0e-d80cce3d8db5)

and then applying shift_and_add to improve signal-to-noise and, maybe, detect a second QPO:
![Screenshot 2024-10-04 at 14 03 49](https://github.com/user-attachments/assets/6eb5988a-ac0f-48f7-a312-825f49d8a306)
