### PR TITLE
Bugfix issue#851

### DIFF
--- a/docs/changes/851.bugfix.rst
+++ b/docs/changes/851.bugfix.rst
@@ -1,0 +1,1 @@
+The `simple_ir` method in class `simulator` now takes into account phase and edge cases.

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -277,15 +277,15 @@ class Simulator(object):
         # Fill in 0 entries until the start time
         h_zeros = np.zeros(int(np.ceil((start / self.dt))))
         impulse_train = h_zeros
-        
-        if(start%self.dt == 0):
+
+        if start % self.dt == 0:
             impulse_train = np.append(h_zeros, 0.5)
 
         # Define constant impulse response
-        h_ones = np.ones(int((start%self.dt + width) / self.dt)) * intensity
-        impulse_train = np.append(impulse_train,h_ones)
+        h_ones = np.ones(int((start % self.dt + width) / self.dt)) * intensity
+        impulse_train = np.append(impulse_train, h_ones)
 
-        if ((start+width)%self.dt == 0):
+        if (start + width) % self.dt == 0:
             impulse_train[-1] = 0.5
 
         return impulse_train

--- a/stingray/simulator/simulator.py
+++ b/stingray/simulator/simulator.py
@@ -275,12 +275,20 @@ class Simulator(object):
         """
 
         # Fill in 0 entries until the start time
-        h_zeros = np.zeros(int(start / self.dt))
+        h_zeros = np.zeros(int(np.ceil((start / self.dt))))
+        impulse_train = h_zeros
+        
+        if(start%self.dt == 0):
+            impulse_train = np.append(h_zeros, 0.5)
 
         # Define constant impulse response
-        h_ones = np.ones(int(width / self.dt)) * intensity
+        h_ones = np.ones(int((start%self.dt + width) / self.dt)) * intensity
+        impulse_train = np.append(impulse_train,h_ones)
 
-        return np.append(h_zeros, h_ones)
+        if ((start+width)%self.dt == 0):
+            impulse_train[-1] = 0.5
+
+        return impulse_train
 
     def relativistic_ir(self, t1=3, t2=4, t3=10, p1=1, p2=1.4, rise=0.6, decay=0.1):
         """


### PR DESCRIPTION
#### Relevant Issue(s)/PR(s) #851 

Textbook implementation of impulse response.

Edge cases are 0.5 and phase is taken into account.
The response maybe zero if the width doesn't fall on the sampling times, a warning can be issued for the same.


Eg. 
start = 3 width = 5 dt = 4 = [0,1,0.5]
start = 4 width = 4 dt = 4 = [0,0.5,0.5]
start = 1 width = 3 dt = 4 = [0,0.5]

ps. the code has redundancies which I can remove once finalized