### PR TITLE
JOSS editorial tweaks

### DIFF
--- a/joss/joss.bib
+++ b/joss/joss.bib
@@ -4,7 +4,7 @@
   author = {{Astropy Collaboration} and Robitaille, Thomas P. and Tollerud, Erik J. and Greenfield, Perry and Droettboom, Michael and Bray, Erik and Aldcroft, Tom and Davis, Matt and Ginsburg, Adam and {Price-Whelan}, Adrian M. and Kerzendorf, Wolfgang E. and Conley, Alexander and Crighton, Neil and Barbary, Kyle and Muna, Demitri and Ferguson, Henry and Grollier, Fr{\'e}d{\'e}ric and Parikh, Madhura M. and Nair, Prasanth H. and Unther, Hans M. and Deil, Christoph and Woillez, Julien and Conseil, Simon and Kramer, Roban and Turner, James E. H. and Singer, Leo and Fox, Ryan and Weaver, Benjamin A. and Zabalza, Victor and Edwards, Zachary I. and Azalee Bostroem, K. and Burke, D. J. and Casey, Andrew R. and Crawford, Steven M. and Dencheva, Nadia and Ely, Justin and Jenness, Tim and Labrie, Kathleen and Lim, Pey Lian and Pierfederici, Francesco and Pontzen, Andrew and Ptak, Andy and Refsdal, Brian and Servillat, Mathieu and Streicher, Ole},
   year = {2013},
   month = oct,
-  journal = {Astronomy and Astrophysics},
+  journal = {Astronomy \& Astrophysics},
   volume = {558},
   pages = {A33},
   issn = {0004-6361},
@@ -16,7 +16,7 @@
 }
 
 @article{astropy2022,
-  title = {The {{Astropy Project}}: {{Sustaining}} and {{Growing}} a {{Community-oriented Open-source Project}} and the {{Latest Major Release}} (v5.0) of the {{Core Package}}},
+  title = {The {{Astropy Project}}: Sustaining and Growing a Community-oriented Open-source Project and the Latest Major Release (v5.0) of the Core Package},
   shorttitle = {The {{Astropy Project}}},
   author = {{Astropy Collaboration} and {Price-Whelan}, Adrian M. and Lim, Pey Lian and Earl, Nicholas and Starkman, Nathaniel and Bradley, Larry and Shupe, David L. and Patil, Aarya A. and Corrales, Lia and Brasseur, C. E. and N{\"o}the, Maximilian and Donath, Axel and Tollerud, Erik and Morris, Brett M. and Ginsburg, Adam and Vaher, Eero and Weaver, Benjamin A. and Tocknell, James and Jamieson, William and {van Kerkwijk}, Marten H. and Robitaille, Thomas P. and Merry, Bruce and Bachetti, Matteo and G{\"u}nther, H. Moritz and Aldcroft, Thomas L. and {Alvarado-Montes}, Jaime A. and Archibald, Anne M. and B{\'o}di, Attila and Bapat, Shreyas and Barentsen, Geert and Baz{\'a}n, Juanjo and Biswas, Manish and Boquien, M{\'e}d{\'e}ric and Burke, D. J. and Cara, Daria and Cara, Mihai and Conroy, Kyle E. and Conseil, Simon and Craig, Matthew W. and Cross, Robert M. and Cruz, Kelle L. and D'Eugenio, Francesco and Dencheva, Nadia and Devillepoix, Hadrien A. R. and Dietrich, J{\"o}rg P. and Eigenbrot, Arthur Davis and Erben, Thomas and Ferreira, Leonardo and {Foreman-Mackey}, Daniel and Fox, Ryan and Freij, Nabil and Garg, Suyog and Geda, Robel and Glattly, Lauren and Gondhalekar, Yash and Gordon, Karl D. and Grant, David and Greenfield, Perry and Groener, Austen M. and Guest, Steve and Gurovich, Sebastian and Handberg, Rasmus and Hart, Akeem and {Hatfield-Dodds}, Zac and Homeier, Derek and Hosseinzadeh, Griffin and Jenness, Tim and Jones, Craig K. and Joseph, Prajwel and Kalmbach, J. Bryce and Karamehmetoglu, Emir and Ka{\l}uszy{\'n}ski, Miko{\l}aj and Kelley, Michael S. P. and Kern, Nicholas and Kerzendorf, Wolfgang E. and Koch, Eric W. and Kulumani, Shankar and Lee, Antony and Ly, Chun and Ma, Zhiyuan and MacBride, Conor and Maljaars, Jakob M. and Muna, Demitri and Murphy, N. A. and Norman, Henrik and O'Steen, Richard and Oman, Kyle A. and Pacifici, Camilla and Pascual, Sergio and {Pascual-Granado}, J. and Patil, Rohit R. and Perren, Gabriel I. and Pickering, Timothy E. and Rastogi, Tanuj and Roulston, Benjamin R. and Ryan, Daniel F. and Rykoff, Eli S. and Sabater, Jose and Sakurikar, Parikshit and Salgado, Jes{\'u}s and Sanghi, Aniket and Saunders, Nicholas and Savchenko, Volodymyr and Schwardt, Ludwig and {Seifert-Eckert}, Michael and Shih, Albert Y. and Jain, Anany Shrey and Shukla, Gyanendra and Sick, Jonathan and Simpson, Chris and Singanamalla, Sudheesh and Singer, Leo P. and Singhal, Jaladh and Sinha, Manodeep and Sip{\H o}cz, Brigitta M. and Spitler, Lee R. and Stansby, David and Streicher, Ole and {\v S}umak, Jani and Swinbank, John D. and Taranu, Dan S. and Tewary, Nikita and Tremblay, Grant R. and {de Val-Borro}, Miguel and Van Kooten, Samuel J. and Vasovi{\'c}, Zlatan and Verma, Shresth and {de Miranda Cardoso}, Jos{\'e} Vin{\'i}cius and Williams, Peter K. G. and Wilson, Tom J. and Winkel, Benjamin and {Wood-Vasey}, W. M. and Xue, Rui and Yoachim, Peter and Zhang, Chen and Zonca, Andrea and {Astropy Project Contributors}},
   year = {2022},
@@ -34,8 +34,8 @@
 }
 
 @incollection{bachettihuppenkothen,
-  title = {Fourier {{Methods}}},
-  booktitle = {Handbook of {{X-ray}} and {{Gamma-ray Astrophysics}}},
+  title = {Fourier Methods},
+  booktitle = {Handbook of {{X-ray}} and Gamma-ray Astrophysics},
   author = {Bachetti, Matteo and Huppenkothen, Daniela},
   editor = {Bambi, Cosimo and Santangelo, Andrea},
   year = {2022},
@@ -51,10 +51,11 @@
 }
 
 @article{dejager,
-  title = {A Poweful Test for Weak Periodic Signals with Unknown Light Curve Shape in Sparse Data},
+  title = {A Powerful Test for Weak Periodic Signals with Unknown Light Curve Shape in Sparse Data},
   author = {{de Jager}, O C and Raubenheimer, B C and Swanepoel, J W H},
   year = {1989},
   month = aug,
+  journal = {Astronomy \& Astrophysics},
   volume = {221},
   pages = {180--190},
   abstract = {A problem with most tests for periodicity is that they are powerful enough to detect only certain kinds of periodic shapes (or 'light curves') in the case of weak signals. This causes a selection effect with the identification of weak periodic signals. Furthermore, the subjective choice of a test after inspection of the data can cause the identification of false sources. A new test for uniformity called the 'H-test' is derived for which the probability distribution is an exponential function. This test is shown to have a very good power against most light curve shapes encountered in X- and gamma-ray astronomy and therefore makes the detection of sources with a larger variety of shapes possible. The use of the H-test is suggested if no a priori information about the light curve shape is available. It is also shown how the probability distribution of the test statistics changes when a periodicity search is conducted using very small steps in the period or frequency range. The flux sensitivity for various light curve shapes is also derived for a few tests and this flux is on average a minimum for the H-test.}
@@ -65,7 +66,7 @@
   author = {Heil, L M and Uttley, P and {Klein-Wolt}, M},
   year = {2015},
   month = apr,
-  journal = {MNRAS},
+  journal = {Monthly Notices of the Royal Astronomical Society},
   volume = {448},
   number = {4},
   pages = {3339--3347},
@@ -75,7 +76,7 @@
 }
 
 @article{hubner,
-  title = {Searching for {{Quasi-periodic Oscillations}} in {{Astrophysical Transients Using Gaussian Processes}}},
+  title = {Searching for Quasi-periodic Oscillations in Astrophysical Transients Using {{Gaussian Processes}}},
   author = {H{\"u}bner, Moritz and Huppenkothen, Daniela and Lasky, Paul D. and Inglis, Andrew R. and Ick, Christopher and Hogg, David W.},
   year = {2022},
   month = sep,
@@ -142,13 +143,13 @@
 }
 
 @article{ransom,
-  title = {Fourier {{Techniques}} for {{Very Long Astrophysical Time-Series Analysis}}},
+  title = {Fourier Techniques for Very Long Astrophysical Time-Series Analysis},
   author = {Ransom, Scott M and Eikenberry, Stephen S and Middleditch, John},
   year = {2002},
   month = sep,
   journal = {The Astronomical Journal},
   volume = {124},
-  pages = {1788Figure},
+  pages = {1788},
   doi = {10.1086/342285},
   abstract = {We present an assortment of both standard and advanced Fourier techniques that are useful in the analysis of astrophysical time series of very long duration-where the observation time is much greater than the time resolution of the individual data points. We begin by reviewing the operational characteristics of Fourier transforms of time-series data, including power-spectral statistics, discussing some of the differences between analyses of binned data, sampled data, and event data, and we briefly discuss algorithms for calculating discrete Fourier transforms (DFTs) of very long time series. We then discuss the response of DFTs to periodic signals and present techniques to recover Fourier amplitude ``lost'' during simple traditional analyses if the periodicities change frequency during the observation. These techniques include Fourier interpolation, which allows us to correct the response for signals that occur between Fourier frequency bins. We then present techniques for estimating additional signal properties such as the signal's centroid and duration in time, the first and second derivatives of the frequency, the pulsed fraction, and an overall estimate of the significance of a detection. Finally, we present a recipe for a basic but thorough Fourier analysis of a time series for well-behaved pulsations.},
   keywords = {Methods: Data Analysis}
@@ -159,7 +160,7 @@
   author = {Scargle, Jeffrey D},
   year = {1989},
   month = aug,
-  journal = {ApJ},
+  journal = {The Astrophysical Journal},
   volume = {343},
   pages = {874--887},
   doi = {10.1086/167757},
@@ -188,7 +189,7 @@
   author = {Uttley, P and Cackett, E M and Fabian, A C and Kara, E and Wilkins, D R},
   year = {2014},
   month = aug,
-  journal = {A\&ARv},
+  journal = {The Astronomy and Astrophysics Review},
   volume = {22},
   number = {1},
   pages = {72--66},

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -82,14 +82,12 @@ affiliations:
 
 date: 01 October 2024
 bibliography: joss.bib
-aas-doi:
-aas-journal:
 ---
 
 # Summary
 
 Stingray is an Astropy-affiliated [@astropy2013; @astropy2022] Python package that brings advanced timing techniques to the wider astronomical community, with a focus on high-energy astrophysics, but built on top of general-purpose classes and methods that are designed to be easily adapted and extended to other use cases.
-Stingray was previously described by @stingrayjoss and @stingrayapj. Its core functionality comprises Fourier-based analyses [@bachettihuppenkothen], but the package has expanded significantly over time in both scope and functionality. In this paper we describe the improvements to the software in the last ~5 years.
+Stingray was previously described by @stingrayapj and @stingrayjoss. Its core functionality comprises Fourier-based analyses [@bachettihuppenkothen], but the package has expanded significantly over time in both scope and functionality. In this paper we describe the improvements to the software in the last ~5 years.
 
 # Background
 
@@ -99,29 +97,33 @@ Celestial objects are known to be change in brightness over time, driven by a di
 For example, the rotation of some pulsars, extremely dense stellar remnants, can be tracked over time and be considered almost like a cosmic clock. Other applications require complex modeling, including the study of the signals produced by the complicated interplay, propagation and partial re-emission of the light emitted by different regions around an accreting black hole. These studies require techniques that blend together traditional time series analysis and modeling of wavelength-dependent spectra [@uttley; @bachettihuppenkothen].
 
 # Statement of need
-Until 2015, the techniques described above were used by competing Groups using their own in-house codes. Very few of them were shared publicly, often with poor documentation and/or based on commercial or niche programming languages. Stingray brought them to the general astronomical community, and is now used worldwide, especially by young students.
+
+Until 2015, the techniques described above were used by competing groups using their own in-house codes. Very few of them were shared publicly, often with poor documentation and/or based on commercial or niche programming languages. Stingray brought them to the general astronomical community, and is now used worldwide, especially by young students.
 
 # Five years of Development
-A core development goal has been to accelerate core stingray functionality, lower the memory footprint, and refactor the code to be extensive and interoperable.
-Stingray’s core classes have shown dramatic increase in performance over time, as evident from [our benchmarks](https://stingray.science/stingray-benchmarks/). Stingray can now produce standard timing products
-of a typical high-flux NICER observation in ~one second. This is thanks to algorithmic improvement, and Just-In-Time compilation through Numba of many key components of the code. We reorganized the code to avoid duplication,
+
+A core development goal has been to accelerate core Stingray functionality, lower the memory footprint, and refactor the code to be extensive and interoperable.
+Stingray's core classes have shown dramatic increase in performance over time, as evident from [our benchmarks](https://stingray.science/stingray-benchmarks/). Stingray can now produce standard timing products
+of a typical high-flux NICER observation in roughly one second. This is thanks to algorithmic improvement, and Just-In-Time compilation through Numba of many key components of the code. We reorganized the code to avoid duplication,
 and created metaclasses that enable seamless integration with other popular array formats for time series (e.g. [Pandas](https://pandas.pydata.org/), [Lightkurve](https://docs.lightkurve.org/), [Astropy Timeseries](https://docs.astropy.org/en/stable/timeseries/index.html)) and data formats ([FITS](), [HDF5](https://www.hdfgroup.org/solutions/hdf5/), [extended CSV](https://docs.astropy.org/en/stable/io/ascii/ecsv.html)).
 
 We completed the originally planned implementation of spectral timing techniques. Newly implemented techniques include the lag spectrum, covariance, rms, and coherence spectra. These methods are now showcased in extensive tutorials exploring NICER and NuSTAR observations.
 
-We introduced a wide range of new techniques designed to analyze unevenly sampled data sets, responding to the growing need for these techniques from astronomical time domain surveys, subject to irregular observing constraints. Methods include Gaussian Process modeling of quasi-periodic oscillations [@hubner] and Lomb-Scargle cross spectra [@scargle]. We have introduced the Fourier-Domain Acceleration Search [@ransom], the H-test [@dejager] and Phase Dispersion Minimization  [@stellingwerf] statistics into the pulsar sub package.
+We introduced a wide range of new techniques designed to analyze unevenly sampled data sets, responding to the growing need for these techniques from astronomical time domain surveys, subject to irregular observing constraints. Methods include Gaussian Process modeling of quasi-periodic oscillations [@hubner] and Lomb-Scargle cross spectra [@scargle]. We have introduced the Fourier-Domain Acceleration Search [@ransom], the H-test [@dejager] and Phase Dispersion Minimization  [@stellingwerf] statistics into the pulsar subpackage.
 We expanded the statistical capabilities of Stingray,
 with particular attention to the calculation of confidence limits and upper limits on variability measures.
 
-Finally, we have added a number of high-level exploratory and diagnostic functionality, such as color-color and hardness-intensity diagrams, and their equivalent diagnostics in the frequency domain, "power colors" [@heil].
+Finally, we have added high-level exploratory and diagnostic functionality, such as color-color and hardness-intensity diagrams, and their equivalent diagnostics in the frequency domain, "power colors" [@heil].
 
-Ongoing work funded by the Italian [National Recovery and Resilience Plan](https://www.mef.gov.it/en/focus/The-National-Recovery-and-Resilience-Plan-NRRP/) is pushing Stingray's performance further with the use of GPUs and parallel computing in anticipation of large-scale astronomical time domain surveys for example with the Vera Rubin Telescope. In addition, the near-future will see an overhaul and redesign of Stingray's `modeling` subpackage in order to take advantage of recent developments in fast optimization and sampling algorithms and probabilistic programming. In order to facilitate spectral-timing with state-of-the-art instruments, we are actively working to integrate Stingray with ongoing software efforts improving modeling of astronomical spectra.
+Ongoing work funded by the Italian [National Recovery and Resilience Plan](https://www.mef.gov.it/en/focus/The-National-Recovery-and-Resilience-Plan-NRRP/) is pushing Stingray's performance further with the use of GPUs and parallel computing in anticipation of large-scale astronomical time domain surveys for example with the Vera Rubin Telescope. In addition, the near future will see an overhaul and redesign of Stingray's `modeling` subpackage in order to take advantage of recent developments in fast optimization and sampling algorithms and probabilistic programming. In order to facilitate spectral timing with state-of-the-art instruments, we are actively working to integrate Stingray with ongoing software efforts improving modeling of astronomical spectra.
 
 # Acknowledgments
-MB and EVL are supported in part by Italian Research Center on High Performance Computing Big Data and Quantum Computing (ICSC), project funded by European Union - NextGenerationEU - and National
+
+MB and EVL are supported in part by Italian Research Center on High Performance Computing Big Data and Quantum Computing (ICSC) project funded by European Union - NextGenerationEU - and National
 Recovery and Resilience Plan (NRRP) - Mission 4 Component 2 within the activities of Spoke 3
-(Astrophysics and Cosmos Observations)
-MB and GM were supported in part by PRIN TEC INAF 2019 ``SpecTemPolar! -- Timing analysis in the era of high-throughput photon detectors''
+(Astrophysics and Cosmos Observations).
+MB and GM were supported in part by PRIN TEC INAF 2019 ``SpecTemPolar! -- Timing analysis in the era of high-throughput photon detectors''.
 DH is supported by the Women In Science Excel (WISE) programme of the Netherlands Organisation for Scientific Research (NWO).
-GM acknowledges financial support from the European Union’s Horizon Europe research and innovation programme under the Marie Sk\l{}odowska-Curie grant agreement No. 101107057
+GM acknowledges financial support from the European Union's Horizon Europe research and innovation programme under the Marie Sk\l{}odowska-Curie grant agreement No. 101107057.
+
 # References


### PR DESCRIPTION
A few small editorial tweaks for the [JOSS publication](https://github.com/openjournals/joss-reviews/issues/7389). There are a few corrections to the paper but this is mostly to make the journal and article titles consistent in the references.