### PR TITLE
Fixed critical error in confidence interval width in power_confidence_limits

### DIFF
--- a/docs/changes/951.bugfix.rst
+++ b/docs/changes/951.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an error in ``power_confidence_limits`` that led to systematically narrower confidence intervals. 

--- a/stingray/stats.py
+++ b/stingray/stats.py
@@ -934,15 +934,16 @@ def power_confidence_limits(preal, n=1, c=0.95):
     Returns
     -------
     pmeas: [float, float]
-        The upper and lower confidence interval (a, 1-a) on the measured power
+        The lower and upper bounds of the symmetric ``c``-level confidence
+        interval on the measured power
 
     Examples
     --------
-    >>> cl = power_confidence_limits(150, c=0.84)
-    >>> assert np.allclose(cl, [127, 176], atol=1)
+    >>> cl = power_confidence_limits(150, c=0.68)
+    >>> assert np.allclose(cl, [128, 176], atol=1)
     """
     rv = stats.ncx2(2 * n, preal)
-    return rv.ppf([1 - c, c])
+    return rv.ppf([(1 - c) / 2, (1 + c) / 2])
 
 
 def power_upper_limit(pmeas, n=1, c=0.95, summed_flag=True):

--- a/stingray/tests/test_stats.py
+++ b/stingray/tests/test_stats.py
@@ -267,3 +267,14 @@ class TestClassicalSignificances(object):
 
     def test_power_upper_limit_averaging(self):
         assert np.isclose(power_upper_limit(100, 10, 0.997, summed_flag=False), 115, rtol=0.1)
+
+    def test_power_confidence_limits(self):
+        from scipy.stats import ncx2
+        preal = 25.0
+        n = 2
+        c = 0.95
+        low, high = power_confidence_limits(preal, n, c)
+
+        # Check boundaries against Scipy CDF definition
+        assert np.isclose(ncx2.cdf(high, df=2 * n, nc=preal), 0.975, atol=1e-4)
+        assert np.isclose(ncx2.cdf(low, df=2 * n, nc=preal), 0.025, atol=1e-4)


### PR DESCRIPTION
#### Relevant Issue(s)/PR(s)

Fixes self-identified bug (no posted issue). 
Previous confidence interval in ``power_confidence_intervals`` returned an interval with [1-c, c] quantiles, resulting in confidence intervals with a confidence level of 2c-1 rather than c. 
This error currently affects HENzsearch, and the corresponding ``analyze_qffa_results`` function in HENDRICS, when returning confidence intervals of a candidate frequency while conducting pulsation searches. All intervals have been systematically overconfident. 

#### Provide an overview of the implemented solution or the fix and elaborate on the modifications.

<!--
Describe your implementations.
-->
Changed the output interval to [(1-c)/2, (1+c)/2] quantiles. 
Changed the docstring example which included the output created by the erroneous code.
Also wrote a test for ``power_confidence_limits`` that inverts the interval through the corresponding non-central chi-squared CDF, verifying the correct quantiles are returned as output. 

#### Is there a new dependency introduced by your contribution? If so, please specify.

No. 

<!--
Consider adding new dependencies as optional to minimize external dependencies for the core Stingray package.
-->

#### Any other comments?

This function currently is unused in Stingray, but used significantly in HENDRICS and therefore only affects HENDRICS users. Therefore, should I create a PR in the HENDRICS project to update the changelog? Is there anything else that should be done on the HENDRICS side? 

<!--
Please add any other context you deem fit.
-->


<!--
Thanks for contributing to Stingray!
-->