### PR TITLE
Add obsid info

### DIFF
--- a/docs/changes/863.feature.rst
+++ b/docs/changes/863.feature.rst
@@ -1,0 +1,1 @@
+Read the OBS_ID keyword from the FITS file if present

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -949,6 +949,8 @@ class FITSTimeseriesReader(object):
         self._add_meta_attr("hduname", hduname)
 
         header = hdulist[hduname].header
+        if "OBS_ID" in header:
+            self._add_meta_attr("obsid", header["OBS_ID"])
 
         # self.header has to be a string, for backwards compatibility and... for convenience!
         # No need to cope with dicts working badly with Netcdf, for example. The header


### PR DESCRIPTION
This is a trivial addition: when present, the OBS_ID header keyword is read and added to the meta information of the `FitsTimeseriesReader` (and the `EventList` that will be created from it)