### PR TITLE
Fix pandoc missing error in nbsphinix setup

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -283,6 +283,21 @@ If that doesn't work on your system, you can invoke ``sphinx-build`` itself from
 The documentation should be located in ``stingray/docs/_build``. Try opening ``./docs/_build/index.rst`` from
 the stingray source directory.
 
+**Note:**
+
+If you see the error::
+
+    nbsphinx.NotebookError: PandocMissing
+
+It means ``Pandoc`` is missing or not found.
+
+Solution:
+
++ Install Pandoc from `pandoc.org <https://pandoc.org>`_ or `GitHub Releases <https://github.com/jgm/pandoc/releases/>`_.
++ Ensure Pandoc is in your system's PATH.
+
+After installation, restart your code editor and try again.
+
 Using Stingray
 ===============
 

--- a/setup.py
+++ b/setup.py
@@ -53,12 +53,6 @@ You can also build the documentation with Sphinx directly using::
     cd docs
     make html
 
-If you getting an error:
-    Error: nbsphinx.NotebookError: PandocMissing
-    This occurs when Pandoc is not installed or not found.
-    Solution: Install Pandoc from pandoc.org or download it directly from https://github.com/jgm/pandoc/releases/, 
-    then restart your code editor.
-
 For more information, see:
 
   http://docs.astropy.org/en/latest/install.html#builddocs

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,12 @@ You can also build the documentation with Sphinx directly using::
     cd docs
     make html
 
+If you getting an error:
+    Error: nbsphinx.NotebookError: PandocMissing
+    This occurs when Pandoc is not installed or not found.
+    Solution: Install Pandoc from pandoc.org or download it directly from https://github.com/jgm/pandoc/releases/, 
+    then restart your code editor.
+
 For more information, see:
 
   http://docs.astropy.org/en/latest/install.html#builddocs


### PR DESCRIPTION
# Update Documentation to Fix `PandocMissing` Error  

## Description  
This PR updates `docs/index.rst` to include instructions for resolving the `nbsphinx.NotebookError: PandocMissing` error.  

## Changes Made  
- Added troubleshooting steps in `docs/index.rst` for missing Pandoc issues.  

## Checklist  
- [x] Follows project documentation standards.  
- [x] Verified correctness of updated instructions.  

## preview
![insex_change](https://github.com/user-attachments/assets/884d5b66-d312-4c03-844d-e61e229e5f1a)


## Notes  
Let me know if any refinements are needed!  
