### PR TITLE
Remove setuptools from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ keywords = [
 dependencies = [
     "numpy>=1.17",
     "astropy>=4.0",
-    "setuptools",
-    "setuptools_scm",
     "scipy>=1.1.0",
     "matplotlib>=3.0,!=3.4.00",
 ]


### PR DESCRIPTION
Having it as a runtime dependency is not needed, and it's breaking the hendrics feedstock. See here: https://github.com/conda-forge/hendrics-feedstock/pull/19