### PR TITLE
Fix pdm bincounting

### DIFF
--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -308,7 +308,6 @@ def fold_events(times, *frequency_derivatives, **opts):
         if expocorr:
             expo_norm = phase_exposure(start_phase, stop_phase, 1, nbin, gti=gti_phases)
             simon("For exposure != 1, the uncertainty might be incorrect")
-
         else:
             expo_norm = 1
 
@@ -328,7 +327,7 @@ def fold_events(times, *frequency_derivatives, **opts):
 
         # I need the variance uncorrected for the number of data points in each
         # bin, so I need to find that first, and then multiply
-        _, bincounts = np.unique(bin_idx, return_counts=True)
+        bincounts, _ = np.histogram(bin_idx, bins=bins * 10 + 0.5)
         raw_profile = raw_profile * bincounts
 
         # dummy array for the error, which we don't have for the variance

--- a/stingray/pulse/tests/test_pulse.py
+++ b/stingray/pulse/tests/test_pulse.py
@@ -215,6 +215,12 @@ class TestAll(object):
         bins, profile, prof_err = fold_events(times, 1, nbin=nbin, weights=counts, mode="pdm")
         assert np.all(prof_err == 0)
 
+    def test_pdm_bincounting(self):
+        nbin = 10
+        times = np.arange(0, 10, 1)
+        counts = np.random.normal(3, 0.5, size=len(times))
+        bins, profile, prof_err = fold_events(times, 0.237, nbin=nbin, weights=counts, mode="pdm")
+
     def test_mode_incorrect(self):
         nbin = 16
         dt = 1 / nbin


### PR DESCRIPTION
<!--
Thanks for creating a pull request! Please ensure visiting our [contributor's guide](https://github.com/StingraySoftware/stingray/blob/main/CONTRIBUTING.md)

Please do not submit empty sections and remove them as per your requirements
-->

#### Relevant Issue(s)/PR(s)
Fixes #871.

#### Provide an overview of the implemented solution or the fix and elaborate on the modifications.
I added a test to demonstrate the bug, which fails with the old implementation using ```np.unique``` with ```return_values=True``` to count the number of instances in each bin. The new implementation is a one line change, which calls ```np.histogram``` instead, re-using the ```bins``` information. The ```bins``` are offset in the call to ```np.histogram``` to include the integer values of ```bin_idx```.

#### Is there a new dependency introduced by your contribution? If so, please specify.
No.

#### Any other comments?
I encountered this bug when trying to use ```fold_events``` on sparely sampled Swift data.