### PR TITLE
Fix err dist none

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -39,7 +39,7 @@ from stingray.loggingconfig import setup_logger
 
 __all__ = ["Lightcurve"]
 
-valid_statistics = ["poisson", "gauss", None]
+valid_statistics = ["poisson", "gauss", "None"]
 
 logger = setup_logger()
 

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -215,7 +215,7 @@ class Lightcurve(StingrayTimeseries):
         err=None,
         input_counts=True,
         gti=None,
-        err_dist="poisson",
+        err_dist="none",
         bg_counts=None,
         bg_ratio=None,
         frac_exp=None,


### PR DESCRIPTION

Fixes #908 

#### Provide an overview of the implemented solution or the fix and elaborate on the modifications.

I have modified the valid_statistics in lightcurve.py. Instead of the using the old None, now we use "None".

`valid_statistics = ["poisson", "gauss", "None"]`

I have also changed the default err_dist in the Lightcurve constructor to "None" to correctly reflect the docs.

```
from stingray import Lightcurve
import numpy as np
from stingray.lightcurve import valid_statistics


times = np.arange(1000)

mean_flux = 100.0
std_flux = 2.0 
flux = np.random.normal(loc=mean_flux, scale=std_flux, size=len(times))
flux_err = np.ones_like(flux) * std_flux

print(valid_statistics)

lc = Lightcurve(times, flux, err=flux_err, err_dist="None", dt=1.0, skip_checks=True)
np.testing.assert_array_equal(lc.counts_err, np.full(lc.n, std_flux))


lc = Lightcurve(times, flux, err=None, err_dist="None", dt=1.0, skip_checks=True)
np.testing.assert_array_equal(lc.counts_err, np.zeros(lc.n))
```

<!--
Thanks for contributing to Stingray!
-->