### PR TITLE
replace numpyfft with scipyfft for better performance 

### DIFF
--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -20,7 +20,7 @@ logger = setup_logger()
 
 try:
     import pyfftw
-    from pyfftw.interfaces.numpy_fft import (
+    from pyfftw.interfaces.scipy_fft import (
         ifft,
         fft,
         fftfreq,
@@ -37,7 +37,7 @@ try:
     HAS_PYFFTW = True
     logger.info("Using PyFFTW")
 except ImportError:
-    from numpy.fft import ifft, fft, fftfreq, fftn, ifftn, fftshift, fft2, ifftshift, rfft, rfftfreq
+    from scipy.fft import ifft, fft, fftfreq, fftn, ifftn, fftshift, fft2, ifftshift, rfft, rfftfreq
 
     HAS_PYFFTW = False
 


### PR DESCRIPTION
it seems that scipy.fft is faster than numpy fft 
sources
-----------
1 ) https://stackoverflow.com/questions/6363154/what-is-the-difference-between-numpy-fft-and-scipy-fftpack
2 ) https://medium.com/@corentin.soubeiran/whos-the-most-efficient-fft-techniques-in-python-boosting-performance-and-understanding-d19b6641d6d8

