### PR TITLE
Fix power upper limit for n =/= 1

### DIFF
--- a/docs/changes/922.bugfix.rst
+++ b/docs/changes/922.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed power upper limit in ``stingray.stats`` for n =/= 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,6 +166,7 @@ linkcheck_ignore = [
     r"https://zenodo.org/",
     r"https://opensource.org/",
     r"https://www.mathworks.com/",
+    r"http.*://stackoverflow.com/questions/.*",
 ]
 
 # -- Options for the edit_on_github extension ---------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ filterwarnings = [
     "ignore:.*__array_wrap__ must accept context and return_scalar arguments:DeprecationWarning",
     "ignore:.*Pyarrow:",
     "ignore:.*Creating an ndarray from ragged nested sequences:",
+    "ignore:.*the tpfmodel submodule is not available without oktopus.*:UserWarning"
 
 ]
 

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -1002,11 +1002,11 @@ def power_upper_limit(pmeas, n=1, c=0.95):
 
     from scipy.optimize import minimize
 
-    initial = isf(pmeas)
+    initial = isf(pmeas * n)
 
-    res = minimize(func_to_minimize, [initial], pmeas, bounds=[(0, initial * 2)])
+    res = minimize(func_to_minimize, [initial], pmeas * n, bounds=[(0, initial * 2)])
 
-    return res.x[0]
+    return res.x[0] / n
 
 
 def amplitude_upper_limit(pmeas, counts, n=1, c=0.95, fft_corr=False, nyq_ratio=0):


### PR DESCRIPTION
There was an error when calculating the upper limit on power in stingray.stats, when the number of summed powers is different from 1. Fixed