### PR TITLE
Pdm weighting

### DIFF
--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -239,21 +239,21 @@ def fold_events(times, *frequency_derivatives,
     nbin : int, optional, default 16
         The number of bins in the pulse profile
 
-    weights : float or array of floats, optional
+    weights : float or array of floats, optional, default 1
         The weights of the data. It can either be specified as a single value
         for all points, or an array with the same length as ``time``
 
-    gti : [[gti0_0, gti0_1], [gti1_0, gti1_1], ...], optional
+    gti : [[gti0_0, gti0_1], [gti1_0, gti1_1], ...], optional, default None
         Good time intervals
 
     ref_time : float, optional, default 0
         Reference time for the timing solution
 
-    expocorr : bool, default False
+    expocorr : bool, optional, default False
         Correct each bin for exposure (use when the period of the pulsar is
         comparable to that of GTIs)
 
-    mode : str, ["ef", "pdm"], default "ef"
+    mode : str, ["ef", "pdm"], optional, default "ef"
         Whether to calculate the epoch folding or phase dispersion
         minimization folded profile. For "ef", it calculates the (weighted)
         sum of the data points in each phase bin, for "pdm", the variance
@@ -336,9 +336,12 @@ def fold_events(times, *frequency_derivatives,
         # so need n_in_bin, sum_in_bin, sumofsquares_in_bin
         # now compute the stats for each bin using bincount
         # minlength=nbin prevents array shortening when a bin index is not represented in bin_indices
-        n_in_bin = np.bincount(bin_indices, weights=event_weights, minlength=nbin)
-        sum_in_bin = np.bincount(bin_indices, weights=weights * event_weights, minlength=nbin)
-        sumofsquares_in_bin = np.bincount(bin_indices, weights=weights**2 * event_weights, minlength=nbin)
+        n_in_bin = np.bincount(bin_indices, weights=event_weights,
+                                minlength=nbin)
+        sum_in_bin = np.bincount(bin_indices, weights=weights * event_weights,
+                                minlength=nbin)
+        sumofsquares_in_bin = np.bincount(bin_indices, weights=weights**2 * event_weights,
+                                minlength=nbin)
         # put it together; avoid division by zero
         raw_profile = sumofsquares_in_bin - sum_in_bin**2 / np.maximum(n_in_bin, 1)
 
@@ -401,6 +404,10 @@ def pdm_profile_stat(profile, sum_dev2, nsample):
     stat : float
         The epoch folding statistics
     """
+    # Get the mean-of-squared-deviations from sum-of-squared-deviations by
+    # considering the number of degrees of freedom:
+    # nsample - nbin for the in_bin sum_dev2 because there are nbin means used
+    # nsample - 1 for the grand sum_dev2 because there is 1 grand mean used
     mean_dev2_in_bin = np.sum(profile) / (nsample - len(profile))
     mean_dev2_grand = sum_dev2 / (nsample - 1)
     stat = mean_dev2_in_bin / mean_dev2_grand

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -378,7 +378,7 @@ def ef_profile_stat(profile, err=None):
     return np.sum((profile - mean) ** 2 / err**2)
 
 
-def pdm_profile_stat(profile, sample_var, nsample):
+def pdm_profile_stat(profile, sum_dev2, nsample):
     """Calculate the phase dispersion minimization
     statistic following Stellingwerf (1978)
 
@@ -388,8 +388,9 @@ def pdm_profile_stat(profile, sample_var, nsample):
         The PDM pulse profile (variance as a function
         of phase)
 
-    sample_var : float
-        The total population variance of the sample
+    sum_dev2 : float
+        The sum-of-squared-deviations of the sample,
+        which uses the grand (whole sample together) mean
 
     nsample : int
         The number of time bins in the initial time
@@ -400,8 +401,9 @@ def pdm_profile_stat(profile, sample_var, nsample):
     stat : float
         The epoch folding statistics
     """
-    s2 = np.sum(profile) / (nsample - len(profile))
-    stat = s2 / sample_var
+    mean_dev2_in_bin = np.sum(profile) / (nsample - len(profile))
+    mean_dev2_grand = sum_dev2 / (nsample - 1)
+    stat = mean_dev2_in_bin / mean_dev2_grand
     return stat
 
 

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -311,6 +311,8 @@ def fold_events(times, *frequency_derivatives,
         raw_profile_err = raw_profile_err / expo_norm
 
     elif mode == "pdm":
+        # Convert the weights to a numpy array just in case it is a list
+        weights = np.asarray(weights)
         if np.allclose(weights, 1.0):
             raise ValueError(
                 "Can only calculate PDM for binned light curves!"

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -329,16 +329,16 @@ def fold_events(times, *frequency_derivatives, **opts):
         bin_indices = np.clip(bin_indices, 0, nbin - 1)
 
         # for efficiency, the sum-of-squared deviations for each bin is split
-        # ss_dev = sum_in_bin( (values - mean_in_bin)**2 )
-        # mean_in_bin = sum_in_bin(values) / n_in_bin
-        # so need n_in_bin, sum_in_bin, sumsquared_in_bin
+        # ss_dev = sum_in_bin( (values_in_bin - mean_in_bin)**2 )
+        # mean_in_bin = sum_in_bin(values_in_bin) / n_in_bin
+        # so need n_in_bin, sum_in_bin, sumofsquares_in_bin
         # now compute the stats for each bin using bincount
         # minlength=nbin prevents array shortening when a bin index is not represented in bin_indices
         n_in_bin = np.bincount(bin_indices, minlength=nbin)
         sum_in_bin = np.bincount(bin_indices, weights=weights, minlength=nbin)
-        sumsquared_in_bin = np.bincount(bin_indices, weights=weights**2, minlength=nbin)
+        sumofsquares_in_bin = np.bincount(bin_indices, weights=weights**2, minlength=nbin)
         # put it together; avoid division by zero
-        raw_profile = sumsquared_in_bin - sum_in_bin**2 / np.maximum(n_in_bin, 1)
+        raw_profile = sumofsquares_in_bin - sum_in_bin**2 / np.maximum(n_in_bin, 1)
 
         # dummy array for the error, which we don't have for the variance
         raw_profile_err = np.zeros_like(raw_profile)

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -321,17 +321,13 @@ def fold_events(times, *frequency_derivatives, **opts):
                 + "`weights` attribute must be set to fluxes!"
             )
 
-        raw_profile, bins, bin_idx = scipy.stats.binned_statistic(
-            phases, weights, statistic=np.var, bins=np.linspace(0, 1, nbin + 1)
-        )
+        # sum-of-squared deviations
+        def ss_dev(values):
+            return np.sum((values - np.mean(values))**2)
 
-        # I need the variance uncorrected for the number of data points in each
-        # bin, so I need to find that first, and then multiply
-        # bin_idx should be from the list [1, ..., nbin], although some might not appear
-        # histogram bin-edges set as [0.5, 1.5, ..., nbin - 0.5, nbin + 0.5]
-        # to include the bin_idx int values
-        bincounts, _ = np.histogram(bin_idx, bins=np.arange(0.5, nbin + 1.5))
-        raw_profile = raw_profile * bincounts
+        raw_profile, bins, bin_idx = scipy.stats.binned_statistic(
+            phases, weights, statistic=ss_dev, bins=np.linspace(0, 1, nbin + 1)
+        )
 
         # dummy array for the error, which we don't have for the variance
         raw_profile_err = np.zeros_like(raw_profile)

--- a/stingray/pulse/pulsar.py
+++ b/stingray/pulse/pulsar.py
@@ -321,6 +321,10 @@ def fold_events(times, *frequency_derivatives, **opts):
                 + "`weights` attribute must be set to fluxes!"
             )
 
+        # For weighted pdm, the measured uncertainties (variances) for each event are required
+        variances = opts.get("variances", np.ones_like(weights))
+        event_weights = 1.0 / variances
+
         bins = np.linspace(0, 1, nbin + 1)
         # phases are already fractional values in [0, 1]
         # casting float to int removes the fractional part
@@ -334,9 +338,9 @@ def fold_events(times, *frequency_derivatives, **opts):
         # so need n_in_bin, sum_in_bin, sumofsquares_in_bin
         # now compute the stats for each bin using bincount
         # minlength=nbin prevents array shortening when a bin index is not represented in bin_indices
-        n_in_bin = np.bincount(bin_indices, minlength=nbin)
-        sum_in_bin = np.bincount(bin_indices, weights=weights, minlength=nbin)
-        sumofsquares_in_bin = np.bincount(bin_indices, weights=weights**2, minlength=nbin)
+        n_in_bin = np.bincount(bin_indices, weights=event_weights, minlength=nbin)
+        sum_in_bin = np.bincount(bin_indices, weights=weights * event_weights, minlength=nbin)
+        sumofsquares_in_bin = np.bincount(bin_indices, weights=weights**2 * event_weights, minlength=nbin)
         # put it together; avoid division by zero
         raw_profile = sumofsquares_in_bin - sum_in_bin**2 / np.maximum(n_in_bin, 1)
 

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -234,10 +234,11 @@ def phase_dispersion_search(
         variances_local = kwargs.get("variances", None)
         event_weights = (1.0/np.asarray(variances_local)) if variances_local is not None else np.ones_like(flux)
         mean_grand = np.average(flux, weights=event_weights)
-        deviation2 = (flux - mean_grand)**2
-        sigma = np.dot( deviation2, event_weights ) / (len_flux - 1)
+        dev2_grand = (flux - mean_grand)**2
+        
+        sum_dev2_grand = np.dot( dev2_grand, event_weights )
 
-        return pdm_profile_stat(profile, sigma, len_flux)
+        return pdm_profile_stat(profile, sum_dev2_grand, len_flux)
 
     return _folding_search(
         stat_fun,

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -229,7 +229,8 @@ def phase_dispersion_search(
         bins, profile, _ = fold_events(t, f, fd, **kwargs, mode="pdm")
         flux = kwargs["weights"]
         len_flux = len(flux)
-        sigma = np.var(flux) * len_flux / (len_flux - 1)
+        # ddof = 1 computes the unbiased estimator of the variance
+        sigma = np.var(flux, ddof=1)
         return pdm_profile_stat(profile, sigma, len_flux)
 
     return _folding_search(

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -229,8 +229,13 @@ def phase_dispersion_search(
         bins, profile, _ = fold_events(t, f, fd, **kwargs, mode="pdm")
         flux = kwargs["weights"]
         len_flux = len(flux)
-        # ddof = 1 computes the unbiased estimator of the variance
-        sigma = np.var(flux, ddof=1)
+        flux_variances = kwargs.get("variances", np.ones(len_flux))
+        event_weights = 1.0 / flux_variances
+
+        mean_grand = np.average(flux, weights=event_weights)
+        deviation2 = (flux - mean_grand)**2
+        sigma = np.dot( deviation2, event_weights ) / (len_flux - 1)
+
         return pdm_profile_stat(profile, sigma, len_flux)
 
     return _folding_search(

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -172,7 +172,8 @@ def epoch_folding_search(
 
 
 def phase_dispersion_search(
-    times, flux, frequencies, nbin=128, segment_size=5000, expocorr=False, gti=None, fdots=0
+    times, flux, frequencies, nbin=128, segment_size=5000, expocorr=False, gti=None, fdots=0,
+    variances=None
 ):
     """Performs folding at trial frequencies in time series data (i.e.~a light curve
     of flux or photon counts) and computes the Phase Dispersion Minimization statistic.
@@ -229,9 +230,9 @@ def phase_dispersion_search(
         bins, profile, _ = fold_events(t, f, fd, **kwargs, mode="pdm")
         flux = kwargs["weights"]
         len_flux = len(flux)
-        flux_variances = kwargs.get("variances", np.ones(len_flux))
-        event_weights = 1.0 / flux_variances
-
+        # Get the local (possibly modified copy of variances) from kwargs rather than as a closure
+        variances_local = kwargs.get("variances", None)
+        event_weights = (1.0/np.asarray(variances_local)) if variances_local is not None else np.ones_like(flux)
         mean_grand = np.average(flux, weights=event_weights)
         deviation2 = (flux - mean_grand)**2
         sigma = np.dot( deviation2, event_weights ) / (len_flux - 1)
@@ -249,6 +250,7 @@ def phase_dispersion_search(
         gti=gti,
         nbin=nbin,
         fdots=fdots,
+        variances=variances,
     )
 
 

--- a/stingray/pulse/search.py
+++ b/stingray/pulse/search.py
@@ -227,8 +227,9 @@ def phase_dispersion_search(
 
     def stat_fun(t, f, fd=0, **kwargs):
         bins, profile, _ = fold_events(t, f, fd, **kwargs, mode="pdm")
-        len_flux = len(kwargs["weights"])
-        sigma = np.var(kwargs["weights"]) * len_flux / (len_flux - 1)
+        flux = kwargs["weights"]
+        len_flux = len(flux)
+        sigma = np.var(flux) * len_flux / (len_flux - 1)
         return pdm_profile_stat(profile, sigma, len_flux)
 
     return _folding_search(

--- a/stingray/pulse/tests/test_pulse.py
+++ b/stingray/pulse/tests/test_pulse.py
@@ -91,9 +91,10 @@ class TestAll(object):
     def test_pdm_stat(self):
         """Test pulse phase calculation, frequency only."""
         prof = np.array([1, 1, 1, 1, 1])
-        sample_var = 2.0
+        sample_var = 2
         nsample = 10
-        np.testing.assert_array_almost_equal(pdm_profile_stat(prof, sample_var, nsample), 0.5)
+        sum_dev2 = sample_var * (nsample - 1)
+        np.testing.assert_array_almost_equal(pdm_profile_stat(prof, sum_dev2, nsample), 0.5)
 
     def test_zn(self):
         """Test pulse phase calculation, frequency only."""
@@ -221,7 +222,8 @@ class TestAll(object):
         )
         for pdm, ef in zip(profile, profile_ef):
             if ef == 0:
-                assert np.isnan(pdm)
+                # PDM implementation avoids division by 0, instead returns 0
+                assert pdm == 0
             else:
                 assert pdm == 2
                 assert ef == 8


### PR DESCRIPTION
<!--
Thanks for creating a pull request! Please ensure visiting our [contributor's guide](https://github.com/StingraySoftware/stingray/blob/main/CONTRIBUTING.md)

Please do not submit empty sections and remove them as per your requirements
-->

#### Relevant Issue(s)/PR(s)

<!--
Fixes #123. See also #789. 
Use keywords like Fixes or Closes to link issues or pull requests, ensuring they're automatically closed upon merge. Refer [Github Documentation](https://github.com/blog/1506-closing-issues-via-pull-requests)
-->
Closes #943 

#### Provide an overview of the implemented solution or the fix and elaborate on the modifications.

The `fold_events` function is modified, first to optimise the binned statistics calculation, now using `np.bincount` instead of the previous `scipy.stats.binned_statistic` method. This has improved the computation speed in my own local testing (from something taking >20 seconds to ~7 seconds), but results may vary. Second, in order to modernise the style of the `fold_events` function, the `opts.pop` and error checking is now changed to use optional parameters with defaults. The use of optional parameters preserves the `opts.pop` functionality.

The main change for this PR is to introduce a new `variances` parameter to `phase_dispersion_search` that enables weighting observations. This change is propagated to the `stat_func` within and the `fold_events`.

So far, my own local testing shows that if `variances` is not supplied, the PDM gives the same results as before, except that if bins were empty before, the resulting PDM would be `NaN`. Now it is `0` as a result of the modified algorithm. The tests have been changed to reflect this.

#### Is there a new dependency introduced by your contribution? If so, please specify.

No. In fact, the use of `scipy` in `fold_events` has been removed.

#### Any other comments?

To be added.